### PR TITLE
fix(skill): correct CLI flag in talon-setup skill

### DIFF
--- a/.claude/skills/talon-setup/SKILL.md
+++ b/.claude/skills/talon-setup/SKILL.md
@@ -167,7 +167,7 @@ npx talonctl add-provider --name claude-code \
   --command claude \
   --context both \
   --context-window 200000 \
-  --rotation-threshold 0.5 \
+  --threshold-ratio 0.5 \
   --enabled
 
 # Gemini (if selected)
@@ -175,7 +175,7 @@ npx talonctl add-provider --name gemini-cli \
   --command <path-to-gemini> \
   --context both \
   --context-window 1000000 \
-  --rotation-threshold 0.8 \
+  --threshold-ratio 0.8 \
   --enabled
 ```
 


### PR DESCRIPTION
## Summary
- Fixed `--rotation-threshold` → `--threshold-ratio` in the talon-setup skill's `add-provider` examples (Claude and Gemini)
- The old flag doesn't exist on `talonctl add-provider`, causing setup to fail with `error: unknown option '--rotation-threshold'`

## Test plan
- [ ] Run `npx talonctl add-provider --name claude-code --command claude --context both --context-window 200000 --threshold-ratio 0.5 --enabled` — should succeed
- [ ] Run full setup flow via talon-setup skill — provider step should complete without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)