### PR TITLE
Feat/docker

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,38 @@
+# .env.example
+# Copy this file to .env in the project root and fill in your secrets.
+# This file is loaded by docker-compose.yaml.
+
+# AI Provider API Keys
+# ---------------------------------------------------------------------------
+# If you use Claude Code (Anthropic API):
+SUBAGENT_ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# If you use Gemini CLI (Google AI API):
+# Note: Gemini CLI usually uses OAuth tokens in ~/.gemini/ but can also use API keys.
+GOOGLE_AI_API_KEY=your_google_ai_api_key_here
+
+# If you use OpenAI:
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Channel Tokens
+# ---------------------------------------------------------------------------
+# Telegram Bot Token (from @BotFather)
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
+
+# Slack Bot Token (xoxb-...)
+SLACK_BOT_TOKEN=your_slack_bot_token_here
+
+# Discord Bot Token
+DISCORD_BOT_TOKEN=your_discord_bot_token_here
+
+# WhatsApp (Twilio/360dialog) credentials
+WHATSAPP_API_KEY=your_whatsapp_api_key_here
+
+# Terminal Channel Token (for talonctl chat)
+TERMINAL_TOKEN=your_secret_terminal_token_here
+
+# Daemon Configuration Overrides
+# ---------------------------------------------------------------------------
+# LOG_LEVEL=debug
+# TALOND_CONFIG_PATH=/config/talond.yaml
+# TALOND_DATA_DIR=/data

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -34,5 +34,3 @@ TERMINAL_TOKEN=your_secret_terminal_token_here
 # Daemon Configuration Overrides
 # ---------------------------------------------------------------------------
 # LOG_LEVEL=debug
-# TALOND_CONFIG_PATH=/config/talond.yaml
-# TALOND_DATA_DIR=/data

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -67,12 +67,17 @@ COPY config/talond.example.yaml ./config/
 # Volume mount points:
 #   /data    — SQLite database file, PID file, IPC sockets
 #   /config  — talond.yaml (bind-mount your config here at runtime)
-VOLUME ["/data", "/config"]
+#   /personas — persona directories (optional)
+VOLUME ["/data", "/config", "/personas"]
 
 # Ensure the daemon user can write to the data directory at runtime.
 # The directory is created here so Docker creates it as root; at startup
 # the container can chown it if needed, or the host pre-creates it.
-RUN mkdir -p /data /config && chown talond:talond /data /config
+RUN mkdir -p /data /config /personas && chown talond:talond /data /config /personas
+
+# Create a symlink from /opt/talond/data to /data so that if dataDir
+# is set to "data" (the default), it resolves to the volume mount.
+RUN ln -s /data /opt/talond/data
 
 # Switch to the non-root user for all subsequent commands
 USER talond
@@ -86,4 +91,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
         try{process.kill(p,0);process.exit(0);}catch{process.exit(1);}} \
         process.exit(0);"
 
-ENTRYPOINT ["/usr/bin/tini", "--", "node", "/opt/talond/dist/daemon/main.js", "--config", "/config/talond.yaml"]
+ENTRYPOINT ["/usr/bin/tini", "--", "node", "/opt/talond/dist/index.js", "--config", "/config/talond.yaml"]

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -68,22 +68,25 @@ COPY config/talond.example.yaml ./config/
 #   /data    — SQLite database file, PID file, IPC sockets
 #   /config  — talond.yaml (bind-mount your config here at runtime)
 #   /personas — persona directories (optional)
-VOLUME ["/data", "/config", "/personas"]
+#   /skills   — custom skills (optional)
+#   /subagents — custom sub-agents (optional)
+VOLUME ["/data", "/config", "/personas", "/skills", "/subagents"]
 
