### PR TITLE
feat(agent): inject current time into agent context

### DIFF
--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -134,11 +134,24 @@ export class AgentRunner {
         .filter(Boolean)
         .join('\n');
 
+      // Generate fresh timestamp per run so the agent can reason about time.
+      const now_ = new Date();
+      const pad = (n: number): string => String(n).padStart(2, '0');
+      const offsetMin = now_.getTimezoneOffset();
+      const offsetSign = offsetMin <= 0 ? '+' : '-';
+      const absOffset = Math.abs(offsetMin);
+      const offsetStr = `${offsetSign}${pad(Math.floor(absOffset / 60))}:${pad(absOffset % 60)}`;
+      const localISO = `${now_.getFullYear()}-${pad(now_.getMonth() + 1)}-${pad(now_.getDate())}T${pad(now_.getHours())}:${pad(now_.getMinutes())}:${pad(now_.getSeconds())}${offsetStr}`;
+      const tzAbbr = Intl.DateTimeFormat('en', { timeZoneName: 'short' }).formatToParts(now_).find((p) => p.type === 'timeZoneName')?.value ?? 'UTC';
+      const dayName = now_.toLocaleDateString('en', { weekday: 'long' });
+      const timeContext = `Current time: ${localISO} (${tzAbbr}, ${dayName})`;
+
       const systemPromptParts = [
         loadedPersona.systemPromptContent ?? '',
         loadedPersona.personalityContent ?? '',
         skillPrompt,
         channelContext,
+        timeContext,
       ];
 
       // Inject previous context when starting a fresh session (no resume).


### PR DESCRIPTION
## Summary
- Injects a fresh local timestamp into the agent's system prompt on every run
- Format: `Current time: 2026-03-13T10:02:24+01:00 (GMT+1, Friday)`
- Includes ISO 8601 timestamp, timezone abbreviation, and day of week

Closes #40 (TASK-074)

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 26 agent-runner tests pass
- [x] Verified timestamp output is correct (local time matches offset)
- [x] GPT-5.3-codex review: LGTM (caught and fixed UTC/local mismatch in first pass)
- [ ] Deploy to VM and ask agent "what time is it?" to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)