### PR TITLE
fix: compound PK for memory_items (BUG-007)

### DIFF
--- a/BOARD.md
+++ b/BOARD.md
@@ -95,7 +95,7 @@ _Nothing currently in progress._
 | BUG-001 | 359 tests failing (pre-existing, not from recent changes) — likely test setup/teardown issues in repository tests | Low |
 | BUG-002 | `SdkProcessSpawner` is dead code now that Agent SDK runs on host — should be removed or repurposed for Docker mode | Low |
 | BUG-003 | `zod` peer dep conflict: Agent SDK `@0.2.71` requires `zod@^4.0.0`, project uses `zod@3.25.76`. Upgrade zod to v4 — `@anthropic-ai/sdk` and `@modelcontextprotocol/sdk` both support v4 in their peer ranges. | Medium |
-| BUG-007 | Memory key (`id`) is globally unique but should be scoped per thread. Two threads using the same key (e.g. `user_name`) collide on insert. Fix: compound primary key `(thread_id, id)` via schema migration, update `findById`/`insert`/`update`/`delete` in memory-repository to always scope by thread_id. Temporary workaround: reject writes for keys owned by other threads. | High |
+| BUG-007 | ~~Memory key (`id`) globally unique, collides across threads.~~ Fixed: compound PK `(thread_id, id)` via migration 002, all repo methods scope by thread_id. | Resolved |
 | BUG-008 | Session resume lost on daemon restart. `SessionTracker` is in-memory only — all conversation context is forgotten after restart. The `session_id` is already persisted in the `runs` table; fix: on first message in a thread, look up the most recent `session_id` from `runs` and seed `SessionTracker`. Affects all channels. | High |
 | BUG-004 | ~~`schedule.manage` host tool dead code~~ — Fixed: wired via host-tools MCP bridge + Unix socket. All 5 tools work (schedule, channel, memory, http, db). | Resolved |
 | BUG-005 | ~~`schedule.manage` sets `next_run_at: null`~~ — Fixed: computes `next_run_at` from cron expression on create/update. | Resolved |

--- a/src/core/database/migrations/002-memory-compound-pk.sql
+++ b/src/core/database/migrations/002-memory-compound-pk.sql
@@ -1,0 +1,33 @@
+-- Migration 002: Compound primary key for memory_items
+--
+-- Fixes BUG-007: memory key (id) was globally unique but should be scoped
+-- per thread. Two threads using the same key (e.g. "user_name") would collide
+-- on insert. This migration changes the primary key from (id) to (thread_id, id).
+--
+-- SQLite does not support ALTER TABLE to change a primary key, so we recreate
+-- the table and copy existing data.
+
+-- 1. Create the new table with compound PK.
+CREATE TABLE memory_items_new (
+  thread_id     TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+  id            TEXT NOT NULL,
+  type          TEXT NOT NULL CHECK (type IN ('fact', 'summary', 'note', 'embedding_ref')),
+  content       TEXT NOT NULL,
+  embedding_ref TEXT,
+  metadata      TEXT NOT NULL DEFAULT '{}',
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  PRIMARY KEY (thread_id, id)
+);
+
+-- 2. Copy existing data.
+INSERT INTO memory_items_new (thread_id, id, type, content, embedding_ref, metadata, created_at, updated_at)
+  SELECT thread_id, id, type, content, embedding_ref, metadata, created_at, updated_at
+  FROM memory_items;
+
+-- 3. Drop old table and rename.
+DROP TABLE memory_items;
+ALTER TABLE memory_items_new RENAME TO memory_items;
+
+-- 4. Recreate index (thread_id is now part of PK, but we keep the type filter index).
+CREATE INDEX idx_memory_thread ON memory_items(thread_id, type);

--- a/src/core/database/repositories/memory-repository.ts
+++ b/src/core/database/repositories/memory-repository.ts
@@ -3,6 +3,9 @@
  *
  * Memory items capture facts, summaries, notes, and embedding references
  * scoped to a thread. They form the per-thread long-term memory layer.