-# Ensure the daemon user can write to the data directory at runtime.
-# The directory is created here so Docker creates it as root; at startup
-# the container can chown it if needed, or the host pre-creates it.
-RUN mkdir -p /data /config /personas && chown talond:talond /data /config /personas
+# Ensure the daemon user can write to the volumes at runtime.
+RUN mkdir -p /data /config /personas /skills /subagents && \
+    chown talond:talond /data /config /personas /skills /subagents
 
-# Create a symlink from /opt/talond/data to /data so that if dataDir
-# is set to "data" (the default), it resolves to the volume mount.
-RUN ln -s /data /opt/talond/data
+# Create symlinks from /opt/talond/<dir> to /<dir> so that relative paths
+# in the config (e.g. personas/assistant) resolve to the volume mounts.
+RUN ln -s /data /opt/talond/data && \
+    ln -s /personas /opt/talond/personas && \
+    ln -s /skills /opt/talond/skills && \
+    ln -s /subagents /opt/talond/subagents
 
 # Switch to the non-root user for all subsequent commands
 USER talond
 
 # Health check: verify the process is alive by checking the PID file.
-# Falls back to a simple node sanity check when no PID file is present yet.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD node -e "const fs=require('fs'); \
         const pid=process.env.TALON_PID_FILE||'/data/talond.pid'; \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -67,10 +67,11 @@ COPY config/talond.example.yaml ./config/
 # Volume mount points:
 #   /data    — SQLite database file, PID file, IPC sockets
 #   /config  — talond.yaml (bind-mount your config here at runtime)
-#   /personas — persona directories (optional)
-#   /skills   — custom skills (optional)
-#   /subagents — custom sub-agents (optional)
-VOLUME ["/data", "/config", "/personas", "/skills", "/subagents"]
+# Optional bind mounts (not declared as VOLUME to avoid anonymous volume surprises):
+#   /personas — persona directories
+#   /skills   — custom skills
+#   /subagents — custom sub-agents
+VOLUME ["/data", "/config"]
 
 # Ensure the daemon user can write to the volumes at runtime.
 RUN mkdir -p /data /config /personas /skills /subagents && \
@@ -87,11 +88,12 @@ RUN ln -s /data /opt/talond/data && \
 USER talond
 
 # Health check: verify the process is alive by checking the PID file.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+# Exits non-zero if the PID file is missing (daemon not started) or the process is dead.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD node -e "const fs=require('fs'); \
         const pid=process.env.TALON_PID_FILE||'/data/talond.pid'; \
-        if(fs.existsSync(pid)){const p=parseInt(fs.readFileSync(pid,'utf8').trim()); \
-        try{process.kill(p,0);process.exit(0);}catch{process.exit(1);}} \
-        process.exit(0);"
+        if(!fs.existsSync(pid)){process.exit(1);} \
+        const p=parseInt(fs.readFileSync(pid,'utf8').trim()); \
+        try{process.kill(p,0);process.exit(0);}catch{process.exit(1);}"
 
 ENTRYPOINT ["/usr/bin/tini", "--", "node", "/opt/talond/dist/index.js", "--config", "/config/talond.yaml"]

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -28,9 +28,13 @@ services:
     environment:
       # Force production mode regardless of what the .env file says
       NODE_ENV: production
+      # Point the daemon to the /data volume for all persistent data
+      TALOND_DATA_DIR: /data
 
     volumes:
       # Persistent data: SQLite database, PID file, IPC sockets
+      # Recommendation: Use a bind mount (e.g. ./data:/data) if you want to
+      # use 'talonctl' from the host machine without 'docker exec'.
       - talond-data:/data
 
       # Configuration: bind-mount your edited talond.yaml here
@@ -38,6 +42,16 @@ services:
         source: ../config/talond.yaml
         target: /config/talond.yaml
         read_only: true
+
+      # Personas: bind-mount your persona directories here
+      - type: bind
+        source: ../personas
+        target: /personas
+        read_only: true
+
+      # Optional: Custom sub-agents or skills
+      # - ../subagents:/opt/talond/subagents:ro
+      # - ../skills:/opt/talond/skills:ro
 
       # -----------------------------------------------------------------------
       # Docker socket (optional — only needed for sandbox container spawning)
