### PR TITLE
fix(skills): make config.name optional in MCP server defs

### DIFF
--- a/src/skills/skill-loader.ts
+++ b/src/skills/skill-loader.ts
@@ -103,7 +103,10 @@ const McpServerConfigSchema = z.object({
 const McpServerDefFileSchema = z.object({
   name: z.string().min(1),
   config: McpServerConfigSchema,
-});
+}).transform((def) => ({
+  ...def,
+  config: { ...def.config, name: def.config.name ?? def.name },
+}));
 
 // ---------------------------------------------------------------------------
 // SkillLoader
@@ -459,12 +462,7 @@ export class SkillLoader {
         );
       }
 
-      const def = parseResult.data;
-      // Backfill config.name from the outer name when omitted.
-      if (!def.config.name) {
-        def.config.name = def.name;
-      }
-      defs.push(def as McpServerDef);
+      defs.push(parseResult.data as McpServerDef);
       this.logger.debug({ skill: skillName, file }, 'MCP server definition loaded');
     }
 

--- a/tests/unit/skills/skill-loader.test.ts
+++ b/tests/unit/skills/skill-loader.test.ts
@@ -306,6 +306,30 @@ describe('SkillLoader', () => {
       expect(skill.resolvedMcpServers[0].config.transport).toBe('stdio');
     });
 
+    it('backfills config.name from outer name when omitted', async () => {
+      const skillDir = await makeTmpDir(cleanup);
+      await writeMinimalManifest(skillDir);
+      const mcpDir = join(skillDir, 'mcp');
+      await mkdir(mcpDir);
+      await writeFile(
+        join(mcpDir, 'github.json'),
+        JSON.stringify({
+          name: 'github',
+          config: {
+            transport: 'http',
+            url: 'https://api.githubcopilot.com/mcp',
+          },
+        }),
+        'utf-8',
+      );
+
+      const result = await loader.loadFromDirectory(skillDir);
+      const skill = result._unsafeUnwrap();
+      expect(skill.resolvedMcpServers).toHaveLength(1);
+      expect(skill.resolvedMcpServers[0].name).toBe('github');
+      expect(skill.resolvedMcpServers[0].config.name).toBe('github');
+    });
+
     it('loads multiple MCP server defs in alphabetical order', async () => {
       const skillDir = await makeTmpDir(cleanup);
       await writeMinimalManifest(skillDir);


### PR DESCRIPTION
## Summary
- `config.name` in MCP server JSON definitions is now optional
- Backfilled from the outer `name` field during skill loading
- Fixes validation error when setup skill generates JSON without redundant `config.name`

## Test plan
- [x] Build passes
- [x] All 65 skills tests pass (loader + resolver)
- [x] GPT-5.3-codex review: LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)