+ *
+ * The primary key is compound: (thread_id, id). This allows different
+ * threads to use the same key (e.g. "user_name") without collisions.
  */
 
 import type Database from 'better-sqlite3';
@@ -49,7 +52,7 @@ export class MemoryRepository extends BaseRepository {
         (@id, @thread_id, @type, @content, @embedding_ref, @metadata, @created_at, @updated_at)
     `);
 
-    this.findByIdStmt = db.prepare(`SELECT * FROM memory_items WHERE id = ?`);
+    this.findByIdStmt = db.prepare(`SELECT * FROM memory_items WHERE thread_id = ? AND id = ?`);
 
     this.findByThreadStmt = db.prepare(`
       SELECT * FROM memory_items WHERE thread_id = ? ORDER BY created_at DESC
@@ -59,7 +62,7 @@ export class MemoryRepository extends BaseRepository {
       SELECT * FROM memory_items WHERE thread_id = ? AND type = ? ORDER BY created_at DESC
     `);
 
-    this.deleteStmt = db.prepare(`DELETE FROM memory_items WHERE id = ?`);
+    this.deleteStmt = db.prepare(`DELETE FROM memory_items WHERE thread_id = ? AND id = ?`);
   }
 
   /** Inserts a new memory item. */
@@ -74,10 +77,15 @@ export class MemoryRepository extends BaseRepository {
     }
   }
 
-  /** Finds a memory item by its primary key. */
-  findById(id: string): Result<MemoryItemRow | null, DbError> {
+  /**
+   * Finds a memory item by its compound key (thread_id, id).
+   *
+   * @param threadId - Thread the item belongs to.
+   * @param id       - Item key within the thread.
+   */
+  findById(threadId: string, id: string): Result<MemoryItemRow | null, DbError> {
     try {
-      const row = this.findByIdStmt.get(id) as MemoryItemRow | undefined;
+      const row = this.findByIdStmt.get(threadId, id) as MemoryItemRow | undefined;
       return ok(row ?? null);
     } catch (cause) {
       return err(new DbError(`Failed to find memory item by id: ${String(cause)}`, cause instanceof Error ? cause : undefined));
@@ -104,29 +112,40 @@ export class MemoryRepository extends BaseRepository {
     }
   }
 
-  /** Updates mutable fields on an existing memory item. */
-  update(id: string, fields: UpdateMemoryItemInput): Result<MemoryItemRow | null, DbError> {
+  /**
+   * Updates mutable fields on an existing memory item.
+   *
+   * @param threadId - Thread the item belongs to.
+   * @param id       - Item key within the thread.
+   * @param fields   - Fields to update.
+   */
+  update(threadId: string, id: string, fields: UpdateMemoryItemInput): Result<MemoryItemRow | null, DbError> {
     try {
       const setClause = Object.keys(fields)
         .map((k) => `${k} = @${k}`)
         .join(', ');
       if (!setClause) {
-        return this.findById(id);
+        return this.findById(threadId, id);
       }
       const stmt = this.db.prepare(
-        `UPDATE memory_items SET ${setClause}, updated_at = @updated_at WHERE id = @id`,
+        `UPDATE memory_items SET ${setClause}, updated_at = @updated_at WHERE thread_id = @thread_id AND id = @id`,
       );
-      stmt.run({ ...fields, updated_at: this.now(), id });
-      return this.findById(id);
+      stmt.run({ ...fields, updated_at: this.now(), thread_id: threadId, id });
+      return this.findById(threadId, id);
     } catch (cause) {
       return err(new DbError(`Failed to update memory item: ${String(cause)}`, cause instanceof Error ? cause : undefined));
     }
   }
 
-  /** Deletes a memory item by id. */
-  delete(id: string): Result<void, DbError> {
+  /**
+   * Deletes a memory item by its compound key.
+   *
+   * @param threadId - Thread the item belongs to.
+   * @param id       - Item key within the thread.
+   */
+  delete(threadId: string, id: string): Result<void, DbError> {
     try {
-      this.deleteStmt.run(id);
+      this.deleteStmt.run(threadId, id);
       return ok(undefined);
     } catch (cause) {
       return err(new DbError(`Failed to delete memory item: ${String(cause)}`, cause instanceof Error ? cause : undefined));

--- a/src/tools/host-tools/memory-access.ts
+++ b/src/tools/host-tools/memory-access.ts
@@ -5,6 +5,9 @@
  * mediates all memory operations to ensure isolation between threads and
  * enforce size limits.
  *
+ * Thread isolation is enforced at the schema level: the primary key is
+ * (thread_id, id), so all lookups are inherently scoped to the thread.
+ *
  * Gated by `memory.read:thread` (read ops) and `memory.write:thread` (write ops).
  */
 
@@ -39,7 +42,8 @@ const VALID_OPERATIONS = new Set(['read', 'write', 'delete', 'list']);
  * Handler class for the memory.access host tool.
  *
  * Dispatches to MemoryRepository for the underlying SQLite operations.
- * All memory items are scoped to the thread in the execution context.
+ * All memory items are scoped to the thread in the execution context
+ * via the compound primary key (thread_id, id).
  *
  * Note: The memory.access tool uses a simplified key/value model on top
  * of the MemoryItemRow schema. The `key` maps to the row `id`, and the
@@ -109,7 +113,7 @@ export class MemoryAccessHandler {
     }
   }
 
-  /** Handle the 'read' operation — look up a memory item by key. */
+  /** Handle the 'read' operation — look up a memory item by (threadId, key). */
   private handleRead(
     args: MemoryAccessArgs,
     context: ToolExecutionContext,
@@ -123,7 +127,7 @@ export class MemoryAccessHandler {
       return { requestId, tool: 'memory.access', status: 'error', error: error.message };
     }
 
-    const result = this.deps.memoryRepository.findById(key);
+    const result = this.deps.memoryRepository.findById(context.threadId, key);
     if (result.isErr()) {
       const msg = `memory.access: read failed — ${result.error.message}`;
       this.deps.logger.error({ requestId, key, err: result.error }, msg);
@@ -131,15 +135,6 @@ export class MemoryAccessHandler {
     }
 
     const item = result.value;
-
-    // Ensure the item belongs to the current thread (security check)
-    if (item && item.thread_id !== context.threadId) {
-      const error = new ToolError(
-        `memory.access: key "${key}" does not belong to thread "${context.threadId}"`,
-      );
-      this.deps.logger.warn({ requestId, key, threadId: context.threadId }, error.message);
-      return { requestId, tool: 'memory.access', status: 'error', error: error.message };
-    }
 
     this.deps.logger.debug({ requestId, key, found: item !== null }, 'memory.access: read complete');
 
@@ -151,7 +146,7 @@ export class MemoryAccessHandler {
     };
   }
 
-  /** Handle the 'write' operation — upsert a memory item. */
+  /** Handle the 'write' operation — upsert a memory item scoped to thread. */
   private handleWrite(
     args: MemoryAccessArgs,
     context: ToolExecutionContext,
@@ -169,29 +164,24 @@ export class MemoryAccessHandler {
     const contentStr = typeof value === 'string' ? value : JSON.stringify(value);
     const memType = resolveMemoryType(namespace);
 
-    // Check if item already exists (to decide insert vs. update)
-    const existing = this.deps.memoryRepository.findById(itemKey);
+    // Check if item already exists in this thread (to decide insert vs. update)
+    const existing = this.deps.memoryRepository.findById(context.threadId, itemKey);
     if (existing.isErr()) {
       const msg = `memory.access: write pre-check failed — ${existing.error.message}`;
       this.deps.logger.error({ requestId, key: itemKey, err: existing.error }, msg);
       return { requestId, tool: 'memory.access', status: 'error', error: msg };
     }
 
-    if (existing.value && existing.value.thread_id === context.threadId) {
-      // Update existing item
-      const updateResult = this.deps.memoryRepository.update(itemKey, { content: contentStr });
+    if (existing.value) {
+      // Update existing item in this thread
+      const updateResult = this.deps.memoryRepository.update(context.threadId, itemKey, { content: contentStr });
       if (updateResult.isErr()) {
         const msg = `memory.access: write (update) failed — ${updateResult.error.message}`;
         this.deps.logger.error({ requestId, key: itemKey, err: updateResult.error }, msg);
         return { requestId, tool: 'memory.access', status: 'error', error: msg };
       }
-    } else if (existing.value) {
-      // Key exists but belongs to a different thread — reject to prevent overwrite.
-      const msg = `memory.access: key "${itemKey}" already exists in another thread. Use a unique key.`;
-      this.deps.logger.warn({ requestId, key: itemKey, threadId: context.threadId }, msg);
-      return { requestId, tool: 'memory.access', status: 'error', error: msg };
     } else {
-      // Insert new item
+      // Insert new item scoped to this thread
       const insertResult = this.deps.memoryRepository.insert({
         id: itemKey,
         thread_id: context.threadId,
@@ -217,7 +207,7 @@ export class MemoryAccessHandler {
     };
   }
 
-  /** Handle the 'delete' operation — remove a memory item by key. */
+  /** Handle the 'delete' operation — remove a memory item by (threadId, key). */
   private handleDelete(
     args: MemoryAccessArgs,
     context: ToolExecutionContext,
@@ -231,23 +221,7 @@ export class MemoryAccessHandler {
       return { requestId, tool: 'memory.access', status: 'error', error: error.message };
     }
 
-    // Verify ownership before deleting
-    const existing = this.deps.memoryRepository.findById(key);
-    if (existing.isErr()) {
-      const msg = `memory.access: delete pre-check failed — ${existing.error.message}`;
-      this.deps.logger.error({ requestId, key, err: existing.error }, msg);
-      return { requestId, tool: 'memory.access', status: 'error', error: msg };
-    }
-
-    if (existing.value && existing.value.thread_id !== context.threadId) {
-      const error = new ToolError(
-        `memory.access: key "${key}" does not belong to thread "${context.threadId}"`,
-      );
-      this.deps.logger.warn({ requestId, key }, error.message);
-      return { requestId, tool: 'memory.access', status: 'error', error: error.message };
-    }
-
-    const deleteResult = this.deps.memoryRepository.delete(key);
+    const deleteResult = this.deps.memoryRepository.delete(context.threadId, key);
     if (deleteResult.isErr()) {
       const msg = `memory.access: delete failed — ${deleteResult.error.message}`;
       this.deps.logger.error({ requestId, key, err: deleteResult.error }, msg);

--- a/tests/unit/core/database/repositories/memory-repository.test.ts
+++ b/tests/unit/core/database/repositories/memory-repository.test.ts
@@ -9,6 +9,7 @@ describe('MemoryRepository', () => {
   let db: Database.Database;
   let repo: MemoryRepository;
   let threadId: string;
+  let threadId2: string;
 
   beforeEach(() => {
     db = createTestDb();
@@ -29,6 +30,14 @@ describe('MemoryRepository', () => {
     threadId = uuid();
     threads.insert({
       id: threadId,
+      channel_id: channelId,
+      external_id: `ext-${uuid()}`,
+      metadata: '{}',
+    });
+
+    threadId2 = uuid();
+    threads.insert({
+      id: threadId2,
       channel_id: channelId,
       external_id: `ext-${uuid()}`,
       metadata: '{}',
@@ -62,17 +71,51 @@ describe('MemoryRepository', () => {
     it('returns err for non-existent thread_id (FK)', () => {
       expect(repo.insert(makeItem({ thread_id: uuid() })).isErr()).toBe(true);
     });
+
+    it('allows same key in different threads', () => {
+      const sharedKey = 'user_name';
+      const r1 = repo.insert(makeItem({ id: sharedKey, thread_id: threadId, content: 'Alice' }));
+      const r2 = repo.insert(makeItem({ id: sharedKey, thread_id: threadId2, content: 'Bob' }));
+      expect(r1.isOk()).toBe(true);
+      expect(r2.isOk()).toBe(true);
+      expect(r1._unsafeUnwrap().content).toBe('Alice');
+      expect(r2._unsafeUnwrap().content).toBe('Bob');
+    });
+
+    it('rejects duplicate key within same thread', () => {
+      const key = 'user_name';
+      repo.insert(makeItem({ id: key, thread_id: threadId }));
+      const r2 = repo.insert(makeItem({ id: key, thread_id: threadId }));
+      expect(r2.isErr()).toBe(true);
+    });
   });
 
   describe('findById', () => {
-    it('finds by primary key', () => {
+    it('finds by compound key (threadId, id)', () => {
       const input = makeItem();
       repo.insert(input);
-      expect(repo.findById(input.id)._unsafeUnwrap()?.id).toBe(input.id);
+      expect(repo.findById(threadId, input.id)._unsafeUnwrap()?.id).toBe(input.id);
     });
 
     it('returns null for unknown id', () => {
-      expect(repo.findById(uuid())._unsafeUnwrap()).toBeNull();
+      expect(repo.findById(threadId, uuid())._unsafeUnwrap()).toBeNull();
+    });
+
+    it('returns null when key exists in different thread', () => {
+      const sharedKey = 'user_name';
+      repo.insert(makeItem({ id: sharedKey, thread_id: threadId }));
+      expect(repo.findById(threadId2, sharedKey)._unsafeUnwrap()).toBeNull();
+    });
+
+    it('finds correct item when same key exists in multiple threads', () => {
+      const sharedKey = 'user_name';
+      repo.insert(makeItem({ id: sharedKey, thread_id: threadId, content: 'Alice' }));
+      repo.insert(makeItem({ id: sharedKey, thread_id: threadId2, content: 'Bob' }));
+
+      const r1 = repo.findById(threadId, sharedKey)._unsafeUnwrap();
+      const r2 = repo.findById(threadId2, sharedKey)._unsafeUnwrap();
+      expect(r1?.content).toBe('Alice');
+      expect(r2?.content).toBe('Bob');
     });
   });
 
@@ -96,20 +139,40 @@ describe('MemoryRepository', () => {
     it('returns empty array for unknown thread', () => {
       expect(repo.findByThread(uuid())._unsafeUnwrap()).toHaveLength(0);
     });
+
+    it('does not return items from other threads', () => {
+      repo.insert(makeItem({ id: 'user_name', thread_id: threadId, content: 'Alice' }));
+      repo.insert(makeItem({ id: 'user_name', thread_id: threadId2, content: 'Bob' }));
+
+      const thread1Items = repo.findByThread(threadId)._unsafeUnwrap();
+      expect(thread1Items).toHaveLength(1);
+      expect(thread1Items[0].content).toBe('Alice');
+    });
   });
 
   describe('update', () => {
     it('updates content and metadata', () => {
       const input = makeItem();
       repo.insert(input);
-      const result = repo.update(input.id, { content: 'Updated fact', metadata: '{"key":"val"}' });
+      const result = repo.update(threadId, input.id, { content: 'Updated fact', metadata: '{"key":"val"}' });
       const row = result._unsafeUnwrap();
       expect(row?.content).toBe('Updated fact');
       expect(row?.metadata).toBe('{"key":"val"}');
     });
 
     it('returns null for unknown id', () => {
-      expect(repo.update(uuid(), { content: 'x' })._unsafeUnwrap()).toBeNull();
+      expect(repo.update(threadId, uuid(), { content: 'x' })._unsafeUnwrap()).toBeNull();
+    });
+
+    it('only updates item in the specified thread', () => {
+      const sharedKey = 'user_name';
+      repo.insert(makeItem({ id: sharedKey, thread_id: threadId, content: 'Alice' }));
+      repo.insert(makeItem({ id: sharedKey, thread_id: threadId2, content: 'Bob' }));
+
+      repo.update(threadId, sharedKey, { content: 'Alice Updated' });
+
+      expect(repo.findById(threadId, sharedKey)._unsafeUnwrap()?.content).toBe('Alice Updated');
+      expect(repo.findById(threadId2, sharedKey)._unsafeUnwrap()?.content).toBe('Bob');
     });
   });
 
@@ -117,12 +180,23 @@ describe('MemoryRepository', () => {
     it('removes the memory item', () => {
       const input = makeItem();
       repo.insert(input);
-      repo.delete(input.id);
-      expect(repo.findById(input.id)._unsafeUnwrap()).toBeNull();
+      repo.delete(threadId, input.id);
+      expect(repo.findById(threadId, input.id)._unsafeUnwrap()).toBeNull();
     });
 
     it('is idempotent for unknown ids', () => {
-      expect(repo.delete(uuid()).isOk()).toBe(true);
+      expect(repo.delete(threadId, uuid()).isOk()).toBe(true);
+    });
+
+    it('only deletes item in the specified thread', () => {
+      const sharedKey = 'user_name';
+      repo.insert(makeItem({ id: sharedKey, thread_id: threadId, content: 'Alice' }));
+      repo.insert(makeItem({ id: sharedKey, thread_id: threadId2, content: 'Bob' }));
+
+      repo.delete(threadId, sharedKey);
+
+      expect(repo.findById(threadId, sharedKey)._unsafeUnwrap()).toBeNull();
+      expect(repo.findById(threadId2, sharedKey)._unsafeUnwrap()?.content).toBe('Bob');
     });
   });
 });

--- a/tests/unit/tools/host-tools/memory-access.test.ts
+++ b/tests/unit/tools/host-tools/memory-access.test.ts
@@ -4,14 +4,16 @@
  * Tests cover:
  *   - All 4 operations: read, write, delete, list
  *   - Arg validation failures (missing key, missing value, invalid operation)
- *   - Thread isolation (cross-thread access denied)
  *   - Repository error propagation
  *   - Namespace/type mapping
  *   - Write upsert behaviour (insert vs. update)
  *   - List filtering by namespace
+ *
+ * Thread isolation is enforced at the schema level (compound PK) and tested
+ * in the repository integration tests rather than here.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ok, err } from 'neverthrow';
 import { MemoryAccessHandler } from '../../../../src/tools/host-tools/memory-access.js';
 import type { MemoryAccessArgs } from '../../../../src/tools/host-tools/memory-access.js';
@@ -118,6 +120,16 @@ describe('MemoryAccessHandler — read', () => {
     });
   });
 
+  it('passes threadId and key to findById', async () => {
+    const findById = vi.fn().mockReturnValue(ok(null));
+    const repo = makeRepo({ findById });
+    const handler = new MemoryAccessHandler({ memoryRepository: repo, logger: makeLogger() });
+
+    await handler.execute(makeArgs({ operation: 'read', key: 'my-key' }), makeContext({ threadId: 'thread-xyz' }));
+
+    expect(findById).toHaveBeenCalledWith('thread-xyz', 'my-key');
+  });
+
   it('returns null result when key is not found', async () => {
     const repo = makeRepo({ findById: vi.fn().mockReturnValue(ok(null)) });
     const handler = new MemoryAccessHandler({ memoryRepository: repo, logger: makeLogger() });
@@ -146,18 +158,6 @@ describe('MemoryAccessHandler — read', () => {
 
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/key is required/);
-  });
-
-  it('denies cross-thread access', async () => {
-    // Row belongs to a different thread
-    const row = makeMemoryRow({ thread_id: 'other-thread' });
-    const repo = makeRepo({ findById: vi.fn().mockReturnValue(ok(row)) });
-    const handler = new MemoryAccessHandler({ memoryRepository: repo, logger: makeLogger() });
-
-    const result = await handler.execute(makeArgs({ operation: 'read', key: 'my-key' }), makeContext({ threadId: 'thread-001' }));
-
-    expect(result.status).toBe('error');
-    expect(result.error).toMatch(/does not belong to thread/);
   });
 
   it('propagates repository errors', async () => {
@@ -210,7 +210,20 @@ describe('MemoryAccessHandler — write', () => {
     );
 
     expect(result.status).toBe('success');
-    expect(updateFn).toHaveBeenCalledWith('existing-key', { content: 'updated value' });
+    expect(updateFn).toHaveBeenCalledWith('thread-001', 'existing-key', { content: 'updated value' });
+  });
+
+  it('passes threadId to findById for write pre-check', async () => {
+    const findById = vi.fn().mockReturnValue(ok(null));
+    const repo = makeRepo({ findById, insert: vi.fn().mockReturnValue(ok(makeMemoryRow())) });
+    const handler = new MemoryAccessHandler({ memoryRepository: repo, logger: makeLogger() });
+
+    await handler.execute(
+      makeArgs({ operation: 'write', key: 'k', value: 'v' }),
+      makeContext({ threadId: 'thread-xyz' }),
+    );
+
+    expect(findById).toHaveBeenCalledWith('thread-xyz', 'k');
   });
 
   it('generates a key when none is provided', async () => {
@@ -317,10 +330,7 @@ describe('MemoryAccessHandler — write', () => {
 describe('MemoryAccessHandler — delete', () => {
   it('deletes an existing item successfully', async () => {
     const deleteFn = vi.fn().mockReturnValue(ok(undefined));
-    const repo = makeRepo({
-      findById: vi.fn().mockReturnValue(ok(makeMemoryRow())),
-      delete: deleteFn,
-    });
+    const repo = makeRepo({ delete: deleteFn });
     const handler = new MemoryAccessHandler({ memoryRepository: repo, logger: makeLogger() });
 
     const result = await handler.execute(
@@ -330,7 +340,7 @@ describe('MemoryAccessHandler — delete', () => {
 
     expect(result.status).toBe('success');
     expect(result.result).toEqual({ key: 'my-key', deleted: true });
-    expect(deleteFn).toHaveBeenCalledWith('my-key');
+    expect(deleteFn).toHaveBeenCalledWith('thread-001', 'my-key');
   });
 
   it('returns error when key is missing', async () => {
@@ -346,23 +356,8 @@ describe('MemoryAccessHandler — delete', () => {
     expect(result.error).toMatch(/key is required/);
   });
 
-  it('denies cross-thread delete', async () => {
-    const row = makeMemoryRow({ thread_id: 'other-thread' });
-    const repo = makeRepo({ findById: vi.fn().mockReturnValue(ok(row)) });
-    const handler = new MemoryAccessHandler({ memoryRepository: repo, logger: makeLogger() });
-
-    const result = await handler.execute(
-      makeArgs({ operation: 'delete', key: 'my-key' }),
-      makeContext({ threadId: 'thread-001' }),
-    );
-
-    expect(result.status).toBe('error');
-    expect(result.error).toMatch(/does not belong to thread/);
-  });
-
   it('propagates delete errors', async () => {
     const repo = makeRepo({
-      findById: vi.fn().mockReturnValue(ok(makeMemoryRow())),
       delete: vi.fn().mockReturnValue(err(new DbError('io error'))),
     });
     const handler = new MemoryAccessHandler({ memoryRepository: repo, logger: makeLogger() });


### PR DESCRIPTION
## Summary

- Memory keys like `user_name` collided across threads because `id` was a globally unique PK
- Changed PK from `(id)` to `(thread_id, id)` — each thread now has its own key namespace
- Migration 002 recreates the table and copies existing data
- All `MemoryRepository` methods (`findById`, `update`, `delete`) now take `threadId` as first arg
- `MemoryAccessHandler` no longer needs manual thread ownership checks — isolation enforced at schema level
- 45 tests pass (18 repo + 27 handler), including new cross-thread isolation tests

## Test plan

- [x] Repository tests: same key in different threads allowed
- [x] Repository tests: duplicate key in same thread rejected  
- [x] Repository tests: cross-thread find/update/delete only affects specified thread
- [x] Handler tests: threadId passed to all repo calls
- [x] TypeScript builds cleanly
- [x] GPT-5.4 review approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)