@@ -60,10 +74,9 @@ services:
     # ports:
     #   - "127.0.0.1:5173:5173"  # MCP server (if enabled in talond.yaml)
 
-    # Health check mirrors the HEALTHCHECK in the Dockerfile but is also
-    # expressed here so Compose restarts unhealthy containers.
+    # Health check: verify the process is alive by checking the PID file.
     healthcheck:
-      test: ["CMD", "node", "-e", "process.exit(0)"]
+      test: ["CMD", "node", "-e", "const fs=require('fs'); const pid=process.env.TALON_PID_FILE||'/data/talond.pid'; if(fs.existsSync(pid)){const p=parseInt(fs.readFileSync(pid,'utf8').trim()); try{process.kill(p,0);process.exit(0);}catch{process.exit(1);}} process.exit(0);"]
       interval: 30s
       timeout: 5s
       start_period: 15s

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -5,7 +5,8 @@
 #   1. cp config/talond.example.yaml config/talond.yaml
 #   2. Edit config/talond.yaml with your API keys and channel settings
 #   3. cp deploy/.env.example .env  (and fill in secrets)
-#   4. docker compose up -d
+#   4. mkdir -p personas data
+#   5. docker compose up -d
 # =============================================================================
 
 services:
@@ -28,8 +29,9 @@ services:
     environment:
       # Force production mode regardless of what the .env file says
       NODE_ENV: production
-      # Point the daemon to the /data volume for all persistent data
+      # Point the daemon to the correct in-container paths
       TALOND_DATA_DIR: /data
+      TALOND_CONFIG_PATH: /config/talond.yaml
 
     volumes:
       # Persistent data: SQLite database, PID file, IPC sockets
@@ -43,15 +45,20 @@ services:
         target: /config/talond.yaml
         read_only: true
 
-      # Personas: bind-mount your persona directories here
+      # Personas: bind-mount so you can edit prompts from the host
+      # and so Claude Code skills can manage personas.
+      # Create the directory first: mkdir -p personas
       - type: bind
         source: ../personas
         target: /personas
-        read_only: true
 
-      # Optional: Custom sub-agents or skills
-      # - ../subagents:/opt/talond/subagents:ro
-      # - ../skills:/opt/talond/skills:ro
+      # Optional: Custom skills or sub-agents — uncomment if used
+      # - type: bind
+      #   source: ../skills
+      #   target: /skills
+      # - type: bind
+      #   source: ../subagents
+      #   target: /subagents
 
       # -----------------------------------------------------------------------
       # Docker socket (optional — only needed for sandbox container spawning)
@@ -74,9 +81,10 @@ services:
     # ports:
     #   - "127.0.0.1:5173:5173"  # MCP server (if enabled in talond.yaml)
 
-    # Health check: verify the process is alive by checking the PID file.
+    # Health check: verify the daemon process is alive via PID file.
+    # Reports unhealthy if the PID file is missing or the process is dead.
     healthcheck:
-      test: ["CMD", "node", "-e", "const fs=require('fs'); const pid=process.env.TALON_PID_FILE||'/data/talond.pid'; if(fs.existsSync(pid)){const p=parseInt(fs.readFileSync(pid,'utf8').trim()); try{process.kill(p,0);process.exit(0);}catch{process.exit(1);}} process.exit(0);"]
+      test: ["CMD", "node", "-e", "const fs=require('fs');const p=process.env.TALON_PID_FILE||'/data/talond.pid';if(!fs.existsSync(p)){process.exit(1);}try{process.kill(parseInt(fs.readFileSync(p,'utf8').trim()),0);process.exit(0);}catch{process.exit(1);}"]
       interval: 30s
       timeout: 5s
       start_period: 15s

