### PR TITLE
fix(agent-runner): send one message per text content block

### DIFF
--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -558,6 +558,7 @@ export class AgentRunner {
                               throw new Error(`channel send failed: ${flushResult.error.message}`);
                             }
                             outputText = '';
+                            fullOutputText += '\n\n';
                           }
                           this.handleProviderToolEvent(
                             generationObservation.getTraceparent(),
@@ -654,7 +655,7 @@ export class AgentRunner {
 
                   return {
                     outputText,
-                    fullOutputText,
+                    fullOutputText: fullOutputText.replace(/\n\n$/, ''),
                     resultSessionId,
                     usage,
                   };

--- a/tests/unit/daemon/agent-runner.test.ts
+++ b/tests/unit/daemon/agent-runner.test.ts
@@ -2372,6 +2372,12 @@ describe('AgentRunner', () => {
       expect(sendCalls).toHaveLength(2);
       expect(sendCalls[0]![1]).toEqual({ body: 'Before tool.' });
       expect(sendCalls[1]![1]).toEqual({ body: 'After tool.' });
+
+      // Verify DB persistence stores the full transcript with block separators
+      expect(ctx.repos.message.insert).toHaveBeenCalledTimes(1);
+      const insertCall = vi.mocked(ctx.repos.message.insert).mock.calls[0]![0] as { content: string };
+      const persisted = JSON.parse(insertCall.content);
+      expect(persisted.body).toBe('Before tool.\n\nAfter tool.');
     });
 
     it('sends three separate messages for text → tool → text → tool → text', async () => {
@@ -2434,6 +2440,12 @@ describe('AgentRunner', () => {
       expect(sendCalls[0]![1]).toEqual({ body: 'Block 1.' });
       expect(sendCalls[1]![1]).toEqual({ body: 'Block 2.' });
       expect(sendCalls[2]![1]).toEqual({ body: 'Block 3.' });
+
+      // Verify DB persistence stores the full transcript with block separators
+      expect(ctx.repos.message.insert).toHaveBeenCalledTimes(1);
+      const insertCall = vi.mocked(ctx.repos.message.insert).mock.calls[0]![0] as { content: string };
+      const persisted = JSON.parse(insertCall.content);
+      expect(persisted.body).toBe('Block 1.\n\nBlock 2.\n\nBlock 3.');
     });
 
     it('concatenates consecutive text events with no tool between them into a single message', async () => {


### PR DESCRIPTION
## Summary

When Claude produces multiple text blocks in one turn (text → tool_use → text), the runner was concatenating them into one message, producing unnatural output. This fix flushes buffered text as a separate channel message whenever a tool_use event follows it.

Closes #102

## What changed

- `src/daemon/agent-runner.ts`: Added flush-on-tool-use pattern. When a `tool_use`, `server_tool_use`, or `mcp_tool_use` event arrives and there is buffered text, the buffer is sent immediately via `connector.send()` before the tool runs. Remaining text after the stream ends is sent as the final message (only if non-empty). Added `fullOutputText` accumulator so LangFuse observability always captures the complete turn output across all flushed blocks.
- `tests/unit/daemon/agent-runner.test.ts`: 4 new tests covering the flushing behaviour.

## Design decisions

- Consecutive text events with no tool between them are **concatenated into one message** (same block, no reason to split).
- Schedule items skip flushing, matching the existing behaviour where schedule runs don't send outbound replies via the connector.
- The `message.insert` DB record uses `fullOutputText` so the database has the complete conversation turn.

## Test plan

**Prerequisites:** `npm install`

1. `npm test` — all 65 agent-runner tests pass, no regressions in the full suite (1 pre-existing failure in `list-skills.test.ts` unrelated to this change)
2. Manual test: configure a persona that responds with text, uses a tool (e.g. memory_access), then responds with more text. Verify two separate messages arrive in the channel instead of one concatenated message.

🤖 Generated with Claude Code