### PR TITLE
feat: add talonctl import-plugin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,20 @@ Default system prompt templates live in `templates/<name>/system.md` and are saf
 
 When creating a persona, `add-persona` checks `templates/<name>/system.md` first. If a named template exists it is copied to `personas/<name>/system.md`; otherwise a generic starter prompt is generated. Existing files are never overwritten — your customisations are safe.
 
+### Importing Claude Code plugins
+
+If you use Claude Code, you can import skills from installed CC plugins into Talon:
+
+```sh
+# See which plugins have importable components
+npx talonctl import-plugin --list
+
+# Import all skills from a plugin
+npx talonctl import-plugin --name backend-development
+```
+
+This copies skill files from `~/.claude/plugins/` into Talon's `skills/` directory. After importing, attach skills to a persona with `talonctl add-skill`. CC-specific components (hooks, commands, agents) are skipped — only skills and MCP server detection are supported.
+
 ### Capability Labels
 
 Tools are gated by scoped capability labels. Capabilities are listed in `allow` or `requireApproval` arrays — anything not listed is denied by default.
@@ -940,6 +954,8 @@ npx talonctl reload
 | `talonctl add-channel --name <n> --type <t>`  | Add a channel connector to config                                                 |
 | `talonctl add-persona --name <n>`             | Scaffold a persona directory and add to config (uses template if available)        |
 | `talonctl add-skill --name <n> --persona <p> [--format <fmt>]` | Scaffold a skill (`yaml` or `skillmd` format) and attach to a persona |
+| `talonctl import-plugin --list`               | List Claude Code plugins that can be imported                                     |
+| `talonctl import-plugin --name <n>`           | Import skills from an installed Claude Code plugin                                |
 
 ```bash
 # Full setup flow
@@ -947,6 +963,10 @@ npx talonctl setup --config talond.yaml --data-dir data
 npx talonctl add-channel --name work-slack --type slack
 npx talonctl add-persona --name researcher
 npx talonctl add-skill --name web-search --persona researcher
+
+# Import skills from a Claude Code plugin
+npx talonctl import-plugin --list
+npx talonctl import-plugin --name backend-development
 ```
 
 ### Channel & Persona Management