--- a/deploy/talonctl-docker.sh
+++ b/deploy/talonctl-docker.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# talonctl-docker.sh — Run talonctl commands against the containerized daemon.
+#
+# Usage:
+#   ./deploy/talonctl-docker.sh status
+#   ./deploy/talonctl-docker.sh reload
+#   ./deploy/talonctl-docker.sh list-channels
+#
+# This is a thin wrapper around `docker exec` that forwards arguments to the
+# talonctl CLI inside the running talond container.
+
+set -euo pipefail
+
+CONTAINER="${TALOND_CONTAINER:-talond}"
+
+if ! docker inspect "$CONTAINER" &>/dev/null; then
+  echo "Error: container '$CONTAINER' not found. Is the daemon running?" >&2
+  exit 1
+fi
+
+exec docker exec -it "$CONTAINER" node dist/cli/index.js "$@"

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -350,6 +350,70 @@ Running at 3 AM means it doesn't compete with interactive conversations. The age
 
 Every 2-3 days works well. Once a week is the minimum. If you skip this entirely, the agent's memory context gets increasingly noisy and you'll notice degraded recall quality after a few weeks.
 
+## Docker Deployment
+
+For a portable and reproducible setup, you can run the Talon daemon in a Docker container.
+
+### Prerequisites
+
+- Docker and Docker Compose installed.
+- AI provider CLIs installed on the host (if you want to use them from the host) OR configured via API keys in `.env`.
+
+### Quick Start
+
+1.  **Prepare configuration:**
+    ```bash
+    cp config/talond.example.yaml config/talond.yaml
+    mkdir -p personas data
+    ```
+2.  **Set up secrets:**
+    ```bash
+    cp deploy/.env.example .env
+    # Edit .env with your API keys and tokens
+    ```
+3.  **Build and start:**
+    ```bash
+    docker compose -f deploy/docker-compose.yaml up -d --build
+    ```
+
+### Persistence and Volumes
+
+The `docker-compose.yaml` defines several volumes:
+- `talond-data`: A named volume for the SQLite database, PID file, and IPC sockets.
+- `/config/talond.yaml`: Bind-mounted from the host.
+- `/personas`: Bind-mounted from the host `personas/` directory.
+
+If you want to use `talonctl` from your host machine (outside the container) to check status or reload config, you should use a bind mount for the data directory in `docker-compose.yaml`:
+
+```yaml
+    volumes:
+      - ./data:/data
+```
+
+This allows the host `talonctl` to read/write the IPC files in the same directory as the containerized daemon.
+
+### Using `talonctl` with Docker
+
+You can run `talonctl` commands directly inside the running container:
+
+```bash
+docker exec -it talond node dist/cli/index.js status
+docker exec -it talond node dist/cli/index.js reload
+```
+
+Or use the host's `talonctl` if you have a bind mount for the data directory:
+
+```bash
+npx talonctl status
+```
+
+### AI Providers in Docker
+
+The Docker image uses the `node:22-slim` base and does not include AI provider CLIs like `claude` or `gemini` by default. To use them from within the container, you have two options:
+
+1.  **API Keys:** Configure your providers in `talond.yaml` to use API keys via environment variables (e.g., `${SUBAGENT_ANTHROPIC_API_KEY}`).
+2.  **Custom Image:** Create a custom Dockerfile that installs the required CLIs.
+
 ## Recommended deployment setup
 
 ### Dedicated VM

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -364,7 +364,7 @@ For a portable and reproducible setup, you can run the Talon daemon in a Docker 
 1.  **Prepare configuration:**
     ```bash
     cp config/talond.example.yaml config/talond.yaml
-    mkdir -p personas data
+    mkdir -p personas
     ```
 2.  **Set up secrets:**
     ```bash
@@ -378,34 +378,44 @@ For a portable and reproducible setup, you can run the Talon daemon in a Docker 
 
 ### Persistence and Volumes
 
-The `docker-compose.yaml` defines several volumes:
+The `docker-compose.yaml` defines:
 - `talond-data`: A named volume for the SQLite database, PID file, and IPC sockets.
-- `/config/talond.yaml`: Bind-mounted from the host.
-- `/personas`: Bind-mounted from the host `personas/` directory.
+- `/config/talond.yaml`: Bind-mounted read-only from the host.
+- `/personas`: Bind-mounted from the host `personas/` directory (read-write so the daemon can write artifacts).
 
-If you want to use `talonctl` from your host machine (outside the container) to check status or reload config, you should use a bind mount for the data directory in `docker-compose.yaml`:
-
-```yaml
-    volumes:
-      - ./data:/data
-```
-
-This allows the host `talonctl` to read/write the IPC files in the same directory as the containerized daemon.
+Optional bind mounts for `/skills` and `/subagents` are commented out in the compose file. Uncomment them if you use custom skills or sub-agents.
 
 ### Using `talonctl` with Docker
 
-You can run `talonctl` commands directly inside the running container:
+Use the included wrapper script to run CLI commands against the containerized daemon:
+
+```bash
+./deploy/talonctl-docker.sh status
+./deploy/talonctl-docker.sh list-channels
+./deploy/talonctl-docker.sh reload
+```
+
+Or run commands directly:
 
 ```bash
 docker exec -it talond node dist/cli/index.js status
-docker exec -it talond node dist/cli/index.js reload
 ```
 
-Or use the host's `talonctl` if you have a bind mount for the data directory:
+The wrapper forwards all arguments to `talonctl` inside the container. Set `TALOND_CONTAINER` to override the container name if it differs from `talond`.
+
+### Using Claude Code skills with Docker
+
+The Claude Code setup skills (`/talon-setup`, `/add-slack`, `/add-telegram`, etc.) work with Docker deployments. They edit config and persona files on the host filesystem, which are bind-mounted into the container. After making changes:
 
 ```bash
-npx talonctl status
+# Reload config without restarting
+./deploy/talonctl-docker.sh reload
+
+# Or restart the container to pick up all changes
+docker compose -f deploy/docker-compose.yaml restart
 ```
+
+The config file is mounted read-only. If a skill needs to modify `talond.yaml`, edit it on the host and reload. Persona files are read-write and take effect on the next agent run.
 
 ### AI Providers in Docker
 


### PR DESCRIPTION
This pull request introduces Docker deployment support for Talon, including new documentation, environment configuration, and improvements to volume handling and health checks. It also adds a research document outlining Langfuse observability integration. The most important changes are grouped below:

**Docker Deployment Support**

* Added a sample `.env.example` file for configuring API keys and channel tokens, making Docker deployments easier and more secure.
* Updated `deploy/Dockerfile` to support additional bind-mountable directories (`/personas`, `/skills`, `/subagents`), improved volume setup, and switched the entrypoint to `dist/index.js` for consistency.
* Enhanced `deploy/docker-compose.yaml` to support bind-mounts for persona directories, persistent data, and custom agent/skill directories. Also improved environment variable management and health checks for the daemon. [[1]](diffhunk://#diff-5e29ca74bc6d43c26c10ae578bc9a3d3a74bab65e84a6b50e3a4f2be244733eaR31-R37) [[2]](diffhunk://#diff-5e29ca74bc6d43c26c10ae578bc9a3d3a74bab65e84a6b50e3a4f2be244733eaR46-R55) [[3]](diffhunk://#diff-5e29ca74bc6d43c26c10ae578bc9a3d3a74bab65e84a6b50e3a4f2be244733eaL63-R79)

**Documentation**

* Added a detailed Docker deployment section to `docs/setup-guide.md`, covering prerequisites, quick start, volume persistence, using `talonctl`, and AI provider configuration in containers.

**Observability Research**

* Introduced `specs/langfuse-observability/research.md`, documenting Langfuse Cloud integration options, mapping Talon's execution model to Langfuse tracing, and outlining a phased implementation plan.