--- a/src/cli/commands/import-plugin.ts
+++ b/src/cli/commands/import-plugin.ts
@@ -210,8 +210,14 @@ export async function scanPlugin(installPath: string): Promise<PluginScanResult>
     for (const entry of dirEntries) {
       if (entry.isDirectory()) {
         const skillMd = path.join(skillsPath, entry.name, 'SKILL.md');
-        if (existsSync(skillMd) && lstatSync(skillMd).isFile()) {
-          skillDirs.push(entry.name);
+        if (existsSync(skillMd)) {
+          try {
+            if (lstatSync(skillMd).isFile()) {
+              skillDirs.push(entry.name);
+            }
+          } catch {
+            // File removed/replaced between checks — treat as no SKILL.md.
+          }
         }
       }
     }
@@ -330,6 +336,15 @@ export async function importPlugin(
   if (scan.skillDirs.length === 0 && !scan.hasMcpServer) {
     throw new Error(
       `Plugin '${options.name}' has no importable skills or MCP servers.`,
+    );
+  }
+
+  // Validate skill names are compatible with Talon's naming rules.
+  const invalidSkills = scan.skillDirs.filter((name) => validateName(name, 'Skill') !== null);
+  if (invalidSkills.length > 0) {
+    throw new Error(
+      `Plugin '${options.name}' contains skills with invalid names: ${invalidSkills.join(', ')}. ` +
+      'Talon skill names must use only letters, numbers, hyphens, and underscores.',
     );
   }
 

--- a/src/cli/commands/import-plugin.ts
+++ b/src/cli/commands/import-plugin.ts
@@ -9,7 +9,7 @@
  */
 
 import fs from 'node:fs/promises';
-import { existsSync, type Dirent } from 'node:fs';
+import { existsSync, realpathSync, lstatSync, type Dirent } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
@@ -124,11 +124,19 @@ export function extractShortName(fullKey: string): string {
 
 /**
  * Validates that a resolved install path is under the expected CC plugins cache.
- * Prevents a corrupted index from pointing to arbitrary filesystem locations.
+ * Uses fs.realpathSync to resolve symlinks, preventing symlink-based escapes.
  */
 export function validateInstallPath(installPath: string, ccPluginsDir: string): void {
-  const resolvedInstall = path.resolve(installPath);
-  const resolvedCache = path.resolve(ccPluginsDir);
+  let resolvedInstall: string;
+  let resolvedCache: string;
+  try {
+    resolvedInstall = realpathSync(installPath);
+    resolvedCache = realpathSync(ccPluginsDir);
+  } catch {
+    // If either path doesn't exist, fall back to path.resolve for the error message.
+    resolvedInstall = path.resolve(installPath);
+    resolvedCache = path.resolve(ccPluginsDir);
+  }
   if (!resolvedInstall.startsWith(resolvedCache + path.sep)) {
     throw new Error(
       `Plugin install path "${installPath}" is outside the Claude Code plugins directory. The plugins index may be corrupted.`,
@@ -202,7 +210,7 @@ export async function scanPlugin(installPath: string): Promise<PluginScanResult>
     for (const entry of dirEntries) {
       if (entry.isDirectory()) {
         const skillMd = path.join(skillsPath, entry.name, 'SKILL.md');
-        if (existsSync(skillMd)) {
+        if (existsSync(skillMd) && lstatSync(skillMd).isFile()) {
           skillDirs.push(entry.name);
         }
       }
@@ -325,6 +333,13 @@ export async function importPlugin(
     );
   }
 
+  // Ensure skills directory exists.
+  try {
+    await fs.mkdir(skillsDir, { recursive: true });
+  } catch (cause) {
+    throw new Error(`Error creating skills directory "${skillsDir}": ${String(cause)}`);
+  }
+
   // Check for collisions before copying anything.
   for (const skillName of scan.skillDirs) {
     const targetDir = path.join(skillsDir, skillName);
@@ -430,7 +445,7 @@ export async function importPluginCommand(
     // Next steps.
     if (result.skillsCopied.length > 0) {
       console.log('\nTo attach these skills to a persona, use:');
-      console.log('  talonctl add-skill --name <skill-name> --persona <persona-name>');
+      console.log('  talonctl add-skill --name <skill-name> --persona <persona-name> --format skillmd');
     }
   } catch (error) {
     console.error(`Error: ${(error as Error).message}`);

--- a/src/cli/commands/import-plugin.ts
+++ b/src/cli/commands/import-plugin.ts
@@ -1,0 +1,439 @@
+/**
+ * `talonctl import-plugin` command.
+ *
+ * Reads already-installed Claude Code plugins from ~/.claude/plugins/ and
+ * copies compatible components (skills) into Talon's global skills/ directory.
+ * MCP servers are detected and reported for manual wiring.
+ *
+ * See: docs/superpowers/specs/2026-03-27-import-plugin-design.md
+ */
+
+import fs from 'node:fs/promises';
+import { existsSync, type Dirent } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { validateName } from '../config-utils.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CC_PLUGINS_DIR = path.join(os.homedir(), '.claude', 'plugins');
+const DEFAULT_SKILLS_DIR = 'skills';
+
+/** CC-specific directories that have no Talon equivalent. */
+const SKIPPED_DIRS = ['hooks', 'commands', 'agents'] as const;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Shape of ~/.claude/plugins/installed_plugins.json */
+interface InstalledPluginsFile {
+  version: number;
+  plugins: Record<string, PluginEntry[]>;
+}
+
+interface PluginEntry {
+  scope: string;
+  installPath: string;
+  version: string;
+  installedAt: string;
+  lastUpdated: string;
+  projectPath?: string;
+  gitCommitSha?: string;
+}
+
+/** Resolved plugin ready for import. */
+interface ResolvedPlugin {
+  shortName: string;
+  fullKey: string;
+  installPath: string;
+  entry: PluginEntry;
+}
+
+/** Result of scanning a plugin directory. */
+interface PluginScanResult {
+  skillDirs: string[];       // subdirectory names under skills/
+  hasMcpServer: boolean;
+  skippedComponents: string[]; // e.g. ['hooks', 'agents']
+}
+
+export interface ImportPluginOptions {
+  name?: string;
+  list?: boolean;
+  skillsDir?: string;
+  ccPluginsDir?: string;
+}
+
+export interface ImportPluginResult {
+  skillsCopied: string[];
+  hasMcpServer: boolean;
+  skippedComponents: string[];
+}
+
+/** Info returned by --list. */
+export interface ListablePlugin {
+  shortName: string;
+  fullKey: string;
+  version: string;
+  hasSkills: boolean;
+  hasMcpServer: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Core logic (importable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads the installed_plugins.json index file.
+ *
+ * @throws Error if the file doesn't exist or can't be parsed.
+ */
+export async function readInstalledPlugins(ccPluginsDir: string): Promise<InstalledPluginsFile> {
+  const indexPath = path.join(ccPluginsDir, 'installed_plugins.json');
+
+  if (!existsSync(indexPath)) {
+    throw new Error(
+      'No Claude Code plugins found. Install plugins in Claude Code first.',
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(indexPath, 'utf-8');
+  } catch (cause) {
+    throw new Error(`Error reading Claude Code plugins index "${indexPath}": ${String(cause)}`);
+  }
+
+  try {
+    return JSON.parse(raw) as InstalledPluginsFile;
+  } catch (cause) {
+    throw new Error(`Error parsing Claude Code plugins index "${indexPath}": ${String(cause)}`);
+  }
+}
+
+/**
+ * Extracts the short plugin name from a full key like "backend-development@claude-code-workflows".
+ */
+export function extractShortName(fullKey: string): string {
+  const atIndex = fullKey.indexOf('@');
+  return atIndex === -1 ? fullKey : fullKey.substring(0, atIndex);
+}
+
+/**
+ * Validates that a resolved install path is under the expected CC plugins cache.
+ * Prevents a corrupted index from pointing to arbitrary filesystem locations.
+ */
+export function validateInstallPath(installPath: string, ccPluginsDir: string): void {
+  const resolvedInstall = path.resolve(installPath);
+  const resolvedCache = path.resolve(ccPluginsDir);
+  if (!resolvedInstall.startsWith(resolvedCache + path.sep)) {
+    throw new Error(
+      `Plugin install path "${installPath}" is outside the Claude Code plugins directory. The plugins index may be corrupted.`,
+    );
+  }
+}
+
+/**
+ * Resolves a plugin by short name from the installed plugins index.
+ * If multiple entries match, picks the one with the most recent lastUpdated.
+ */
+export function resolvePlugin(
+  shortName: string,
+  plugins: InstalledPluginsFile,
+): ResolvedPlugin {
+  // Collect all entries across all keys that match the short name.
+  const candidates: Array<{ fullKey: string; entry: PluginEntry }> = [];
+
+  for (const [fullKey, entries] of Object.entries(plugins.plugins)) {
+    if (extractShortName(fullKey) === shortName) {
+      for (const entry of entries) {
+        candidates.push({ fullKey, entry });
+      }
+    }
+  }
+
+  if (candidates.length === 0) {
+    throw new Error(
+      `Plugin '${shortName}' not found. Run \`talonctl import-plugin --list\` to see available plugins.`,
+    );
+  }
+
+  // Pick the most recently updated.
+  candidates.sort(
+    (a, b) =>
+      new Date(b.entry.lastUpdated).getTime() -
+      new Date(a.entry.lastUpdated).getTime(),
+  );
+
+  const best = candidates[0]!;
+  return {
+    shortName,
+    fullKey: best.fullKey,
+    installPath: best.entry.installPath,
+    entry: best.entry,
+  };
+}
+
+/**
+ * Scans a plugin directory for importable components.
+ */
+export async function scanPlugin(installPath: string): Promise<PluginScanResult> {
+  if (!existsSync(installPath)) {
+    throw new Error(
+      `Plugin install path not found: "${installPath}". It may have been uninstalled from Claude Code.`,
+    );
+  }
+
+  const skillDirs: string[] = [];
+  const skippedComponents: string[] = [];
+
+  // Check for skills.
+  const skillsPath = path.join(installPath, 'skills');
+  if (existsSync(skillsPath)) {
+    let dirEntries: Dirent[];
+    try {
+      dirEntries = await fs.readdir(skillsPath, { withFileTypes: true }) as unknown as Dirent[];
+    } catch (cause) {
+      throw new Error(`Error reading plugin skills directory "${skillsPath}": ${String(cause)}`);
+    }
+    for (const entry of dirEntries) {
+      if (entry.isDirectory()) {
+        const skillMd = path.join(skillsPath, entry.name, 'SKILL.md');
+        if (existsSync(skillMd)) {
+          skillDirs.push(entry.name);
+        }
+      }
+    }
+  }
+
+  // Check for skipped CC-specific directories.
+  for (const dir of SKIPPED_DIRS) {
+    if (existsSync(path.join(installPath, dir))) {
+      skippedComponents.push(dir);
+    }
+  }
+
+  // Check for MCP server.
+  let hasMcpServer = false;
+  const pkgJsonPath = path.join(installPath, 'package.json');
+  if (existsSync(pkgJsonPath)) {
+    try {
+      const pkgRaw = await fs.readFile(pkgJsonPath, 'utf-8');
+      const pkg = JSON.parse(pkgRaw) as Record<string, unknown>;
+      const deps = {
+        ...(pkg.dependencies as Record<string, string> | undefined),
+        ...(pkg.devDependencies as Record<string, string> | undefined),
+      };
+      if ('@modelcontextprotocol/sdk' in deps) {
+        hasMcpServer = true;
+      }
+    } catch {
+      // Ignore parse errors in package.json.
+    }
+  }
+
+  return { skillDirs, hasMcpServer, skippedComponents };
+}
+
+/**
+ * Lists all installed CC plugins that have importable components.
+ */
+export async function listImportablePlugins(
+  options: Pick<ImportPluginOptions, 'ccPluginsDir'>,
+): Promise<ListablePlugin[]> {
+  const ccPluginsDir = options.ccPluginsDir ?? DEFAULT_CC_PLUGINS_DIR;
+  const index = await readInstalledPlugins(ccPluginsDir);
+
+  // Deduplicate by short name — pick the most recently updated entry.
+  const byShortName = new Map<string, { fullKey: string; entry: PluginEntry }>();
+  for (const [fullKey, entries] of Object.entries(index.plugins)) {
+    const shortName = extractShortName(fullKey);
+    for (const entry of entries) {
+      const existing = byShortName.get(shortName);
+      if (
+        !existing ||
+        new Date(entry.lastUpdated).getTime() >
+          new Date(existing.entry.lastUpdated).getTime()
+      ) {
+        byShortName.set(shortName, { fullKey, entry });
+      }
+    }
+  }
+
+  const result: ListablePlugin[] = [];
+
+  for (const [shortName, { fullKey, entry }] of byShortName) {
+    if (!existsSync(entry.installPath)) continue;
+
+    try {
+      validateInstallPath(entry.installPath, ccPluginsDir);
+      const scan = await scanPlugin(entry.installPath);
+      if (scan.skillDirs.length > 0 || scan.hasMcpServer) {
+        result.push({
+          shortName,
+          fullKey,
+          version: entry.version,
+          hasSkills: scan.skillDirs.length > 0,
+          hasMcpServer: scan.hasMcpServer,
+        });
+      }
+    } catch {
+      // Skip plugins with broken install paths.
+    }
+  }
+
+  return result.sort((a, b) => a.shortName.localeCompare(b.shortName));
+}
+
+/**
+ * Imports a CC plugin's skills into Talon's skills directory.
+ *
+ * @throws Error with a user-facing message on any failure.
+ */
+export async function importPlugin(
+  options: ImportPluginOptions,
+): Promise<ImportPluginResult> {
+  const ccPluginsDir = options.ccPluginsDir ?? DEFAULT_CC_PLUGINS_DIR;
+  const skillsDir = options.skillsDir ?? DEFAULT_SKILLS_DIR;
+
+  if (!options.name) {
+    throw new Error('Plugin name is required. Use --name <name> or --list to see available plugins.');
+  }
+
+  // Validate name.
+  const nameError = validateName(options.name, 'Plugin');
+  if (nameError) {
+    throw new Error(nameError);
+  }
+
+  // Resolve plugin.
+  const index = await readInstalledPlugins(ccPluginsDir);
+  const resolved = resolvePlugin(options.name, index);
+
+  // Validate install path is under CC plugins directory.
+  validateInstallPath(resolved.installPath, ccPluginsDir);
+
+  // Scan plugin.
+  const scan = await scanPlugin(resolved.installPath);
+
+  if (scan.skillDirs.length === 0 && !scan.hasMcpServer) {
+    throw new Error(
+      `Plugin '${options.name}' has no importable skills or MCP servers.`,
+    );
+  }
+
+  // Check for collisions before copying anything.
+  for (const skillName of scan.skillDirs) {
+    const targetDir = path.join(skillsDir, skillName);
+    if (existsSync(targetDir)) {
+      throw new Error(
+        `Skills from plugin '${options.name}' already exist in ${skillsDir}/. Remove them first to re-import.`,
+      );
+    }
+  }
+
+  // Copy skill directories. Use errorOnExist to prevent TOCTOU overwrites.
+  const skillsCopied: string[] = [];
+  for (const skillName of scan.skillDirs) {
+    const srcDir = path.join(resolved.installPath, 'skills', skillName);
+    const destDir = path.join(skillsDir, skillName);
+    try {
+      await fs.cp(srcDir, destDir, { recursive: true, errorOnExist: true, force: false });
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code === 'EEXIST') {
+        throw new Error(
+          `Skills from plugin '${options.name}' already exist in ${skillsDir}/. Remove them first to re-import.`,
+        );
+      }
+      throw new Error(`Error copying skill "${skillName}" to "${destDir}": ${String(cause)}`);
+    }
+    skillsCopied.push(skillName);
+  }
+
+  return {
+    skillsCopied,
+    hasMcpServer: scan.hasMcpServer,
+    skippedComponents: scan.skippedComponents,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI wrappers
+// ---------------------------------------------------------------------------
+
+/**
+ * CLI entrypoint for `talonctl import-plugin --list`.
+ */
+export async function listPluginsCommand(
+  options: Pick<ImportPluginOptions, 'ccPluginsDir'>,
+): Promise<void> {
+  try {
+    const plugins = await listImportablePlugins(options);
+
+    if (plugins.length === 0) {
+      console.log('No importable Claude Code plugins found.');
+      return;
+    }
+
+    console.log('Importable Claude Code plugins:\n');
+    for (const p of plugins) {
+      const components: string[] = [];
+      if (p.hasSkills) components.push('skills');
+      if (p.hasMcpServer) components.push('MCP server');
+      console.log(`  ${p.shortName} (${p.version}) — ${components.join(', ')}`);
+    }
+    console.log(`\nUse \`talonctl import-plugin --name <name>\` to import.`);
+  } catch (error) {
+    console.error(`Error: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * CLI entrypoint for `talonctl import-plugin --name <name>`.
+ */
+export async function importPluginCommand(
+  options: ImportPluginOptions,
+): Promise<void> {
+  try {
+    const result = await importPlugin(options);
+
+    // Report copied skills.
+    if (result.skillsCopied.length > 0) {
+      console.log(`Imported ${result.skillsCopied.length} skill(s):`);
+      for (const name of result.skillsCopied) {
+        console.log(`  ${options.skillsDir ?? DEFAULT_SKILLS_DIR}/${name}/`);
+      }
+    } else {
+      console.log('No skills imported.');
+    }
+
+    // Report skipped components.
+    if (result.skippedComponents.length > 0) {
+      console.log(
+        `\nSkipped CC-specific components: ${result.skippedComponents.join(', ')} (no Talon equivalent)`,
+      );
+    }
+
+    // Report MCP server.
+    if (result.hasMcpServer) {
+      if (result.skillsCopied.length === 0) {
+        console.log('MCP server detected — configure it via talonctl MCP commands.');
+      } else {
+        console.log('\nMCP server also detected — configure it via talonctl MCP commands.');
+      }
+    }
+
+    // Next steps.
+    if (result.skillsCopied.length > 0) {
+      console.log('\nTo attach these skills to a persona, use:');
+      console.log('  talonctl add-skill --name <skill-name> --persona <persona-name>');
+    }
+  } catch (error) {
+    console.error(`Error: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -42,6 +42,7 @@ import { listProvidersCommand } from './commands/list-providers.js';
 import { addProviderCommand } from './commands/add-provider.js';
 import { setDefaultProviderCommand } from './commands/set-default-provider.js';
 import { testProviderCommand } from './commands/test-provider.js';
+import { importPluginCommand, listPluginsCommand } from './commands/import-plugin.js';
 
 // Load .env before anything else so ${VAR} substitution works in config.
 const envPath = resolve(process.env.TALOND_ENV_FILE || '.env');
@@ -180,6 +181,28 @@ program
       format: opts.format,
       configPath: opts.config,
     });
+  });
+
+program
+  .command('import-plugin')
+  .description('Import skills from an installed Claude Code plugin into Talon')
+  .option('--name <name>', 'Short plugin name (e.g. backend-development)')
+  .option('--list', 'List importable Claude Code plugins')
+  .option('--skills-dir <path>', 'Talon skills directory', 'skills')
+  .option('--cc-plugins-dir <path>', 'Claude Code plugins directory')
+  .action(async (opts: { name?: string; list?: boolean; skillsDir: string; ccPluginsDir?: string }) => {
+    if (opts.list) {
+      await listPluginsCommand({ ccPluginsDir: opts.ccPluginsDir });
+    } else if (opts.name) {
+      await importPluginCommand({
+        name: opts.name,
+        skillsDir: opts.skillsDir,
+        ccPluginsDir: opts.ccPluginsDir,
+      });
+    } else {
+      console.error('Error: provide --name <name> to import a plugin or --list to see available plugins.');
+      process.exit(1);
+    }
   });
 
 program

--- a/tests/unit/cli/import-plugin.test.ts
+++ b/tests/unit/cli/import-plugin.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Unit tests for the `talonctl import-plugin` command.
+ *
+ * Tests the pure functions: readInstalledPlugins, extractShortName,
+ * resolvePlugin, scanPlugin, listImportablePlugins, and importPlugin.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  readInstalledPlugins,
+  extractShortName,
+  resolvePlugin,
+  validateInstallPath,
+  scanPlugin,
+  listImportablePlugins,
+  importPlugin,
+} from '../../../src/cli/commands/import-plugin.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'talon-import-plugin-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+/** The cc-plugins dir for this test run, created lazily. */
+function ccPluginsDir(): string {
+  return join(tmpDir, 'cc-plugins');
+}
+
+/** Build a plugin install path that is under the ccPluginsDir (required by path validation). */
+function pluginInstallPath(name: string): string {
+  return join(ccPluginsDir(), 'cache', name);
+}
+
+/** Write a minimal installed_plugins.json. */
+function writePluginIndex(
+  plugins: Record<string, Array<{ installPath: string; version: string; lastUpdated: string; scope?: string }>>,
+): string {
+  const ccDir = ccPluginsDir();
+  mkdirSync(ccDir, { recursive: true });
+  writeFileSync(
+    join(ccDir, 'installed_plugins.json'),
+    JSON.stringify({ version: 2, plugins }, null, 2),
+  );
+  return ccDir;
+}
+
+/** Scaffold a plugin directory with skills. */
+function scaffoldPlugin(basePath: string, skills: string[], opts?: { mcpDeps?: boolean; hooks?: boolean; agents?: boolean; commands?: boolean }): void {
+  mkdirSync(basePath, { recursive: true });
+
+  if (skills.length > 0) {
+    const skillsDir = join(basePath, 'skills');
+    mkdirSync(skillsDir, { recursive: true });
+    for (const name of skills) {
+      const skillDir = join(skillsDir, name);
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---\nname: ${name}\ndescription: "Test skill"\n---\n\n# ${name}\n`,
+      );
+    }
+  }
+
+  if (opts?.mcpDeps) {
+    writeFileSync(
+      join(basePath, 'package.json'),
+      JSON.stringify({
+        name: 'test-mcp-plugin',
+        dependencies: { '@modelcontextprotocol/sdk': '^1.0.0' },
+      }),
+    );
+  }
+
+  if (opts?.hooks) mkdirSync(join(basePath, 'hooks'), { recursive: true });
+  if (opts?.agents) mkdirSync(join(basePath, 'agents'), { recursive: true });
+  if (opts?.commands) mkdirSync(join(basePath, 'commands'), { recursive: true });
+}
+
+// ---------------------------------------------------------------------------
+// extractShortName
+// ---------------------------------------------------------------------------
+
+describe('extractShortName', () => {
+  it('extracts name before @', () => {
+    expect(extractShortName('backend-development@claude-code-workflows')).toBe('backend-development');
+  });
+
+  it('returns full string if no @', () => {
+    expect(extractShortName('my-plugin')).toBe('my-plugin');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readInstalledPlugins
+// ---------------------------------------------------------------------------
+
+describe('readInstalledPlugins', () => {
+  it('reads a valid index file', async () => {
+    const ccDir = writePluginIndex({
+      'test@marketplace': [{ installPath: '/tmp/test', version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+    });
+    const result = await readInstalledPlugins(ccDir);
+    expect(result.version).toBe(2);
+    expect(result.plugins).toHaveProperty('test@marketplace');
+  });
+
+  it('throws when index file missing', async () => {
+    await expect(readInstalledPlugins(join(tmpDir, 'nonexistent'))).rejects.toThrow(
+      'No Claude Code plugins found',
+    );
+  });
+
+  it('throws on malformed JSON', async () => {
+    const ccDir = join(tmpDir, 'cc-bad');
+    mkdirSync(ccDir, { recursive: true });
+    writeFileSync(join(ccDir, 'installed_plugins.json'), '{not valid json');
+    await expect(readInstalledPlugins(ccDir)).rejects.toThrow('Error parsing');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateInstallPath
+// ---------------------------------------------------------------------------
+
+describe('validateInstallPath', () => {
+  it('accepts paths under the CC plugins dir', () => {
+    expect(() => validateInstallPath('/home/user/.claude/plugins/cache/market/plugin/1.0', '/home/user/.claude/plugins')).not.toThrow();
+  });
+
+  it('rejects paths outside CC plugins dir', () => {
+    expect(() => validateInstallPath('/etc/evil', '/home/user/.claude/plugins')).toThrow('outside the Claude Code plugins directory');
+  });
+
+  it('rejects path traversal attempts', () => {
+    expect(() => validateInstallPath('/home/user/.claude/plugins/../../../etc/passwd', '/home/user/.claude/plugins')).toThrow('outside the Claude Code plugins directory');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePlugin
+// ---------------------------------------------------------------------------
+
+describe('resolvePlugin', () => {
+  it('resolves a plugin by short name', () => {
+    const installPath = join(tmpDir, 'install');
+    const index = {
+      version: 2,
+      plugins: {
+        'my-plugin@market': [
+          { installPath, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z', scope: 'user', installedAt: '2026-01-01T00:00:00Z' },
+        ],
+      },
+    };
+    const resolved = resolvePlugin('my-plugin', index);
+    expect(resolved.shortName).toBe('my-plugin');
+    expect(resolved.installPath).toBe(installPath);
+  });
+
+  it('picks the most recently updated entry across marketplaces', () => {
+    const oldPath = join(tmpDir, 'old');
+    const newPath = join(tmpDir, 'new');
+    const index = {
+      version: 2,
+      plugins: {
+        'my-plugin@market-a': [
+          { installPath: oldPath, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z', scope: 'user', installedAt: '2026-01-01T00:00:00Z' },
+        ],
+        'my-plugin@market-b': [
+          { installPath: newPath, version: '2.0.0', lastUpdated: '2026-06-01T00:00:00Z', scope: 'user', installedAt: '2026-06-01T00:00:00Z' },
+        ],
+      },
+    };
+    const resolved = resolvePlugin('my-plugin', index);
+    expect(resolved.installPath).toBe(newPath);
+  });
+
+  it('throws when plugin not found', () => {
+    const index = { version: 2, plugins: {} };
+    expect(() => resolvePlugin('nonexistent', index)).toThrow("Plugin 'nonexistent' not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanPlugin
+// ---------------------------------------------------------------------------
+
+describe('scanPlugin', () => {
+  it('finds skills with SKILL.md', async () => {
+    const pluginPath = join(tmpDir, 'plugin');
+    scaffoldPlugin(pluginPath, ['api-design', 'caching']);
+    const scan = await scanPlugin(pluginPath);
+    expect(scan.skillDirs.sort()).toEqual(['api-design', 'caching']);
+    expect(scan.hasMcpServer).toBe(false);
+    expect(scan.skippedComponents).toEqual([]);
+  });
+
+  it('detects MCP server from package.json', async () => {
+    const pluginPath = join(tmpDir, 'plugin');
+    scaffoldPlugin(pluginPath, [], { mcpDeps: true });
+    const scan = await scanPlugin(pluginPath);
+    expect(scan.hasMcpServer).toBe(true);
+  });
+
+  it('detects skipped CC-specific directories', async () => {
+    const pluginPath = join(tmpDir, 'plugin');
+    scaffoldPlugin(pluginPath, ['skill-a'], { hooks: true, agents: true, commands: true });
+    const scan = await scanPlugin(pluginPath);
+    expect(scan.skippedComponents.sort()).toEqual(['agents', 'commands', 'hooks']);
+  });
+
+  it('ignores skill dirs without SKILL.md', async () => {
+    const pluginPath = join(tmpDir, 'plugin');
+    mkdirSync(join(pluginPath, 'skills', 'empty-skill'), { recursive: true });
+    const scan = await scanPlugin(pluginPath);
+    expect(scan.skillDirs).toEqual([]);
+  });
+
+  it('throws when install path missing', async () => {
+    await expect(scanPlugin(join(tmpDir, 'nonexistent'))).rejects.toThrow(
+      'Plugin install path not found',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listImportablePlugins
+// ---------------------------------------------------------------------------
+
+describe('listImportablePlugins', () => {
+  it('returns only plugins with skills or MCP servers', async () => {
+    const pluginWithSkills = pluginInstallPath('with-skills');
+    const pluginMcpOnly = pluginInstallPath('mcp-only');
+    const pluginEmpty = pluginInstallPath('empty');
+
+    scaffoldPlugin(pluginWithSkills, ['skill-a']);
+    scaffoldPlugin(pluginMcpOnly, [], { mcpDeps: true });
+    mkdirSync(pluginEmpty, { recursive: true });
+
+    const ccDir = writePluginIndex({
+      'with-skills@market': [{ installPath: pluginWithSkills, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+      'mcp-only@market': [{ installPath: pluginMcpOnly, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+      'empty@market': [{ installPath: pluginEmpty, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+    });
+
+    const result = await listImportablePlugins({ ccPluginsDir: ccDir });
+    const names = result.map((p) => p.shortName);
+    expect(names).toContain('with-skills');
+    expect(names).toContain('mcp-only');
+    expect(names).not.toContain('empty');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// importPlugin
+// ---------------------------------------------------------------------------
+
+describe('importPlugin', () => {
+  it('copies skill directories into skills/', async () => {
+    const pluginPath = pluginInstallPath('test-plugin');
+    const skillsDir = join(tmpDir, 'skills');
+    mkdirSync(skillsDir, { recursive: true });
+
+    // Scaffold plugin with skills including assets.
+    scaffoldPlugin(pluginPath, ['my-skill']);
+    const assetsDir = join(pluginPath, 'skills', 'my-skill', 'assets');
+    mkdirSync(assetsDir, { recursive: true });
+    writeFileSync(join(assetsDir, 'checklist.md'), '# Checklist\n');
+
+    const ccDir = writePluginIndex({
+      'test-plugin@market': [{ installPath: pluginPath, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+    });
+
+    const result = await importPlugin({
+      name: 'test-plugin',
+      skillsDir,
+      ccPluginsDir: ccDir,
+    });
+
+    expect(result.skillsCopied).toEqual(['my-skill']);
+    expect(existsSync(join(skillsDir, 'my-skill', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(skillsDir, 'my-skill', 'assets', 'checklist.md'))).toBe(true);
+  });
+
+  it('errors when skill already exists', async () => {
+    const pluginPath = pluginInstallPath('test-plugin');
+    const skillsDir = join(tmpDir, 'skills');
+
+    scaffoldPlugin(pluginPath, ['existing-skill']);
+    // Pre-create the skill in talon's skills dir.
+    mkdirSync(join(skillsDir, 'existing-skill'), { recursive: true });
+
+    const ccDir = writePluginIndex({
+      'test-plugin@market': [{ installPath: pluginPath, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+    });
+
+    await expect(
+      importPlugin({ name: 'test-plugin', skillsDir, ccPluginsDir: ccDir }),
+    ).rejects.toThrow('already exist');
+  });
+
+  it('errors when plugin has no importable components', async () => {
+    const pluginPath = pluginInstallPath('empty-plugin');
+    mkdirSync(pluginPath, { recursive: true });
+
+    const ccDir = writePluginIndex({
+      'empty-plugin@market': [{ installPath: pluginPath, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+    });
+
+    await expect(
+      importPlugin({ name: 'empty-plugin', skillsDir: join(tmpDir, 'skills'), ccPluginsDir: ccDir }),
+    ).rejects.toThrow('no importable skills or MCP servers');
+  });
+
+  it('reports MCP server and skipped components', async () => {
+    const pluginPath = pluginInstallPath('full-plugin');
+    const skillsDir = join(tmpDir, 'skills');
+    mkdirSync(skillsDir, { recursive: true });
+
+    scaffoldPlugin(pluginPath, ['skill-a'], { mcpDeps: true, hooks: true, agents: true });
+
+    const ccDir = writePluginIndex({
+      'full-plugin@market': [{ installPath: pluginPath, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+    });
+
+    const result = await importPlugin({
+      name: 'full-plugin',
+      skillsDir,
+      ccPluginsDir: ccDir,
+    });
+
+    expect(result.skillsCopied).toEqual(['skill-a']);
+    expect(result.hasMcpServer).toBe(true);
+    expect(result.skippedComponents.sort()).toEqual(['agents', 'hooks']);
+  });
+
+  it('errors when name is missing', async () => {
+    await expect(importPlugin({})).rejects.toThrow('Plugin name is required');
+  });
+
+  it('errors when name is invalid', async () => {
+    await expect(importPlugin({ name: 'bad name!' })).rejects.toThrow('invalid');
+  });
+});

--- a/tests/unit/cli/import-plugin.test.ts
+++ b/tests/unit/cli/import-plugin.test.ts
@@ -388,6 +388,24 @@ describe('importPlugin', () => {
     expect(existsSync(join(skillsDir, 'test-skill', 'SKILL.md'))).toBe(true);
   });
 
+  it('errors when plugin contains skills with invalid names', async () => {
+    const pluginPath = pluginInstallPath('bad-names-plugin');
+    const skillsDir = join(tmpDir, 'skills');
+    mkdirSync(skillsDir, { recursive: true });
+
+    // Create a skill with a dot in the name (invalid for Talon).
+    mkdirSync(join(pluginPath, 'skills', 'my.skill'), { recursive: true });
+    writeFileSync(join(pluginPath, 'skills', 'my.skill', 'SKILL.md'), '---\nname: my.skill\n---\n');
+
+    const ccDir = writePluginIndex({
+      'bad-names-plugin@market': [{ installPath: pluginPath, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+    });
+
+    await expect(
+      importPlugin({ name: 'bad-names-plugin', skillsDir, ccPluginsDir: ccDir }),
+    ).rejects.toThrow('invalid names');
+  });
+
   it('errors when name is missing', async () => {
     await expect(importPlugin({})).rejects.toThrow('Plugin name is required');
   });

--- a/tests/unit/cli/import-plugin.test.ts
+++ b/tests/unit/cli/import-plugin.test.ts
@@ -347,6 +347,47 @@ describe('importPlugin', () => {
     expect(result.skippedComponents.sort()).toEqual(['agents', 'hooks']);
   });
 
+  it('succeeds for MCP-only plugin with zero skills', async () => {
+    const pluginPath = pluginInstallPath('mcp-plugin');
+    const skillsDir = join(tmpDir, 'skills');
+    mkdirSync(skillsDir, { recursive: true });
+
+    scaffoldPlugin(pluginPath, [], { mcpDeps: true });
+
+    const ccDir = writePluginIndex({
+      'mcp-plugin@market': [{ installPath: pluginPath, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+    });
+
+    const result = await importPlugin({
+      name: 'mcp-plugin',
+      skillsDir,
+      ccPluginsDir: ccDir,
+    });
+
+    expect(result.skillsCopied).toEqual([]);
+    expect(result.hasMcpServer).toBe(true);
+  });
+
+  it('creates skillsDir if it does not exist', async () => {
+    const pluginPath = pluginInstallPath('create-dir-plugin');
+    const skillsDir = join(tmpDir, 'nonexistent-skills');
+
+    scaffoldPlugin(pluginPath, ['test-skill']);
+
+    const ccDir = writePluginIndex({
+      'create-dir-plugin@market': [{ installPath: pluginPath, version: '1.0.0', lastUpdated: '2026-01-01T00:00:00Z' }],
+    });
+
+    const result = await importPlugin({
+      name: 'create-dir-plugin',
+      skillsDir,
+      ccPluginsDir: ccDir,
+    });
+
+    expect(result.skillsCopied).toEqual(['test-skill']);
+    expect(existsSync(join(skillsDir, 'test-skill', 'SKILL.md'))).toBe(true);
+  });
+
   it('errors when name is missing', async () => {
     await expect(importPlugin({})).rejects.toThrow('Plugin name is required');
   });


### PR DESCRIPTION
## Summary

- Add `talonctl import-plugin --name <plugin>` to import skills from installed Claude Code plugins into Talon's `skills/` directory
- Add `talonctl import-plugin --list` to show plugins with importable components (skills or MCP servers)
- Copies SKILL.md files with assets/references, detects MCP servers for manual wiring, warns about CC-specific components (hooks, commands, agents)
- Includes path traversal validation, TOCTOU-safe `fs.cp` with `errorOnExist`, and user-facing error messages consistent with existing CLI commands

## Test plan

- [x] 23 unit tests covering: plugin discovery, resolution, scanning, path validation, collision detection, copy, MCP detection, and edge cases
- [x] Build passes
- [x] GPT-5.4 code review — 3 medium issues found and addressed (path traversal, TOCTOU race, error handling)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)