### PR TITLE
docs: add talond.dev documentation content

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -1,21 +1,16 @@
 ---
 title: Configuration
-description: All talond.yaml configuration sections explained
+description: Practical overview of the talond.yaml configuration file
 ---
 
 # Configuration
 
-Talon uses a single YAML file (`talond.yaml` by default). All fields are optional — sensible defaults apply when omitted. Credentials use `${ENV_VAR}` substitution.
+Talon uses a single YAML config file, `talond.yaml` by default.
+All top-level sections are optional. The schema in `src/core/config/config-schema.ts` supplies defaults when sections are omitted.
 
-Pass a custom config path with `--config`:
+## Environment variables
 
-```bash
-node dist/index.js --config /etc/talon/talond.yaml
-```
-
-## Environment variable substitution
-
-Any config value can reference an environment variable:
+Config values can reference environment variables:
 
 ```yaml
 channels:
@@ -25,123 +20,117 @@ channels:
       botToken: ${TELEGRAM_BOT_TOKEN}
 ```
 
-Variables are loaded from `.env` at startup. Use `talonctl env-check` to audit for missing variables.
+The CLI loads `.env` before parsing config. Use `talonctl env-check` to see which placeholders are still missing.
 
----
-
-## storage
-
-SQLite database location.
+## Minimal useful skeleton
 
 ```yaml
 storage:
   type: sqlite
   path: data/talond.sqlite
+
+personas:
+  - name: assistant
+    model: claude-sonnet-4-6
+    systemPromptFile: personas/assistant/system.md
+    capabilities:
+      allow:
+        - memory.access:thread
+        - net.http:egress
+        - schedule.manage:own
+
+channels:
+  - name: my-telegram
+    type: telegram
+    config:
+      botToken: ${TELEGRAM_BOT_TOKEN}
+      allowedChatIds:
+        - "123456789"
+
+bindings:
+  - persona: assistant
+    channel: my-telegram
+    isDefault: true
+
+auth:
+  mode: subscription
+
+logLevel: info
+dataDir: data
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `type` | `sqlite` | Database backend. Only `sqlite` is supported. |
-| `path` | `data/talond.sqlite` | Path to the SQLite file. Created on first run. |
-
----
-
-## personas
-
-An array of agent personas. Each persona has its own system prompt, model, skills, and capability policy.
+## Personas
 
 ```yaml
 personas:
   - name: assistant
     model: claude-sonnet-4-6
+    provider: claude-code
     systemPromptFile: personas/assistant/system.md
     skills:
       - web-search
     subagents:
       - session-summarizer
-      - memory-groomer
-      - memory-retriever
     capabilities:
       allow:
-        - channel.send:my-telegram
-        - memory.access:*
-        - net.http
-        - schedule.manage
-        - subagent.invoke:*
+        - memory.access:thread
+        - net.http:egress
+        - schedule.manage:own
+        - subagent.invoke
       requireApproval:
-        - db.query
+        - db.query:own
+    mounts:
+      - source: /srv/notes
+        target: /workspace/notes
+        mode: ro
     maxConcurrent: 2
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `name` | required | Unique identifier for this persona |
-| `model` | `claude-sonnet-4-6` | Model ID passed to the provider |
-| `provider` | (default provider) | Override the agent runner provider for this persona |
-| `systemPromptFile` | — | Path to the system prompt Markdown file |
-| `skills` | `[]` | List of skill names to attach |
-| `subagents` | `[]` | List of sub-agent names the persona can invoke |
-| `capabilities.allow` | `[]` | Capability labels the persona can use freely |
-| `capabilities.requireApproval` | `[]` | Capability labels that require user confirmation |
-| `maxConcurrent` | — | Max parallel agent runs for this persona |
+Key points:
 
-See [Personas guide](/docs/guides/personas) and [capability labels](/docs/guides/personas#capability-labels) for the full list.
+- `model` defaults to `claude-sonnet-4-6`
+- `provider` is optional and overrides the default foreground provider for that persona
+- `skills` and `subagents` default to empty arrays
+- capability labels are default-deny; grant only what the persona needs
 
----
-
-## channels
-
-Channel connectors. Each entry has a `type`, a `name`, and a connector-specific `config` block.
+## Channels
 
 ```yaml
 channels:
-  - name: my-telegram
-    type: telegram
+  - name: my-terminal
+    type: terminal
     enabled: true
     showToolCalls: true
     config:
-      botToken: ${TELEGRAM_BOT_TOKEN}
-      allowedChatIds:
-        - 123456789
+      port: 7700
+      host: 127.0.0.1
+      token: ${TERMINAL_TOKEN}
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `name` | required | Unique identifier for this channel |
-| `type` | required | `telegram`, `slack`, `discord`, `whatsappBusiness`, `whatsappBaileys`, `email`, `terminal` |
-| `enabled` | `true` | Enable or disable this channel at startup |
-| `showToolCalls` | `false` | Send a status message to the channel on each tool call |
-| `config` | `{}` | Connector-specific configuration (varies by type) |
+Common fields:
 
-See the [Channels guide](/docs/guides/channels) for per-connector config fields.
+| Field | Meaning |
+|---|---|
+| `name` | Unique channel name |
+| `type` | Connector type |
+| `enabled` | Defaults to `true` |
+| `showToolCalls` | Optional per-channel tool-call messages |
+| `config` | Connector-specific config |
 
----
+Connector-specific config is covered in the [Channels guide](/docs/guides/channels).
 
-## bindings
-
-Route channels to personas.
+## Bindings
 
 ```yaml
 bindings:
   - persona: assistant
     channel: my-telegram
     isDefault: true
-  - persona: researcher
-    channel: my-slack
-    isDefault: true
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `persona` | required | Persona name |
-| `channel` | required | Channel name |
-| `isDefault` | `false` | Mark as the default binding for this channel |
+Bindings route a channel to a persona. The first binding created for a channel becomes its default binding automatically.
 
----
-
-## queue
-
-Controls the durable message queue.
+## Queue
 
 ```yaml
 queue:
@@ -151,18 +140,9 @@ queue:
   concurrencyLimit: 5
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `maxAttempts` | `3` | Max delivery attempts before dead-lettering |
-| `backoffBaseMs` | `1000` | Initial retry delay in ms |
-| `backoffMaxMs` | `60000` | Max retry delay in ms (exponential backoff cap) |
-| `concurrencyLimit` | `5` | Max messages processed simultaneously |
+These values control queue retries and foreground processing concurrency.
 
----
-
-## agentRunner
-
-Foreground agent execution. Configures which provider runs the main conversation agent and how context rotation works.
+## Foreground providers: `agentRunner`
 
 ```yaml
 agentRunner:
@@ -180,23 +160,13 @@ agentRunner:
         summarizer: session-summarizer
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `defaultProvider` | `claude-code` | Provider to use when none is specified per-persona |
-| `providers.<name>.enabled` | `true` | Enable this provider |
-| `providers.<name>.command` | `claude` | CLI command to invoke |
-| `providers.<name>.contextWindowTokens` | `200000` | Context window size for rotation calculations |
-| `contextManagement.enabled` | `true` | Enable automatic session rotation |
-| `contextManagement.triggerMetric` | `cache_read_input_tokens` | Token metric to monitor |
-| `contextManagement.thresholdRatio` | `0.5` | Fraction of `contextWindowTokens` that triggers rotation |
-| `contextManagement.recentMessageCount` | `10` | Verbatim messages to include after rotation |
-| `contextManagement.summarizer` | `session-summarizer` | Sub-agent used to compress history |
+Notes:
 
----
+- the schema default includes an enabled `claude-code` provider
+- `contextManagement` belongs only under `agentRunner.providers.<name>`
+- when `contextManagement.enabled` is `true`, `triggerMetric`, `thresholdRatio`, and `summarizer` are required
 
-## backgroundAgent
-
-Long-running Claude Code workers for deep tasks.
+## Background providers: `backgroundAgent`
 
 ```yaml
 backgroundAgent:
@@ -211,59 +181,51 @@ backgroundAgent:
       contextWindowTokens: 200000
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `enabled` | `true` | Globally enable background workers |
-| `maxConcurrent` | `3` | Max simultaneous background workers |
-| `defaultTimeoutMinutes` | `30` | Wall-clock timeout per worker (15–480 min) |
-| `defaultProvider` | `claude-code` | Provider for background workers |
-| `claudePath` | — | Explicit path to the Claude Code binary |
+Notes:
 
----
+- background providers do not have `contextManagement`
+- `claudePath` still exists as a legacy shortcut and is normalized into a `claude-code` provider when no explicit `providers` block exists
 
-## auth
-
-AI provider credentials.
+## Auth
 
 ```yaml
 auth:
   mode: subscription
   providers:
     anthropic:
-      apiKey: ${SUBAGENT_ANTHROPIC_API_KEY}
+      apiKey: ${ANTHROPIC_API_KEY}
     openai:
       apiKey: ${OPENAI_API_KEY}
     ollama:
       baseURL: http://localhost:11434/v1
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `mode` | `subscription` | `subscription` (Claude Code login) or `api_key` |
-| `apiKey` | — | API key for `api_key` mode |
-| `providers.<name>.apiKey` | — | API key for a specific provider |
-| `providers.<name>.baseURL` | — | Custom base URL (for Ollama or proxies) |
+`mode` defaults to `subscription`. `providers.<name>.apiKey` and `providers.<name>.baseURL` are both optional.
 
----
-
-## scheduler
-
-Controls how often the scheduler checks for due tasks.
+## Scheduler
 
 ```yaml
 scheduler:
   tickIntervalMs: 5000
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `tickIntervalMs` | `5000` | Scheduler tick interval in ms (minimum 1000) |
+## Sandbox
 
----
+```yaml
+sandbox:
+  runtime: docker
+  image: talon-sandbox:latest
+  maxConcurrent: 3
+  networkDefault: off
+  idleTimeoutMs: 1800000
+  hardTimeoutMs: 3600000
+  resourceLimits:
+    memoryMb: 1024
+    cpus: 1
+    pidsLimit: 256
+```
 
-## langfuse
-
-Observability tracing. Disabled by default.
+## Langfuse
 
 ```yaml
 langfuse:
@@ -277,22 +239,7 @@ langfuse:
   flushIntervalSeconds: 5
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `enabled` | `false` | Enable Langfuse tracing |
-| `publicKey` | — | Required when enabled |
-| `secretKey` | — | Required when enabled |
-| `baseUrl` | `https://cloud.langfuse.com` | Langfuse instance URL |
-| `environment` | `production` | Environment tag on traces |
-| `exportMode` | `batched` | `batched` or `immediate` |
-| `flushAt` | `20` | Batch size before flush |
-| `flushIntervalSeconds` | `5` | Max seconds between flushes |
-
----
-
-## ipc
-
-Internal daemon-to-CLI communication. Rarely needs changing.
+## IPC
 
 ```yaml
 ipc:
@@ -300,11 +247,9 @@ ipc:
   daemonSocketDir: data/ipc/daemon
 ```
 
----
+## Next references
 
-## logLevel and dataDir
-
-```yaml
-logLevel: info   # trace | debug | info | warn | error | fatal
-dataDir: data    # root directory for all runtime data
-```
+- [Config schema reference](/docs/reference/config-schema)
+- [Channels guide](/docs/guides/channels)
+- [Personas guide](/docs/guides/personas)
+- [Skills guide](/docs/guides/skills)

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -5,11 +5,12 @@ description: Install Talon on your server
 
 # Installation
 
-Talon runs as a native Node.js daemon. No Docker required to get started (though Docker is used for agent sandboxing when enabled).
+Talon runs as a native Node.js daemon. The current first-run checks also expect Docker to be installed and the daemon to be running.
 
 ## Prerequisites
 
 - **Node.js 22+** — Talon uses `process.loadEnvFile`, which requires Node 22
+- **Docker** — `talonctl setup` and `talonctl doctor` check Docker availability
 - **Claude Code** — the default agent provider. Install and authenticate it: `npm install -g @anthropic-ai/claude-code`
 - **SQLite** — ships with `better-sqlite3`, no separate install needed
 - **Git** — to clone the repo
@@ -41,17 +42,21 @@ You should see the talonctl version string. If you get a module error, confirm N
 
 ## Initial setup
 
-Run the interactive setup wizard. It checks your environment, creates the `data/` directory structure, and generates a starter `talond.yaml`:
+Run the first-run setup command. It checks your environment, creates the `data/` directory structure, generates a starter `talond.yaml`, runs migrations, and validates the result:
 
 ```bash
 npx talonctl setup
 ```
 
-The wizard walks through:
+The setup command runs these steps:
 
-1. Environment check (Node version, Claude Code availability)
-2. Data directory creation
-3. Config file generation with sensible defaults
+1. OS detection
+2. Node version check
+3. Docker availability check
+4. Data directory creation
+5. Config generation
+6. Database migrations
+7. Config validation
 
 After setup, run `talonctl doctor` to validate everything:
 
@@ -59,7 +64,7 @@ After setup, run `talonctl doctor` to validate everything:
 npx talonctl doctor --config talond.yaml
 ```
 
-Seven checks run — OS compatibility, Node version, Docker (if using sandbox), directory structure, config syntax, pending migrations, and deep config validation. Fix any failures before starting the daemon.
+`talonctl doctor` then checks Node.js, Docker, config validity, database access, and data directories. Fix any failures before starting the daemon.
 
 ## Apply database migrations
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -36,7 +36,9 @@ personas:
     systemPromptFile: personas/assistant/system.md
     capabilities:
       allow:
-        - channel.send:my-telegram
+        - memory.access:thread
+        - net.http:egress
+        - schedule.manage:own
 
 channels:
   - name: my-telegram
@@ -45,7 +47,7 @@ channels:
     config:
       botToken: ${TELEGRAM_BOT_TOKEN}
       allowedChatIds:
-        - 123456789  # replace with your Telegram user ID
+        - "123456789"  # replace with your Telegram user ID
 
 bindings:
   - persona: assistant
@@ -59,15 +61,22 @@ logLevel: info
 dataDir: data
 ```
 
-Replace `123456789` with your actual Telegram user ID.
+Replace `"123456789"` with your actual Telegram user ID.
 
-## 3. Scaffold the persona
+## 3. Create the system prompt
+
+Create the file referenced by `systemPromptFile`:
 
 ```bash
-npx talonctl add-persona --name assistant
+mkdir -p personas/assistant
+cat > personas/assistant/system.md <<'EOF'
+# Assistant
+
+You are a concise, helpful assistant.
+EOF
 ```
 
-This creates `personas/assistant/system.md` from the built-in template. Edit it to set the agent's tone, constraints, and any tool instructions.
+If you prefer to scaffold personas with `talonctl add-persona`, do that before writing the persona entry into `talond.yaml`.
 
 ## 4. Run migrations
 
@@ -81,7 +90,7 @@ npx talonctl migrate --config talond.yaml
 npx talonctl doctor --config talond.yaml
 ```
 
-All 7 checks should pass. If any fail, the output tells you what to fix.
+All checks should pass. If any fail, the output tells you what to fix.
 
 ## 6. Start the daemon
 
@@ -121,7 +130,7 @@ channels:
 Add `TERMINAL_TOKEN=your-secret` to `.env`, add a binding, restart the daemon, then connect:
 
 ```bash
-talonctl chat --host localhost --port 7700 --token your-secret
+npx talonctl chat --host 127.0.0.1 --port 7700 --token your-secret
 ```
 
 You get a rendered Markdown terminal client with a typing spinner while the agent works.

--- a/docs/guides/background-agents.mdx
+++ b/docs/guides/background-agents.mdx
@@ -1,35 +1,27 @@
 ---
 title: Background agents
-description: Spawn long-running Claude Code workers for deep tasks
+description: Run long-lived background agent tasks without blocking the foreground conversation
 ---
 
 # Background agents
 
-Background agents are long-running Claude Code CLI workers that run out-of-band — they don't block the foreground conversation. Use them for tasks that need the full Claude Code runtime but shouldn't tie up the agent mid-conversation.
+Background agents are long-running tasks started through the `background_agent` host tool.
+They are not limited to Claude Code: the background-agent manager uses whichever enabled background provider you select or inherit.
 
-## When to use background agents
+## What happens on spawn
 
-Good use cases:
-- Repo-wide refactoring or code analysis
-- Large document processing or research
-- Tasks that take 5+ minutes and don't need turn-by-turn interaction
+When a foreground agent calls `background_agent` with `action: "spawn"`:
 
-Not appropriate for:
-- Quick lookups or calculations (use sub-agents instead)
-- Tasks that need access to the conversation history in real time
-- Anything that needs to send multiple incremental messages back
+1. Talon checks the background-agent concurrency limit.
+2. It resolves the provider. Priority is: explicit `provider` argument, otherwise the configured `backgroundAgent.defaultProvider`.
+3. It builds a task-specific system prompt using:
+   - the persona prompt
+   - optional prior thread context
+   - the task prompt
+4. It starts the provider-specific background process and records the task in SQLite.
+5. It returns a `taskId` immediately.
 
-## How it works
-
-The foreground agent calls `background_agent` with a task description. Talon spawns a Claude Code CLI process, tracks it in SQLite, and returns a task ID immediately. The foreground conversation continues normally.
-
-When the background worker finishes (or times out, or fails), Talon delivers a completion message to the originating thread via the normal queue and channel-send path.
-
-Background workers:
-- Inherit the persona's system prompt and MCP servers from assigned skills
-- Do **not** have access to Talon's host-tools MCP server (no channel send, no memory write, no recursive spawning)
-- Are subject to `maxConcurrent` and `defaultTimeoutMinutes` limits
-- Have their state persisted — completion/failure/timeout/cancellation are all recorded
+When the process finishes, Talon enqueues a completion notification back into the originating thread.
 
 ## Configuration
 
@@ -44,19 +36,26 @@ backgroundAgent:
       enabled: true
       command: claude
       contextWindowTokens: 200000
+    gemini-cli:
+      enabled: true
+      command: /usr/local/bin/gemini
+      contextWindowTokens: 1000000
+      options:
+        defaultModel: gemini-2.5-pro
 ```
 
 | Field | Default | Description |
 |---|---|---|
-| `enabled` | `true` | Globally enable background workers |
-| `maxConcurrent` | `3` | Maximum simultaneous workers (1–10) |
-| `defaultTimeoutMinutes` | `30` | Default wall-clock timeout (15–480 min) |
-| `defaultProvider` | `claude-code` | Provider used for workers |
-| `claudePath` | — | Explicit path to the Claude Code binary if not on PATH |
+| `enabled` | `true` | Enable background tasks globally |
+| `maxConcurrent` | `3` | Max concurrent running tasks |
+| `defaultTimeoutMinutes` | `30` | Default timeout for a task |
+| `defaultProvider` | `claude-code` | Default background provider |
+| `providers` | built-in `claude-code` entry | Provider configs for background tasks |
+| `claudePath` | — | Legacy shortcut that is normalized into a `claude-code` provider when no explicit providers are configured |
 
-## Enabling for a persona
+## Persona access
 
-Grant `subagent.background` in the persona's capabilities:
+A persona needs the `subagent.background` capability to use the tool:
 
 ```yaml
 personas:
@@ -64,49 +63,45 @@ personas:
     capabilities:
       allow:
         - subagent.background
-        - channel.send:my-telegram
 ```
 
 ## Profiles
 
-Background agent profiles are named presets that configure what tools and system prompt the worker gets. The agent can call `background_agent action="profiles"` to discover available profiles before spawning.
+A background-agent `profile` is just another loaded persona.
+If the foreground agent passes `profile`, Talon uses that persona's:
 
-To check what profiles are available, instruct the agent to do so in the system prompt:
+- system prompt
+- personality fragments
+- skills
+- provider override
+- model
 
-```markdown
-## Background Agents
+Agents should call `background_agent` with `action: "profiles"` first when they need to discover what profiles are available.
 
-You can delegate work to specialized background agents. Use
-`background_agent action="profiles"` to discover what profiles are available.
-When asked about your capabilities or what agents you can use, always check
-profiles first rather than guessing.
-```
+## Spawn parameters
 
-## Example interaction
+The MCP tool accepts these spawn-related fields:
 
-User sends: *"Analyze all TypeScript files in `/home/user/project` and produce a dependency graph."*
+- `prompt`
+- `provider`
+- `profile`
+- `workingDirectory`
+- `timeoutMinutes`
 
-The foreground agent:
-1. Calls `background_agent action="profiles"` to check available profiles
-2. Selects an appropriate profile
-3. Calls `background_agent action="spawn"` with the task description and timeout
-4. Immediately responds to the user: *"Started analysis. I'll let you know when it's done — this should take about 15 minutes."*
+Notes:
 
-When the worker finishes, the user receives a completion message with results.
+- `timeoutMinutes` is clamped to a minimum effective value of 15 minutes
+- when `provider` is omitted, Talon uses the background default provider
+- when `profile` is omitted, Talon uses the current thread's persona as the background profile
 
-## Limits and constraints
+## Skill loading
 
-- Workers cannot spawn additional background agents
-- Workers cannot send messages directly — results arrive via the daemon after completion
-- If a worker exceeds `defaultTimeoutMinutes`, it's killed and the originating thread is notified
-- The daemon enforces `maxConcurrent` — if the limit is reached, new spawn requests queue until a slot opens
+Foreground agents see the lazy skill index and call `skill_load` on demand.
+Background agents instead receive merged skill prompt contents eagerly at spawn time.
 
-## Monitoring
+## Limits
 
-Check running background workers via daemon status:
-
-```bash
-npx talonctl status
-```
-
-The status output includes active background worker count and any recently completed/failed tasks.
+- background tasks cannot exceed `backgroundAgent.maxConcurrent`
+- the task record is persisted in SQLite
+- a task can be queried later with `status` or `result`
+- completed output is truncated for storage if necessary by the background-agent manager

--- a/docs/guides/channels.mdx
+++ b/docs/guides/channels.mdx
@@ -1,290 +1,276 @@
 ---
 title: Channels
-description: Connect Talon to Telegram, Slack, WhatsApp, Discord, email, and terminal
+description: Configure Talon channel connectors and their connector-specific config
 ---
 
 # Channels
 
-A channel is a messaging connector. Talon normalizes inbound messages from every channel into a common format, routes them to the bound persona, and converts responses back to the channel's native formatting.
+Channels are Talon's inbound and outbound connectors. Every configured channel normalizes inbound messages into Talon's internal event format and renders agent output back into a channel-specific format.
 
-## Common options
+## Common channel fields
 
-Every channel entry accepts these fields regardless of type:
-
-| Field | Default | Description |
-|---|---|---|
-| `name` | required | Unique identifier — used in bindings and capability labels |
-| `type` | required | Connector type (see below) |
-| `enabled` | `true` | Disable a channel without removing it from config |
-| `showToolCalls` | `false` | Send a status message on each tool call (useful for debugging) |
+Every channel entry supports the same wrapper fields:
 
 ```yaml
 channels:
   - name: my-slack
     type: slack
     enabled: true
-    showToolCalls: true   # sends "🌐 Using Brave Search: web search" on each tool call
+    showToolCalls: true
     config:
       botToken: ${SLACK_BOT_TOKEN}
-      appToken: ${SLACK_APP_TOKEN}
+      signingSecret: ${SLACK_SIGNING_SECRET}
 ```
+
+| Field | Default | Description |
+|---|---|---|
+| `name` | required | Unique channel name |
+| `type` | required | Connector type |
+| `enabled` | `true` | Enable the connector at startup |
+| `showToolCalls` | runtime default `false` | When enabled, Talon sends human-readable tool-call messages to that channel |
+| `config` | `{}` | Connector-specific config |
+
+`showToolCalls` is optional in config. When omitted, the runtime behaves as `false`.
 
 ---
 
 ## Telegram
 
-Long-polling connector using the Telegram Bot API. Create a bot with [@BotFather](https://t.me/BotFather) and get a token.
+Telegram uses Bot API long polling.
 
 ```yaml
 channels:
   - name: my-telegram
     type: telegram
-    enabled: true
     config:
       botToken: ${TELEGRAM_BOT_TOKEN}
       pollingTimeoutSec: 30
       allowedChatIds:
-        - 123456789   # your Telegram user ID
+        - "123456789"
 ```
 
 | Config field | Description |
 |---|---|
-| `botToken` | Bot token from @BotFather |
-| `pollingTimeoutSec` | Long-poll timeout in seconds (default: 30) |
-| `allowedChatIds` | Whitelist of chat IDs that can message the bot |
+| `botToken` | Required bot token from BotFather |
+| `pollingTimeoutSec` | Optional long-poll timeout in seconds. Default: `30` |
+| `allowedChatIds` | Optional allow-list of Telegram chat IDs. Use strings, for example `"123456789"` |
 
-**Format:** MarkdownV2. Bold, italic, inline code, and code blocks render natively in Telegram.
+Notes:
 
-**Thread mapping:** Each Telegram `chat_id` is a separate conversation thread with its own memory.
+- each Telegram `chat_id` becomes its own Talon thread
+- Telegram supports `sendTyping()`, so the daemon shows activity while the agent works
+- non-text inbound updates are ignored
 
 ---
 
 ## Slack
 
-Event-driven connector using Slack's Socket Mode. Requires a Slack app with the appropriate OAuth scopes.
+Slack always sends outbound messages through `chat.postMessage`.
+Inbound delivery works in one of two modes:
+
+- with `appToken`: Talon opens a Socket Mode connection itself
+- without `appToken`: the connector starts, but inbound events must be fed externally via `feedEvent()`
 
 ```yaml
 channels:
   - name: my-slack
     type: slack
-    enabled: true
     config:
       botToken: ${SLACK_BOT_TOKEN}
       appToken: ${SLACK_APP_TOKEN}
       signingSecret: ${SLACK_SIGNING_SECRET}
+      defaultChannel: C01234567
 ```
 
 | Config field | Description |
 |---|---|
-| `botToken` | Bot user OAuth token (`xoxb-...`) — needs `chat:write`, `app_mentions:read` |
-| `appToken` | App-level token (`xapp-...`) — needs `connections:write` for Socket Mode |
-| `signingSecret` | Signing secret for request verification |
+| `botToken` | Required bot user token |
+| `appToken` | Optional app-level Socket Mode token |
+| `signingSecret` | Required signing secret |
+| `defaultChannel` | Optional fallback channel ID for outbound sends when the current thread is not already a Slack thread |
 
-**Required Slack app permissions:**
-- OAuth scopes: `app_mentions:read`, `channels:history`, `chat:write`, `im:history`, `im:write`
-- Event subscriptions: `message.im`, `app_mention`
-- Enable Socket Mode in your app settings
+Notes:
 
-**Format:** Slack mrkdwn (`*bold*`, `_italic_`, `` `code` ``).
-
-**Thread mapping:** `channel_id:thread_ts` — threads are preserved as expected in Slack.
+- thread IDs are encoded as `<channelId>:<thread_ts>`
+- if `appToken` is omitted, the stock daemon does not provide an Events API ingress; inbound Slack requires external event delivery
 
 ---
 
 ## WhatsApp Baileys
 
-WhatsApp Web bridge via the [Baileys](https://github.com/WhiskeySockets/Baileys) library. No Meta Business account needed — authenticates like a regular WhatsApp Web client.
-
-Baileys is an optional dependency. Install it before using this connector:
-
-```bash
-npm install @whiskeysockets/baileys
-```
-
-### Dedicated number
-
-Use a second WhatsApp number as the bot account. Others message the bot number directly.
+The `whatsappBaileys` connector uses WhatsApp Web through Baileys.
 
 ```yaml
 channels:
   - name: my-whatsapp
     type: whatsappBaileys
-    enabled: true
-    config:
-      authDir: ./baileys-auth
-      allowedSenders:
-        - '96490886312027'   # sender ID from logs (see below)
-```
-
-### Self-chat mode
-
-Use your personal WhatsApp number. The bot only responds in your "Message Yourself" thread.
-
-```yaml
-channels:
-  - name: my-whatsapp
-    type: whatsappBaileys
-    enabled: true
     config:
       authDir: ./baileys-auth
       selfChat: true
       triggerWords:
-        - '@Talon'   # optional — only process messages starting with this word
+        - "@Talon"
 ```
 
-With `triggerWords`, the trigger is stripped before the message reaches the agent. `@Talon what's the weather?` becomes `what's the weather?`.
+| Config field | Description |
+|---|---|
+| `authDir` | Optional auth directory. Default: `./baileys-auth` |
+| `browser` | Optional browser tuple shown in Linked Devices |
+| `markOnlineOnConnect` | Optional online-presence toggle. Default: `false` |
+| `allowedSenders` | Optional allow-list of bare sender IDs |
+| `selfChat` | Optional self-chat mode. Default: `false` |
+| `triggerWords` | Optional case-insensitive prefixes that must start the message |
 
-### Authentication
+Notes:
 
-Authenticate by scanning a QR code before starting the daemon:
+- in normal mode, group messages are ignored
+- in self-chat mode, Talon accepts only your own "Message Yourself" thread and only `fromMe` messages
+- trigger words are stripped before the prompt reaches the agent
+
+Authenticate before starting the daemon:
 
 ```bash
 npx talonctl whatsapp-auth --auth-dir ./baileys-auth
 ```
 
-Scan the QR code in WhatsApp on your phone. Credentials are saved to `authDir`. The daemon uses them automatically on startup — no QR code at runtime.
-
-To re-authenticate: delete the `authDir` folder and run the command again.
-
-### Finding sender IDs
-
-WhatsApp uses opaque LID identifiers (`96490886312027@lid`) that don't match phone numbers directly. To find them:
-
-1. Set `logLevel: debug` in `talond.yaml`
-2. Restart the daemon
-3. Send a test message from the phone you want to allow
-4. Find the log line `whatsapp-baileys: inbound message received` — the `jid` field shows the full ID
-5. Copy the part before the `@` into `allowedSenders`
-6. Set `logLevel: info` and restart
-
 ---
 
 ## WhatsApp Business
 
-Meta Cloud API connector. Requires a Meta Business account with a WhatsApp-enabled phone number and a public webhook URL.
+The schema name is `whatsappBusiness`. The channel factory also still recognizes the legacy alias `whatsapp`, but `whatsappBusiness` is the correct config value.
 
 ```yaml
 channels:
   - name: my-whatsapp-business
     type: whatsappBusiness
-    enabled: true
     config:
-      phoneNumberId: '123456789'
+      phoneNumberId: "123456789"
       accessToken: ${WHATSAPP_ACCESS_TOKEN}
       verifyToken: ${WHATSAPP_VERIFY_TOKEN}
       appSecret: ${WHATSAPP_APP_SECRET}
+      apiVersion: v18.0
       webhookPort: 3000
-      webhookHost: '0.0.0.0'
-      webhookPath: '/webhook'
+      webhookHost: 0.0.0.0
+      webhookPath: /webhook
 ```
 
 | Config field | Description |
 |---|---|
-| `phoneNumberId` | WhatsApp Business phone number ID from Meta Developer Console |
-| `accessToken` | Permanent system user access token |
-| `verifyToken` | Token you choose — used for webhook verification |
-| `appSecret` | App secret for HMAC-SHA256 webhook signature validation |
-| `webhookPort` | Port for the embedded webhook HTTP server (default: 3000) |
-| `webhookHost` | Bind address (default: `0.0.0.0`) |
-| `webhookPath` | Webhook path (default: `/webhook`) |
-
-The embedded webhook server handles Meta's verification handshake (GET) and signed event delivery (POST). You need a public URL pointing to this server — use nginx, Caddy, or ngrok.
+| `phoneNumberId` | Required phone number ID |
+| `accessToken` | Required Cloud API token |
+| `verifyToken` | Required webhook verify token |
+| `appSecret` | Optional app secret; when set, Talon validates webhook signatures and starts its embedded webhook server |
+| `apiVersion` | Optional API version. Default: `v18.0` |
+| `webhookPort` | Optional webhook port. Default: `3000` when `appSecret` is set |
+| `webhookHost` | Optional bind host. Default: `0.0.0.0` |
+| `webhookPath` | Optional webhook path. Default: `/webhook` |
 
 ---
 
 ## Terminal
 
-WebSocket-based channel for direct CLI access. Connect with `talonctl chat` from any machine.
+The terminal connector runs a WebSocket server.
 
 ```yaml
 channels:
   - name: my-terminal
     type: terminal
-    enabled: true
     config:
       port: 7700
-      host: 0.0.0.0
+      host: 127.0.0.1
       token: ${TERMINAL_TOKEN}
 ```
 
 | Config field | Description |
 |---|---|
-| `port` | WebSocket server port (default: 7700) |
-| `host` | Bind address |
-| `token` | Shared secret for authentication |
+| `port` | Required WebSocket port |
+| `host` | Optional bind host. Default: `127.0.0.1` |
+| `token` | Required shared secret |
 
-Connect:
+Notes:
+
+- the connector itself has no port default; you must set `config.port`
+- the CLI client defaults to `127.0.0.1:7700`, so using `7700` is convenient but not required
+- `clientId` controls thread persistence on reconnect
+
+Connect with:
 
 ```bash
-export TERMINAL_TOKEN=your-secret-token
-
-talonctl chat --host localhost --port 7700
-talonctl chat --host 10.0.1.95 --port 7700 --persona researcher
-talonctl chat --host localhost --port 7700 --client-id my-laptop
+npx talonctl chat --host 127.0.0.1 --port 7700 --token "$TERMINAL_TOKEN"
 ```
-
-`--persona` switches which persona handles the session. `--client-id` gives your client a stable identity — reconnecting with the same ID resumes the same thread.
-
-The client renders Markdown via `marked-terminal` and shows a spinner while the agent is working.
 
 ---
 
 ## Discord
 
-Gateway-based connector. Send is implemented; inbound reception from the Discord Gateway is not yet complete (see TASK-043).
+Discord outbound send is implemented through the REST API.
+Inbound Discord messages require an external Gateway event feed calling `feedEvent()`.
 
 ```yaml
 channels:
   - name: my-discord
     type: discord
-    enabled: true
     config:
       botToken: ${DISCORD_BOT_TOKEN}
-      applicationId: '123456789'
+      applicationId: "123456789"
+      guildId: "555555555"
       allowedChannelIds:
-        - '987654321'
+        - "987654321"
+      intents: 33280
 ```
+
+| Config field | Description |
+|---|---|
+| `botToken` | Required bot token |
+| `applicationId` | Required application ID |
+| `guildId` | Optional guild restriction |
+| `allowedChannelIds` | Optional allow-list of channel IDs |
+| `intents` | Optional Gateway intents bitmask. Default behavior is `33280` (`GUILD_MESSAGES + MESSAGE_CONTENT`) |
+
+In the stock daemon, Discord inbound is not wired up because the connector expects an external Gateway feed.
 
 ---
 
 ## Email
 
-IMAP polling + SMTP send. Not yet tested end-to-end — treat as beta.
+The email connector normalizes IMAP and SMTP concepts, but the stock daemon does not inject real SMTP or IMAP transports. Outbound email therefore is not fully wired by default, and the built-in IMAP client is a no-op stub.
 
 ```yaml
 channels:
   - name: my-email
     type: email
-    enabled: true
     config:
-      imapHost: imap.gmail.com
-      imapPort: 993
-      imapUser: agent@example.com
-      imapPass: ${EMAIL_PASSWORD}
-      imapSecure: true
       smtpHost: smtp.gmail.com
       smtpPort: 587
       smtpUser: agent@example.com
       smtpPass: ${EMAIL_PASSWORD}
       smtpSecure: false
-      fromAddress: 'Talon <agent@example.com>'
+      imapHost: imap.gmail.com
+      imapPort: 993
+      imapUser: agent@example.com
+      imapPass: ${EMAIL_PASSWORD}
+      imapSecure: true
+      fromAddress: "Talon <agent@example.com>"
+      allowedSenders:
+        - user@example.com
+      pollingIntervalMs: 30000
+      mailbox: INBOX
 ```
 
-Thread tracking via `In-Reply-To` / `References` headers. Outbound format is Markdown converted to HTML.
+| Config field | Description |
+|---|---|
+| `smtpHost` / `smtpPort` / `smtpUser` / `smtpPass` / `smtpSecure` | SMTP settings |
+| `imapHost` / `imapPort` / `imapUser` / `imapPass` / `imapSecure` | IMAP settings |
+| `fromAddress` | Required outbound From address |
+| `allowedSenders` | Optional inbound sender allow-list |
+| `pollingIntervalMs` | Optional IMAP poll interval. Default: `30000` |
+| `mailbox` | Optional mailbox name. Default: `INBOX` |
 
 ---
 
-## Managing channels
+## Managing channels with `talonctl`
 
 ```bash
-# Add a channel (interactive prompts for config fields)
 npx talonctl add-channel --name my-telegram --type telegram
-
-# List all configured channels
 npx talonctl list-channels
-
-# Remove a channel (cascades to bindings)
-npx talonctl remove-channel --name old-slack
-
-# Disable without removing (edit talond.yaml: enabled: false)
+npx talonctl remove-channel --name my-telegram
 ```

--- a/docs/guides/personas.mdx
+++ b/docs/guides/personas.mdx
@@ -1,175 +1,114 @@
 ---
 title: Personas
-description: Configure AI agent identities, capabilities, and system prompts
+description: Configure persona prompts, capabilities, skills, sub-agents, and scheduling prompts
 ---
 
 # Personas
 
-A persona is an AI agent's complete identity — its system prompt, model, skills, sub-agents, and capability policy. You can run multiple personas simultaneously, each bound to different channels with different permissions.
+A persona is Talon's runtime identity for an agent: system prompt, optional provider override, model, skills, sub-agents, capability labels, mounts, and optional concurrency limits.
 
-## How personas work
-
-When a message arrives on a channel, Talon routes it to the bound persona. The persona's system prompt becomes the agent's identity. Its capability list determines which tools it can call. All turns in the same thread use the same persona.
-
-## Defining a persona
+## Persona config
 
 ```yaml
 personas:
   - name: assistant
     model: claude-sonnet-4-6
+    provider: claude-code
     systemPromptFile: personas/assistant/system.md
     skills:
       - web-search
     subagents:
       - session-summarizer
-      - memory-groomer
       - memory-retriever
     capabilities:
       allow:
-        - channel.send:my-telegram
-        - memory.access:*
-        - net.http
-        - schedule.manage
-        - subagent.invoke:*
+        - memory.access:thread
+        - net.http:egress
+        - schedule.manage:own
+        - subagent.invoke
         - subagent.background
+        - channel.send:my-telegram
       requireApproval:
-        - db.query
+        - db.query:own
     maxConcurrent: 2
 ```
 
-## Scaffolding a persona
+## What `talonctl add-persona` creates
 
-```bash
-npx talonctl add-persona --name assistant
+`npx talonctl add-persona --name assistant` scaffolds:
+
+```text
+personas/assistant/
+  system.md
+  personality/01-tone.md
+  prompts/memory-grooming.md
 ```
 
-This creates `personas/assistant/system.md` from a template (if `templates/assistant/system.md` exists) or generates a generic starter. Existing files are never overwritten.
+It also adds the persona to `talond.yaml` with these default allow-list labels:
 
-The `personas/` directory is gitignored by default — your custom system prompts stay local.
+- `memory.access:thread`
+- `net.http:egress`
+- `schedule.manage:own`
 
-## System prompt
+If you pass `--description`, Talon writes that description into `system.md` frontmatter. That description is later exposed through background-agent profile discovery.
 
-The system prompt is a plain Markdown file. Write it as if you're describing the agent's role, constraints, and available tools to the model.
+## System prompt, personality files, and prompt files
 
-Talon injects additional context before the prompt reaches the model:
+`systemPromptFile` points to the main prompt file. The loader also reads:
 
-- **Available skills** — name and one-line description of each loaded skill
-- **Previous context** — session summary + last N messages (after context rotation)
-- **Memory items** — relevant facts/notes retrieved for the current thread
+- `personality/*.md` next to the system prompt and appends those files alphabetically
+- `prompts/*.md` next to the system prompt and indexes them by basename for scheduled `promptFile` usage
 
-A minimal system prompt:
-
-```markdown
-# Assistant
-
-You are a helpful AI assistant for personal use.
-
-## Behaviour
-- Be concise and accurate.
-- Reply in clear, plain language.
-- Ask for clarification when the request is ambiguous.
-
-## Constraints
-- Do not reveal system configuration details.
-- If you do not know something, say so.
-```
-
-## Model configuration
-
-The `model` field is passed directly to the provider. For Claude Code (the default provider), this is a Claude model ID:
-
-```yaml
-personas:
-  - name: assistant
-    model: claude-sonnet-4-6   # or claude-opus-4-6, claude-haiku-4-5, etc.
-```
-
-To use a different provider for a specific persona:
-
-```yaml
-personas:
-  - name: lightweight
-    model: claude-haiku-4-5
-    provider: claude-code
-```
+That means a schedule using `promptFile: memory-grooming` resolves `personas/<name>/prompts/memory-grooming.md`.
 
 ## Capability labels
 
-Capabilities are scoped labels. Anything not listed in `allow` or `requireApproval` is denied by default.
+Capability filtering is based on the label prefix before `:`.
+These are the built-in host-tool labels exposed by the CLI today:
 
-| Capability | Description |
+| Label | Grants access to |
 |---|---|
-| `channel.send:<channel>` | Send messages to a named channel |
-| `channel.send:*` | Send to any channel |
-| `memory.access:*` | Read and write per-thread memory |
-| `net.http` | Fetch external URLs |
-| `db.query` | Read-only queries against 4 allowed tables |
-| `schedule.manage` | Create, update, and delete scheduled tasks |
-| `subagent.invoke:*` | Invoke sub-agents by name |
-| `subagent.background` | Spawn and manage background agent workers |
-| `fs.read:*` | Read files (used by `file-searcher` sub-agent) |
-| `fs.write:workspace` | Write files (example: for approval-gated file ops) |
+| `memory.access:thread` | `memory_access` |
+| `net.http:egress` | `net_http` |
+| `channel.send:*` or `channel.send:<channel>` | `channel_send` |
+| `schedule.manage:own` | `schedule_manage` |
+| `db.query:own` | `db_query` |
+| `subagent.invoke` | `subagent_invoke` |
+| `subagent.background` | `background_agent` |
 
-### require Approval
+Anything not present in `allow` or `requireApproval` is denied by default.
 
-Capabilities in `requireApproval` prompt the user in-channel before executing:
+`requireApproval` still exposes the tool to the agent; Talon uses it as a policy distinction rather than hiding the tool entirely.
 
-```yaml
-capabilities:
-  allow:
-    - channel.send:my-telegram
-    - memory.access:*
-  requireApproval:
-    - db.query    # user must approve each database query
-    - net.http    # user must approve each HTTP request
-```
+## Skills
 
-The approval prompt is sent to the channel that originated the message. If the user doesn't respond within the timeout, the tool call is rejected.
+Personas list skill names in `skills`. At runtime:
+
+- Talon loads skill directories from `./skills/<name>` and `<dataDir>/skills/<name>`
+- the persona sees only the skill index by default
+- the agent calls `skill_load` to load full instructions on demand
+- a skill is usable only if every `requiredCapabilities` label is present in the persona's combined `allow + requireApproval` set
 
 ## Sub-agents
 
-Sub-agents are cheap-model workers that handle mechanical tasks. Declare which sub-agents a persona can invoke:
+`subagents` is an allow-list of sub-agent names the persona can invoke through `subagent_invoke`.
 
-```yaml
-personas:
-  - name: assistant
-    subagents:
-      - session-summarizer
-      - memory-groomer
-      - memory-retriever
-      - file-searcher
-    capabilities:
-      allow:
-        - subagent.invoke:*
-```
-
-The agent also needs instructions in the system prompt explaining when and how to call sub-agents.
-
-Built-in sub-agents:
+Built-in sub-agents in this repo:
 
 | Name | Model | Purpose |
 |---|---|---|
-| `session-summarizer` | Haiku 4.5 | Compress conversation history (called automatically) |
-| `memory-retriever` | Haiku 4.5 | Find relevant memory items for a query |
-| `memory-groomer` | Haiku 4.5 | Prune/consolidate stale memory |
-| `file-searcher` | Haiku 4.5 | Full-text search across files |
+| `session-summarizer` | `claude-sonnet-4-6` | Compress conversation history |
+| `memory-retriever` | `claude-haiku-4-5` | Retrieve relevant memory entries |
+| `memory-groomer` | `claude-haiku-4-5` | Prune and consolidate memory |
+| `file-searcher` | `claude-haiku-4-5` | Search files and return snippets |
+
+## Background-agent profiles
+
+Any loaded persona can also act as a background-agent profile. When a foreground agent calls `background_agent` with `action: "profiles"`, Talon returns persona names plus the optional description parsed from each persona's `system.md` frontmatter.
 
 ## Bindings
 
-Personas connect to channels via bindings. Manage them with `talonctl`:
-
-```bash
-# Bind a persona to a channel
-npx talonctl bind --persona assistant --channel my-telegram
-
-# List all bindings
-npx talonctl list-personas
-
-# Remove a binding
-npx talonctl unbind --persona assistant --channel my-telegram
-```
-
-Or declare them directly in config:
+Personas are routed to channels through `bindings`:
 
 ```yaml
 bindings:
@@ -178,39 +117,26 @@ bindings:
     isDefault: true
 ```
 
-The first binding created for a channel becomes the default. `isDefault: true` explicitly marks a binding as default.
+You can manage them with:
 
-## Multiple personas
+```bash
+npx talonctl bind --persona assistant --channel my-telegram
+npx talonctl unbind --persona assistant --channel my-telegram
+```
 
-Different channels can have different personas with completely different system prompts and capability sets:
+The first binding on a channel becomes the default binding automatically.
+
+## Mounts
+
+If a persona needs sandbox file access, use `mounts`:
 
 ```yaml
 personas:
-  - name: alfred
-    model: claude-sonnet-4-6
-    systemPromptFile: personas/alfred/system.md
-    capabilities:
-      allow:
-        - channel.send:my-telegram
-        - memory.access:*
-        - schedule.manage
-
-  - name: researcher
-    model: claude-opus-4-6
-    systemPromptFile: personas/researcher/system.md
-    skills:
-      - web-search
-    capabilities:
-      allow:
-        - channel.send:my-slack
-        - net.http
-        - subagent.background
-
-bindings:
-  - persona: alfred
-    channel: my-telegram
-    isDefault: true
-  - persona: researcher
-    channel: my-slack
-    isDefault: true
+  - name: coder
+    mounts:
+      - source: /srv/repos/project-a
+        target: /workspace/project-a
+        mode: rw
 ```
+
+`source` and `target` are required. `mode` defaults to `ro`.

--- a/docs/guides/scheduling.mdx
+++ b/docs/guides/scheduling.mdx
@@ -1,118 +1,95 @@
 ---
 title: Scheduling
-description: Create cron, interval, and one-shot scheduled tasks
+description: Create and manage cron schedules from Talon or from the CLI
 ---
 
 # Scheduling
 
-Talon's scheduler lets agents create, manage, and cancel scheduled tasks. A scheduled task sends a prompt to a persona at a defined time or on a recurring schedule. The task runs through the normal message queue — it gets queued, processed by the agent, and the response goes through the bound channel.
+Talon's public scheduling surface is cron-based.
+The scheduler polls for due schedules, enqueues them as normal queue items, and the agent handles them like any other message.
 
-## Schedule types
+## Enable schedule management
 
-| Type | Description | Example |
-|---|---|---|
-| `cron` | Standard cron expression | `0 9 * * 1-5` — weekdays at 9am |
-| `interval` | Repeating interval in milliseconds | `3600000` — every hour |
-| `once` | Single execution at a specific time | ISO 8601 datetime |
-
-## Enabling schedule management
-
-Grant the `schedule.manage` capability to the persona:
+Grant the schedule capability to the persona:
 
 ```yaml
 personas:
   - name: assistant
     capabilities:
       allow:
-        - schedule.manage
-        - channel.send:my-telegram
+        - schedule.manage:own
 ```
 
-## The schedule_manage tool
+## The host tool name
 
-The agent manages schedules via the `schedule_manage` host tool. Parameters:
+The MCP tool exposed to the agent is `schedule_manage`.
+Inside the daemon its internal name is `schedule.manage`.
 
-| Action | Required params | Description |
-|---|---|---|
-| `create` | `type`, `expression`/`runAt`, `prompt`, `persona`, `channel` | Create a schedule |
-| `list` | — | List all active schedules |
-| `update` | `scheduleId`, fields to change | Modify an existing schedule |
-| `delete` | `scheduleId` | Cancel a schedule |
-| `promptFile` | `file` path | Load a reusable prompt from a file |
+Supported actions:
 
-Example prompt to create a schedule (agent-side):
+- `create`
+- `update`
+- `cancel`
+- `delete`
+- `list`
 
-> "Set up a daily summary every morning at 8am. It should ask you to check my tasks and send a summary to Telegram."
+Supported fields:
 
-The agent calls `schedule_manage` with `action: create`, `type: cron`, `expression: 0 8 * * *`, and the prompt text.
+- `action`
+- `scheduleId`
+- `cronExpr`
+- `label`
+- `prompt`
+- `promptFile`
 
-## Managing schedules via CLI
+Important constraints:
+
+- only cron expressions are supported by this tool
+- `prompt` and `promptFile` are mutually exclusive
+- `promptFile` is a prompt alias from the persona's `prompts/` directory, not an arbitrary path
+
+## Using `promptFile`
+
+If a persona has:
+
+```text
+personas/assistant/prompts/morning-summary.md
+```
+
+then the schedule should use:
+
+```yaml
+promptFile: morning-summary
+```
+
+At execution time the scheduler resolves that alias through the persona loader.
+
+## CLI scheduling commands
+
+The CLI command `add-schedule` also creates cron schedules only:
 
 ```bash
-# Add a schedule manually
 npx talonctl add-schedule \
   --persona assistant \
   --channel my-telegram \
-  --type cron \
-  --expression "0 9 * * 1-5" \
-  --prompt "Good morning. Please summarize what I should focus on today."
-
-# List all schedules
-npx talonctl list-schedules
-
-# Remove a schedule
-npx talonctl remove-schedule --id <schedule-id>
+  --cron "0 9 * * 1-5" \
+  --label "Morning summary" \
+  --prompt "Summarize what I should focus on today."
 ```
 
-## Scheduler configuration
+List and remove them with:
 
-The scheduler tick interval controls how often due schedules are checked. Default is 5 seconds.
+```bash
+npx talonctl list-schedules
+npx talonctl list-schedules --persona assistant
+npx talonctl remove-schedule <schedule-id>
+```
+
+## Scheduler config
 
 ```yaml
 scheduler:
   tickIntervalMs: 5000
 ```
 
-Reduce this for near-real-time scheduling. For low-traffic deployments, 30 seconds or more is fine.
-
-## Using prompt files
-
-For recurring prompts, store the prompt text in a file rather than inline in the schedule. The `promptFile` parameter in `schedule_manage` accepts a path relative to the data directory:
-
-```
-data/prompts/daily-summary.md
-```
-
-```markdown
-Check my open tasks and recent messages. Summarize:
-1. What's pending from yesterday
-2. What's due today
-3. Any blockers or things that need my attention
-
-Keep it short — 5 bullet points max.
-```
-
-The agent calls `schedule_manage` with `promptFile: prompts/daily-summary.md`. Talon reads the file at execution time, so you can update the prompt without touching the schedule.
-
-## One-shot schedules
-
-A `once` schedule fires once at the specified time and is then automatically removed:
-
-```bash
-npx talonctl add-schedule \
-  --persona assistant \
-  --channel my-telegram \
-  --type once \
-  --run-at "2026-04-01T09:00:00Z" \
-  --prompt "Remind me to review the Q2 plan today."
-```
-
-## How scheduled tasks run
-
-1. The scheduler tick checks for schedules where `nextRunAt <= now`
-2. Due schedules are enqueued as normal messages in the persona's queue
-3. The agent processes them like any inbound message
-4. For `cron` and `interval` schedules, `nextRunAt` is advanced after execution
-5. For `once` schedules, the record is deleted after execution
-
-Scheduled tasks compete with user messages in the same FIFO queue. They don't preempt active conversations.
+The default tick interval is 5 seconds.

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -1,188 +1,173 @@
 ---
 title: Skills
-description: Package prompt fragments, MCP servers, and tool manifests into reusable bundles
+description: Package prompt instructions, MCP servers, tool manifests, and migrations into reusable bundles
 ---
 
 # Skills
 
-A skill is a named bundle of prompt instructions, MCP server definitions, and tool manifests. Attach skills to personas to extend their capabilities without bloating the system prompt.
+Skills are filesystem bundles attached to personas. Talon supports two on-disk formats:
 
-## How skills work
+- `SKILL.md` with YAML frontmatter
+- legacy `skill.yaml` plus `prompts/`
 
-Talon injects only the skill's name and one-line description into the system prompt. When the agent needs a skill's full instructions, it calls the `skill_load` tool. The full content loads on demand.
+## Runtime behavior
 
-This lazy loading keeps system prompt size low regardless of how many skills are attached. A persona with 7 skills attached uses about 3.7k tokens for skill metadata — compared to ~21k if all content were eager-loaded.
+For foreground agent runs, skills are lazy-loaded:
 
-Background agents are an exception: they load all skills eagerly at startup to ensure full access without needing to call `skill_load`.
+- the persona prompt gets only a skill index with name and description
+- when the agent needs the instructions for one skill, it calls `skill_load`
+- MCP servers from skills are still connected eagerly
 
-### Token comparison
+Background agents are different: they merge full skill prompt contents eagerly when the background task starts.
 
-| Scenario | Eager loading | Lazy loading |
-|---|---|---|
-| 7 skills, using 1 | ~21k tokens | ~3.7k tokens |
-| 20 skills, using 0 | ~60k tokens | ~2k tokens |
+## `SKILL.md` format
 
----
-
-## Skill formats
-
-### SKILL.md (recommended)
-
-Single file with YAML frontmatter:
-
-```
+```text
 skills/web-search/
-  SKILL.md             # YAML frontmatter + markdown instructions
-  mcp/brave.json       # MCP server definition (optional)
+  SKILL.md
+  mcp/brave.json
+  tools/search.yaml
+  migrations/001.sql
 ```
 
-`SKILL.md` structure:
+Example:
 
 ```markdown
 ---
 name: web-search
-description: Search the web using Brave Search
+version: 0.1.0
+description: Search the web and summarize the results
 requiredCapabilities:
-  - net.http
-mcpServers:
-  - brave
+  - net.http:egress
 ---
 
 # Web Search
 
-Use the `brave_web_search` tool to search the web. Prefer specific queries.
-Always include source URLs in your response.
+Prefer precise queries.
+Always include source URLs in the final answer.
 ```
 
-### skill.yaml + prompts/ (legacy)
+Important: the supported `SKILL.md` frontmatter keys are:
 
-```
+- `name`
+- `version`
+- `description`
+- `requiredCapabilities`
+
+MCP servers, tool manifests, and migrations are loaded from sibling directories, not from frontmatter fields.
+
+## Legacy `skill.yaml` format
+
+```text
 skills/web-search/
-  skill.yaml           # metadata and required capabilities
-  prompts/
-    01-instructions.md
-    02-examples.md
+  skill.yaml
+  prompts/01-instructions.md
+  tools/search.yaml
   mcp/brave.json
+  migrations/001.sql
 ```
 
-`skill.yaml`:
+Example:
 
 ```yaml
 name: web-search
-description: Search the web using Brave Search
+version: 0.1.0
+description: Search the web and summarize the results
 requiredCapabilities:
-  - net.http
+  - net.http:egress
 ```
 
-Both formats support the same features. Use SKILL.md for new skills.
+The loader also understands these manifest fields, all defaulting to empty arrays:
 
----
+- `promptFragments`
+- `toolManifests`
+- `mcpServers`
+- `migrations`
 
-## Scaffolding a skill
+If those lists are omitted, the loader auto-discovers:
+
+- `prompts/*.md`
+- `tools/*.yaml`
+- `mcp/*.json`
+- `migrations/*.sql`
+
+## Creating a skill
 
 ```bash
-# SKILL.md format (recommended)
 npx talonctl add-skill --name web-search --persona assistant --format skillmd
-
-# Legacy YAML format
-npx talonctl add-skill --name web-search --persona assistant
+npx talonctl add-skill --name web-search --persona assistant --format yaml
 ```
 
-This creates the skill directory structure and attaches the skill to the persona in `talond.yaml`.
+This command:
 
----
+- scaffolds the skill directory
+- adds the skill name to the target persona's `skills` list in `talond.yaml`
 
-## Attaching MCP servers to a skill
+## MCP server definitions
 
-Skills can bundle MCP server definitions. Place JSON files in the `mcp/` subdirectory:
+`talonctl add-mcp` writes a JSON file into `skills/<skill>/mcp/`.
 
+```bash
+npx talonctl add-mcp --skill web-search --name brave-search \
+  --transport stdio \
+  --command npx \
+  --args @modelcontextprotocol/server-brave-search
 ```
-skills/web-search/mcp/brave.json
-```
+
+The JSON shape on disk is:
 
 ```json
 {
-  "command": "npx",
-  "args": ["@modelcontextprotocol/server-brave-search"],
-  "env": {
-    "BRAVE_API_KEY": "${BRAVE_API_KEY}"
+  "name": "brave-search",
+  "config": {
+    "transport": "stdio",
+    "command": "npx",
+    "args": ["@modelcontextprotocol/server-brave-search"]
   }
 }
 ```
 
-MCP servers from skills connect at daemon startup — they don't wait for `skill_load`. The environment variable substitution uses the same `${ENV_VAR}` syntax as the main config.
+Supported MCP config fields in JSON are:
 
----
+- `transport`
+- `command`
+- `args`
+- `url`
+- `headers`
+- `env`
+- `allowedTools`
+- `credentialScope`
+- `rateLimit`
 
-## Capability requirements
+## Tool manifests
 
-Skills can declare required capabilities. At startup, Talon intersects the skill's requirements with the persona's capability list:
+Skills can ship additional tool manifests in `tools/*.yaml`.
+Each tool manifest supports:
 
-```
-granted = persona.capabilities.allow ∩ skill.requiredCapabilities
-```
+- `name`
+- `description`
+- `capabilities`
+- optional `parameterSchema`
+- `executionLocation` of `host`, `sandbox`, or `mcp`
 
-If a skill requires a capability the persona doesn't have, a warning is logged at startup and the skill is skipped. The daemon still starts — the skill is just unavailable.
+## Required capabilities
 
----
+A skill is usable only if all of its `requiredCapabilities` labels exist in the persona's combined allow-list and approval-list.
 
-## Adding MCP servers directly
+Examples of built-in capability labels:
 
-You can also add MCP servers to a persona without a skill:
+- `memory.access:thread`
+- `net.http:egress`
+- `schedule.manage:own`
+- `db.query:own`
+- `subagent.invoke`
+- `subagent.background`
 
-```bash
-npx talonctl add-mcp --name brave-search \
-  --persona assistant \
-  --command npx \
-  --args @modelcontextprotocol/server-brave-search \
-  --transport stdio
-```
-
----
-
-## Writing a custom skill
-
-1. Create the directory:
-
-```bash
-mkdir -p skills/my-skill
-```
-
-2. Create `SKILL.md`:
-
-```markdown
----
-name: my-skill
-description: Brief description shown in the system prompt
-requiredCapabilities:
-  - net.http
----
-
-# My Skill
-
-Instructions for the agent. Describe when and how to use the skill's tools.
-Include examples if helpful.
-```
-
-3. Add any MCP servers to `skills/my-skill/mcp/`.
-
-4. Attach to a persona in `talond.yaml`:
-
-```yaml
-personas:
-  - name: assistant
-    skills:
-      - my-skill
-```
-
-5. Reload: `npx talonctl reload`
-
----
+Scope-less labels like `net.http` are accepted by the skill loader, but it logs a warning because the preferred format is `<domain>.<action>:<scope>`.
 
 ## Listing skills
 
 ```bash
 npx talonctl list-skills
+npx talonctl list-skills --persona assistant
 ```
-
-Shows all configured skills across all personas with their attachment status.

--- a/docs/landing.mdx
+++ b/docs/landing.mdx
@@ -47,7 +47,7 @@ Messages survive crashes. SQLite-backed FIFO queue per conversation thread, with
 Package system prompt fragments, MCP server configs, and tool manifests into named skills. Only metadata is loaded into context by default — full content loads on demand, saving thousands of tokens per turn.
 
 **Background agents**
-Spawn long-running Claude Code workers for deep tasks without blocking the conversation. The daemon tracks workers to completion and delivers results back through the normal channel.
+Spawn long-running background provider tasks for deep work without blocking the conversation. The daemon tracks them to completion and delivers results back through the normal channel.
 
 **Built-in sub-agents**
 Offload mechanical tasks — file search, memory retrieval, grooming, session summarization — to cheap Haiku-class models. Keeps foreground inference costs low.
@@ -71,7 +71,7 @@ Change config, personas, and skills without restarting the daemon. `talonctl rel
 Clone the repo, run `npm install && npm run build`. Node 22+ and Claude Code (or Gemini CLI) are the only external requirements. SQLite ships with the package.
 
 **2. Configure**
-Run `npx talonctl setup` for an interactive walkthrough. Add channels with `talonctl add-channel`, create personas with `talonctl add-persona`, bind them together, then validate with `talonctl doctor`.
+Run `npx talonctl setup` for first-run environment checks, starter config generation, migrations, and validation. Add channels with `talonctl add-channel`, create personas with `talonctl add-persona`, bind them together, then validate with `talonctl doctor`.
 
 **3. Connect**
 Start the daemon: `node dist/index.js --config talond.yaml`. Your Telegram bot, Slack app, or WhatsApp number is now backed by a persistent AI agent running on your hardware.
@@ -85,12 +85,12 @@ Start the daemon: `node dist/index.js --config talond.yaml`. Your Telegram bot, 
 | Channel | Status | Notes |
 |---|---|---|
 | Telegram | Stable | Long polling, MarkdownV2, allowedChatIds filter |
-| Slack | Stable | Socket Mode, mrkdwn formatting |
+| Slack | Stable | Socket Mode when `appToken` is set; outbound send always works via Web API |
 | WhatsApp (Baileys) | Stable | WhatsApp Web bridge, self-chat or dedicated number |
 | WhatsApp Business | Stable | Meta Cloud API, requires webhook server |
 | Terminal | Stable | WebSocket + `talonctl chat`, rendered markdown |
-| Discord | Partial | Send implemented, Gateway inbound coming |
-| Email | Beta | IMAP polling + SMTP, not yet tested end-to-end |
+| Discord | Partial | Outbound send works; inbound requires an external Gateway event feed |
+| Email | Partial | Config shape exists, but the stock daemon does not inject real SMTP/IMAP transports |
 
 ---
 

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -5,109 +5,295 @@ description: Complete reference for all talond.yaml configuration fields
 
 # Config schema reference
 
-Full reference for `talond.yaml`. All top-level sections are optional — defaults apply when omitted. Validated at startup using Zod; the daemon refuses to start with an invalid config.
-
----
+This page tracks the actual schema in `src/core/config/config-schema.ts`.
+Every top-level section is optional. When omitted, Talon applies schema defaults.
 
 ## Root fields
+
+```yaml
+logLevel: info
+dataDir: data
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `logLevel` | `trace \| debug \| info \| warn \| error \| fatal` | `info` | Pino log level |
-| `dataDir` | string | `data` | Root directory for runtime data (DB, IPC sockets, artifacts) |
+| `dataDir` | string | `data` | Root runtime data directory |
 
 ---
 
-## storage
+## `storage`
+
+```yaml
+storage:
+  type: sqlite
+  path: data/talond.sqlite
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `type` | `sqlite` | `sqlite` | Database backend |
-| `path` | string | `data/talond.sqlite` | SQLite file path (relative to cwd) |
+| `path` | string | `data/talond.sqlite` | SQLite file path |
 
 ---
 
-## personas[]
+## `sandbox`
+
+```yaml
+sandbox:
+  runtime: docker
+  image: talon-sandbox:latest
+  maxConcurrent: 3
+  networkDefault: off
+  idleTimeoutMs: 1800000
+  hardTimeoutMs: 3600000
+  resourceLimits:
+    memoryMb: 1024
+    cpus: 1
+    pidsLimit: 256
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `name` | string | required | Unique persona identifier |
-| `model` | string | `claude-sonnet-4-6` | Model ID passed to the provider |
-| `provider` | string | — | Override the default agent runner provider |
-| `systemPromptFile` | string | — | Path to system prompt Markdown file |
-| `skills` | string[] | `[]` | Skill names to attach |
-| `subagents` | string[] | `[]` | Sub-agent names the persona can invoke |
-| `capabilities.allow` | string[] | `[]` | Granted capability labels |
-| `capabilities.requireApproval` | string[] | `[]` | Capability labels requiring user confirmation |
-| `mounts` | mount[] | `[]` | Filesystem mounts for sandboxed execution |
-| `maxConcurrent` | integer ≥ 1 | — | Max parallel agent runs for this persona |
+| `runtime` | `docker \| apple-container` | `docker` | Sandbox runtime |
+| `image` | string | `talon-sandbox:latest` | Sandbox image |
+| `maxConcurrent` | integer ≥ 1 | `3` | Max concurrent sandboxed runs |
+| `networkDefault` | `off \| on` | `off` | Default network access |
+| `idleTimeoutMs` | integer ≥ 0 | `1800000` | Idle timeout in ms |
+| `hardTimeoutMs` | integer ≥ 0 | `3600000` | Hard timeout in ms |
+| `resourceLimits.memoryMb` | integer | `1024` | Memory limit per sandbox |
+| `resourceLimits.cpus` | number | `1` | CPU limit per sandbox |
+| `resourceLimits.pidsLimit` | integer | `256` | PID limit per sandbox |
 
-### mounts[]
+---
+
+## `personas[]`
+
+```yaml
+personas:
+  - name: assistant
+    model: claude-sonnet-4-6
+    provider: claude-code
+    systemPromptFile: personas/assistant/system.md
+    skills:
+      - web-search
+    subagents:
+      - session-summarizer
+    capabilities:
+      allow:
+        - memory.access:thread
+        - net.http:egress
+        - schedule.manage:own
+      requireApproval:
+        - db.query:own
+    mounts:
+      - source: /srv/notes
+        target: /workspace/notes
+        mode: ro
+    maxConcurrent: 2
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | required | Persona name |
+| `model` | string | `claude-sonnet-4-6` | Model identifier |
+| `provider` | string | — | Optional provider override |
+| `systemPromptFile` | string | — | Path to `system.md` |
+| `skills` | string[] | `[]` | Attached skill names |
+| `subagents` | string[] | `[]` | Allowed sub-agent names |
+| `capabilities.allow` | string[] | `[]` | Allowed capability labels |
+| `capabilities.requireApproval` | string[] | `[]` | Approval-gated capability labels |
+| `mounts` | array | `[]` | Sandbox mounts |
+| `maxConcurrent` | integer ≥ 1 | — | Optional per-persona concurrency cap |
+
+### `personas[].mounts[]`
+
+```yaml
+mounts:
+  - source: /srv/notes
+    target: /workspace/notes
+    mode: ro
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `source` | string | required | Host path |
-| `target` | string | required | Mount target path |
+| `target` | string | required | Mount target in the sandbox |
 | `mode` | `ro \| rw` | `ro` | Mount mode |
 
 ---
 
-## channels[]
+## `channels[]`
+
+```yaml
+channels:
+  - name: my-telegram
+    type: telegram
+    enabled: true
+    showToolCalls: true
+    config:
+      botToken: ${TELEGRAM_BOT_TOKEN}
+      pollingTimeoutSec: 30
+      allowedChatIds:
+        - "123456789"
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `name` | string | required | Unique channel identifier |
-| `type` | enum | required | `telegram`, `slack`, `discord`, `whatsappBusiness`, `whatsappBaileys`, `email`, `terminal` |
-| `enabled` | boolean | `true` | Enable/disable at startup |
-| `showToolCalls` | boolean | `false` | Send tool-call status messages to the channel |
+| `type` | `telegram \| whatsappBusiness \| whatsappBaileys \| slack \| email \| discord \| terminal` | required | Channel connector type |
+| `name` | string | required | Channel name |
+| `config` | object | `{}` | Connector-specific config |
 | `tokenRef` | string | — | Optional token reference |
-| `config` | object | `{}` | Connector-specific config (see Channels guide) |
+| `enabled` | boolean | `true` | Enable channel at startup |
+| `showToolCalls` | boolean | — | Optional per-channel tool-call messages |
+
+Notes:
+
+- The config schema accepts `whatsappBusiness`, not the legacy CLI alias `whatsapp`.
+- `showToolCalls` is optional in config; when omitted the runtime behaves as `false`.
 
 ---
 
-## bindings[]
+## `bindings[]`
+
+```yaml
+bindings:
+  - persona: assistant
+    channel: my-telegram
+    isDefault: true
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `persona` | string | required | Persona name |
 | `channel` | string | required | Channel name |
-| `isDefault` | boolean | `false` | Mark as default binding for this channel |
+| `isDefault` | boolean | `false` | Marks the default binding for the channel |
 
 ---
 
-## queue
+## `ipc`
+
+```yaml
+ipc:
+  pollIntervalMs: 500
+  daemonSocketDir: data/ipc/daemon
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `maxAttempts` | integer ≥ 1 | `3` | Max delivery attempts before dead-letter |
-| `backoffBaseMs` | integer | `1000` | Initial retry delay in ms |
-| `backoffMaxMs` | integer | `60000` | Maximum retry delay in ms |
-| `concurrencyLimit` | integer ≥ 1 | `5` | Max simultaneous message processing |
+| `pollIntervalMs` | integer ≥ 100 | `500` | IPC polling interval |
+| `daemonSocketDir` | string | `data/ipc/daemon` | IPC socket directory |
 
 ---
 
-## agentRunner
+## `queue`
+
+```yaml
+queue:
+  maxAttempts: 3
+  backoffBaseMs: 1000
+  backoffMaxMs: 60000
+  concurrencyLimit: 5
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `defaultProvider` | string | `claude-code` | Default provider name |
-| `providers` | record | see below | Provider configurations |
+| `maxAttempts` | integer ≥ 1 | `3` | Retry attempts before dead-letter |
+| `backoffBaseMs` | integer | `1000` | Initial retry delay |
+| `backoffMaxMs` | integer | `60000` | Maximum retry delay |
+| `concurrencyLimit` | integer ≥ 1 | `5` | Max concurrent queue processing |
 
-### agentRunner.providers.\<name\>
+---
+
+## `scheduler`
+
+```yaml
+scheduler:
+  tickIntervalMs: 5000
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | boolean | `false` | Enable this provider |
-| `command` | string | required | CLI command (e.g. `claude`) |
-| `contextWindowTokens` | integer | `200000` | Context window size |
+| `tickIntervalMs` | integer ≥ 1000 | `5000` | Scheduler tick interval |
+
+---
+
+## `auth`
+
+```yaml
+auth:
+  mode: subscription
+  apiKey: ${TALON_API_KEY}
+  providers:
+    anthropic:
+      apiKey: ${ANTHROPIC_API_KEY}
+    ollama:
+      baseURL: http://localhost:11434/v1
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `mode` | `subscription \| api_key` | `subscription` | Auth mode |
+| `apiKey` | string | — | Global API key for `api_key` mode |
+| `providers.<name>.apiKey` | string | — | Provider-specific API key |
+| `providers.<name>.baseURL` | string | — | Provider-specific base URL |
+
+---
+
+## `agentRunner`
+
+```yaml
+agentRunner:
+  defaultProvider: claude-code
+  providers:
+    claude-code:
+      enabled: true
+      command: claude
+      contextWindowTokens: 200000
+      contextManagement:
+        enabled: true
+        triggerMetric: cache_read_input_tokens
+        thresholdRatio: 0.5
+        recentMessageCount: 10
+        summarizer: session-summarizer
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `defaultProvider` | string | `claude-code` | Default foreground provider |
+| `providers` | record | built-in `claude-code` entry | Provider configs |
+
+### `agentRunner.providers.<name>`
+
+```yaml
+providers:
+  gemini-cli:
+    enabled: false
+    command: /usr/local/bin/gemini
+    contextWindowTokens: 1000000
+    options:
+      defaultModel: gemini-2.5-pro
+    contextManagement:
+      enabled: true
+      triggerMetric: input_tokens
+      thresholdRatio: 0.8
+      recentMessageCount: 10
+      summarizer: session-summarizer
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | boolean | `false` | Enable the provider |
+| `command` | string | required | CLI command |
+| `contextWindowTokens` | integer ≥ 1000 | `200000` | Context window size |
 | `options` | object | — | Provider-specific options |
-| `contextManagement.enabled` | boolean | `false` | Enable session rotation |
-| `contextManagement.triggerMetric` | string | — | Required when enabled. `input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, or `cache_total_input_tokens` |
-| `contextManagement.thresholdRatio` | float 0–1 | — | Required when enabled. Fraction of `contextWindowTokens` that triggers rotation |
-| `contextManagement.recentMessageCount` | integer | `10` | Verbatim messages to include after rotation |
-| `contextManagement.summarizer` | string | — | Required when enabled. Sub-agent name for history compression |
+| `contextManagement.enabled` | boolean | `false` | Enable rotation |
+| `contextManagement.triggerMetric` | enum | — | Required when enabled |
+| `contextManagement.thresholdRatio` | number 0-1 | — | Required when enabled |
+| `contextManagement.recentMessageCount` | integer ≥ 0 | `10` | Messages retained after rotation |
+| `contextManagement.summarizer` | string | — | Required when enabled |
 
-Default provider config:
+Built-in schema default:
 
 ```yaml
 agentRunner:
@@ -127,76 +313,59 @@ agentRunner:
 
 ---
 
-## backgroundAgent
+## `backgroundAgent`
+
+```yaml
+backgroundAgent:
+  enabled: true
+  maxConcurrent: 3
+  defaultTimeoutMinutes: 30
+  defaultProvider: claude-code
+  providers:
+    claude-code:
+      enabled: true
+      command: claude
+      contextWindowTokens: 200000
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | boolean | `true` | Enable background workers globally |
-| `maxConcurrent` | integer 1–10 | `3` | Max simultaneous workers |
-| `defaultTimeoutMinutes` | integer 15–480 | `30` | Default wall-clock timeout |
-| `defaultProvider` | string | `claude-code` | Provider for workers |
-| `providers` | record | see below | Provider configs (same structure as agentRunner, no contextManagement) |
-| `claudePath` | string | — | Explicit path to Claude Code binary |
+| `enabled` | boolean | `true` | Enable background agents globally |
+| `maxConcurrent` | integer 1-10 | `3` | Max concurrent background tasks |
+| `defaultTimeoutMinutes` | integer 15-480 | `30` | Default timeout |
+| `defaultProvider` | string | `claude-code` | Default background provider |
+| `providers` | record | built-in `claude-code` entry | Provider configs |
+| `claudePath` | string | — | Legacy shortcut for creating a `claude-code` provider when no explicit providers are set |
+
+`backgroundAgent.providers.<name>` uses the same provider shape as `ProviderConfigSchema`: `enabled`, `command`, `contextWindowTokens`, and optional `options`.
 
 ---
 
-## auth
+## `langfuse`
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `mode` | `subscription \| api_key` | `subscription` | Authentication mode |
-| `apiKey` | string | — | API key for `api_key` mode |
-| `providers.<name>.apiKey` | string | — | Per-provider API key |
-| `providers.<name>.baseURL` | string | — | Per-provider base URL (for Ollama, proxies) |
-
----
-
-## scheduler
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `tickIntervalMs` | integer ≥ 1000 | `5000` | Scheduler tick interval in ms |
-
----
-
-## ipc
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `pollIntervalMs` | integer ≥ 100 | `500` | IPC poll interval in ms |
-| `daemonSocketDir` | string | `data/ipc/daemon` | Unix socket directory |
-
----
-
-## sandbox
-
-Controls agent execution sandboxing (Docker or Apple Container).
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `runtime` | `docker \| apple-container` | `docker` | Container runtime |
-| `image` | string | `talon-sandbox:latest` | Sandbox container image |
-| `maxConcurrent` | integer ≥ 1 | `3` | Max concurrent sandboxed agent processes |
-| `networkDefault` | `off \| on` | `off` | Default network access for sandboxed agents |
-| `idleTimeoutMs` | integer | `1800000` | Idle container timeout (30 min) |
-| `hardTimeoutMs` | integer | `3600000` | Hard container timeout (60 min) |
-| `resourceLimits.memoryMb` | integer | `1024` | Memory limit per container in MB |
-| `resourceLimits.cpus` | float | `1` | CPU limit per container |
-| `resourceLimits.pidsLimit` | integer | `256` | PID limit per container |
-
----
-
-## langfuse
+```yaml
+langfuse:
+  enabled: true
+  publicKey: ${LANGFUSE_PUBLIC_KEY}
+  secretKey: ${LANGFUSE_SECRET_KEY}
+  baseUrl: https://cloud.langfuse.com
+  environment: production
+  release: 1.2.3
+  owner: talon
+  exportMode: batched
+  flushAt: 20
+  flushIntervalSeconds: 5
+```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `enabled` | boolean | `false` | Enable Langfuse tracing |
-| `publicKey` | string | — | Required when enabled |
-| `secretKey` | string | — | Required when enabled |
-| `baseUrl` | URL string | `https://cloud.langfuse.com` | Langfuse instance URL |
+| `publicKey` | string | `""` | Required when enabled |
+| `secretKey` | string | `""` | Required when enabled |
+| `baseUrl` | URL string | `https://cloud.langfuse.com` | Langfuse base URL |
 | `environment` | string | `production` | Environment tag |
-| `release` | string | — | Release/version tag |
-| `owner` | string | — | Owner tag for traces |
+| `release` | string | — | Optional release tag |
+| `owner` | string | — | Optional owner tag |
 | `exportMode` | `batched \| immediate` | `batched` | Export strategy |
-| `flushAt` | integer ≥ 1 | `20` | Batch size before flush |
-| `flushIntervalSeconds` | integer ≥ 1 | `5` | Max seconds between flushes |
+| `flushAt` | integer ≥ 1 | `20` | Batch size |
+| `flushIntervalSeconds` | integer ≥ 1 | `5` | Flush interval |

--- a/docs/reference/host-tools.mdx
+++ b/docs/reference/host-tools.mdx
@@ -1,172 +1,205 @@
 ---
 title: Host tools reference
-description: Built-in MCP tools available to Talon agents
+description: Built-in MCP tools exposed through Talon's internal host-tools server
 ---
 
 # Host tools reference
 
-Talon exposes a set of built-in tools to agents via an internal MCP server (`__talond_host_tools`) over a Unix socket. Every tool call is policy-checked against the persona's capability list and audit-logged.
+Talon exposes 7 built-in tools to agents through the internal MCP server `__talond_host_tools`.
+At the MCP layer the tool names use underscores, for example `memory_access`.
+Inside the daemon the corresponding internal names use dots, for example `memory.access`.
 
-Agents never interact with channels, the database, or the network directly — all side effects go through these tools.
+Every host-tool call is:
 
----
-
-## schedule_manage
-
-Create, list, update, and delete scheduled tasks. Requires `schedule.manage` capability.
-
-**Actions:**
-
-| Action | Description |
-|---|---|
-| `create` | Create a new schedule |
-| `list` | List all active schedules |
-| `update` | Modify an existing schedule |
-| `delete` | Cancel and remove a schedule |
-
-**Parameters for `create`:**
-
-| Parameter | Type | Description |
-|---|---|---|
-| `type` | `cron \| interval \| once` | Schedule type |
-| `expression` | string | Cron expression (`0 9 * * *`) or interval in ms (`3600000`) |
-| `runAt` | ISO 8601 string | For `once` type: exact run time |
-| `prompt` | string | Prompt to send when the schedule fires |
-| `promptFile` | string | Path to a prompt file (alternative to inline `prompt`) |
-| `persona` | string | Persona name to run the prompt as |
-| `channel` | string | Channel name to send the result to |
-| `timeoutMs` | integer | Optional execution timeout |
-
-**Parameters for `delete` / `update`:**
-
-| Parameter | Type | Description |
-|---|---|---|
-| `scheduleId` | string | ID returned by `create` or `list` |
+- filtered by the persona's capability labels before the tool is even listed
+- checked again at the bridge before execution
+- executed on the host, not inside the sandbox
 
 ---
 
-## channel_send
+## `schedule_manage`
 
-Send a message to a channel connector. Requires `channel.send:<channel>` capability.
+Internal tool: `schedule.manage`
 
-| Parameter | Type | Description |
+Capability labels:
+
+- `schedule.manage:own`
+
+Creates, updates, cancels, deletes, or lists schedules owned by the current persona.
+
+| Parameter | Type | Notes |
 |---|---|---|
-| `channel` | string | Channel name |
-| `threadId` | string | Thread ID to send to |
-| `content` | string | Message content (Markdown) |
+| `action` | `create \| update \| cancel \| delete \| list` | Required |
+| `scheduleId` | string | Required for `update`, `cancel`, and `delete` |
+| `cronExpr` | string | Required for `create`; optional for `update`; must be a 5-field cron expression |
+| `label` | string | Optional human-readable label |
+| `prompt` | string | Inline prompt; mutually exclusive with `promptFile` |
+| `promptFile` | string | Prompt alias from the persona's `prompts/` directory; mutually exclusive with `prompt` |
 
-The daemon converts Markdown to the channel's native format automatically (MarkdownV2 for Telegram, mrkdwn for Slack, etc.).
+Notes:
+
+- This tool currently manages cron schedules only.
+- `cancel` disables a schedule.
+- `delete` removes it permanently.
+- `promptFile` resolves a basename like `memory-grooming`, not a filesystem path.
 
 ---
 
-## memory_access
+## `channel_send`
 
-Read and write structured per-thread memory items. Requires `memory.access:*` capability.
+Internal tool: `channel.send`
 
-**Actions:**
+Capability labels:
 
-| Action | Description |
-|---|---|
-| `read` | Read memory items for the current thread |
-| `write` | Write or update a memory item |
-| `delete` | Delete a memory item by ID |
-| `list` | List all memory items for the current thread |
+- `channel.send:*`
+- `channel.send:<channel-name>`
 
-**Memory item types:** `fact`, `summary`, `note`
+Sends a Markdown message to another Talon channel.
 
-| Parameter | Type | Description |
+| Parameter | Type | Notes |
 |---|---|---|
-| `action` | string | `read`, `write`, `delete`, `list` |
-| `type` | string | Memory item type (for write) |
-| `content` | string | Item content (for write) |
-| `itemId` | string | Item ID (for delete) |
-| `query` | string | Search query (for read) |
+| `channelId` | string | Required; this is the configured channel name |
+| `content` | string | Required Markdown body |
+| `replyTo` | string | Optional channel-specific thread or message ID |
+
+Notes:
+
+- The agent does not pass a thread ID directly; Talon resolves the current thread context for the target channel.
+- Output is converted to the target connector's native format automatically.
 
 ---
 
-## net_http
+## `memory_access`
 
-Fetch external URLs. Requires `net.http` capability.
+Internal tool: `memory.access`
 
-| Parameter | Type | Description |
+Capability labels:
+
+- `memory.access:thread`
+
+Reads and writes per-thread memory items.
+
+| Parameter | Type | Notes |
 |---|---|---|
-| `url` | string | URL to fetch |
-| `method` | string | HTTP method (default: `GET`) |
-| `headers` | object | Request headers |
-| `body` | string | Request body (for POST/PUT) |
-| `timeoutMs` | integer | Request timeout in ms |
+| `operation` | `read \| write \| delete \| list` | Required |
+| `key` | string | Required for `read` and `delete`; optional for `write` |
+| `value` | any | Required for `write`; non-string values are JSON-stringified |
+| `namespace` | string | Optional; maps to the memory item type |
 
-Returns the response status, headers, and body.
+Notes:
+
+- When `write` omits `key`, Talon generates a UUID.
+- Supported namespaces map to `fact`, `summary`, and `note`.
+- Unknown namespaces fall back to `note`.
 
 ---
 
-## db_query
+## `net_http`
 
-Read-only database queries against a restricted set of tables. Requires `db.query` capability.
+Internal tool: `net.http`
 
-**Allowed tables:**
+Capability labels:
 
-| Table | Contents |
-|---|---|
-| `memory_items` | Per-thread memory facts, summaries, notes |
-| `schedules` | Scheduled tasks |
-| `messages` | Conversation messages |
-| `threads` | Conversation threads |
+- `net.http:egress`
 
-**Security restrictions:**
+Proxies outbound HTTP and HTTPS requests through the host.
 
-- SELECT-only — write keywords are rejected at the regex pre-check stage
-- Complex patterns rejected: UNION, subqueries, CTEs, INTERSECT, EXCEPT
-- Queries are automatically scoped to the current thread and persona
-- Hard row limit: 1,000 rows per query
-- Uses a separate read-only SQLite connection
-
-| Parameter | Type | Description |
+| Parameter | Type | Notes |
 |---|---|---|
-| `query` | string | SQL SELECT statement |
-| `params` | array | Query parameters (parameterized queries only) |
+| `method` | `GET \| POST \| PUT \| PATCH \| DELETE \| HEAD` | Required |
+| `url` | string | Required |
+| `headers` | object | Optional string header map |
+| `body` | string | Optional request body |
+| `timeoutMs` | number | Optional; defaults to `30000`, capped at `120000` |
+
+Notes:
+
+- Only `http:` and `https:` URLs are allowed.
+- Domain allowlisting is enforced by the host-side handler.
+- An empty allowlist means the capability label is the only gate.
 
 ---
 
-## subagent_invoke
+## `db_query`
 
-Invoke a sub-agent by name and return its result. Requires `subagent.invoke:*` (or `subagent.invoke:<name>`) capability.
+Internal tool: `db.query`
 
-| Parameter | Type | Description |
+Capability labels:
+
+- `db.query:own`
+
+Runs restricted read-only SQL queries against the Talon SQLite database.
+
+| Parameter | Type | Notes |
 |---|---|---|
-| `name` | string | Sub-agent name |
-| `input` | object | Input payload (schema varies by sub-agent) |
+| `sql` | string | Required; must be a simple `SELECT` statement |
+| `params` | array | Optional prepared-statement parameters |
+| `limit` | number | Optional; defaults to `100`, maximum `1000` |
 
-Built-in sub-agents:
+Allowed tables:
 
-| Name | Input schema | Returns |
-|---|---|---|
-| `file-searcher` | `{ query, rootPaths?, extensions?, maxFileSize? }` | Ranked file paths with snippets |
-| `memory-retriever` | `{ query, topK?, threshold? }` | Ranked memory items with relevance scores |
-| `memory-groomer` | `{ periodMs? }` | `{ pruned, consolidated, kept }` counts |
-| `session-summarizer` | `{ transcript }` | `{ keyFacts, openThreads, summary }` |
+- `memory_items`
+- `schedules`
+- `messages`
+- `threads`
+
+Restrictions:
+
+- only `SELECT` is allowed
+- `UNION`, `EXCEPT`, `INTERSECT`, CTEs, and subqueries are rejected
+- Talon auto-injects thread and persona scoping where applicable
+- the query runs through a read-only SQLite connection
 
 ---
 
-## background_agent
+## `subagent_invoke`
 
-Spawn and manage long-running background Claude Code workers. Requires `subagent.background` capability.
+Internal tool: `subagent.invoke`
 
-**Actions:**
+Capability labels:
 
-| Action | Description |
-|---|---|
-| `spawn` | Start a new background worker |
-| `status` | Check the status of a running worker |
-| `cancel` | Cancel a running worker |
-| `profiles` | List available background agent profiles |
+- `subagent.invoke`
 
-**Parameters for `spawn`:**
+Runs a named sub-agent synchronously and returns its structured result.
 
-| Parameter | Type | Description |
+| Parameter | Type | Notes |
 |---|---|---|
-| `task` | string | Task description / prompt for the worker |
-| `profile` | string | Agent profile name (from `profiles` action) |
-| `timeoutMinutes` | integer | Override `defaultTimeoutMinutes` |
+| `name` | string | Required sub-agent name |
+| `input` | object | Optional JSON object passed through to the sub-agent |
 
-Returns a task ID immediately. The worker runs asynchronously and sends a completion message to the originating thread when done.
+Built-in sub-agents shipped in this repo:
+
+| Name | Model | Purpose |
+|---|---|---|
+| `session-summarizer` | `claude-sonnet-4-6` | Compress long conversation history for session resumption |
+| `memory-retriever` | `claude-haiku-4-5` | Retrieve relevant memory items for a query |
+| `memory-groomer` | `claude-haiku-4-5` | Consolidate and prune memory entries |
+| `file-searcher` | `claude-haiku-4-5` | Search files and return ranked snippets |
+
+---
+
+## `background_agent`
+
+Internal tool: `subagent.background`
+
+Capability labels:
+
+- `subagent.background`
+
+Starts and manages long-running background agent tasks.
+
+| Parameter | Type | Notes |
+|---|---|---|
+| `action` | `spawn \| status \| cancel \| result \| profiles` | Required |
+| `prompt` | string | Required for `spawn` |
+| `taskId` | string | Used by `status`, `cancel`, and `result` |
+| `provider` | string | Optional provider override for `spawn` |
+| `profile` | string | Optional persona profile name for `spawn` |
+| `workingDirectory` | string | Optional working directory for `spawn` |
+| `timeoutMinutes` | number | Optional timeout override for `spawn`; minimum effective value is 15 |
+
+Notes:
+
+- Call `action: "profiles"` first if the agent needs to discover which persona profiles are available.
+- A `profile` uses another loaded persona's prompt, skills, model, provider, and capabilities.
+- Background tasks return a task ID immediately and later deliver completion back into the originating thread.

--- a/docs/reference/talonctl.mdx
+++ b/docs/reference/talonctl.mdx
@@ -5,386 +5,486 @@ description: Complete CLI reference for the talonctl management tool
 
 # talonctl reference
 
-`talonctl` is the management CLI for the Talon daemon. All commands are available via `npx talonctl <command>` or `node dist/cli/index.js <command>`.
+`talonctl` manages a Talon daemon and its config. Commands usually read `talond.yaml` from the current directory unless they are IPC-only commands.
 
-Most commands read `talond.yaml` from the current directory by default. Override with `--config <path>`.
+Examples in this file use `npx talonctl ...`, but the same subcommands also work through `node dist/cli/index.js ...`.
 
 ---
 
 ## Daemon management
 
-### status
+### `status`
 
-Show daemon health, active channels, queue depth, and token usage.
+Shows daemon status through IPC.
 
 ```bash
 npx talonctl status
-npx talonctl status --timeout 5000
+npx talonctl status --ipc-dir data/ipc/daemon --timeout 5000
 ```
 
 | Flag | Description |
 |---|---|
-| `--timeout <ms>` | IPC timeout in ms (default: 5000) |
+| `--ipc-dir <path>` | Override the daemon IPC directory |
+| `--timeout <ms>` | Response timeout in milliseconds. Default: `5000` |
 
-### reload
+### `reload`
 
-Hot-reload config, personas, and skills without restarting the daemon.
+Hot-reloads config, personas, and channels through IPC.
 
 ```bash
 npx talonctl reload
-npx talonctl reload --config talond.yaml
-```
-
-### chat
-
-Connect to a persona via the terminal channel. Requires a running terminal channel connector.
-
-```bash
-npx talonctl chat --host localhost --port 7700
-npx talonctl chat --host 10.0.1.95 --port 7700 --persona researcher
-npx talonctl chat --host localhost --port 7700 --client-id my-laptop --token my-secret
+npx talonctl reload --ipc-dir data/ipc/daemon --timeout 5000
 ```
 
 | Flag | Description |
 |---|---|
-| `--host <host>` | Daemon host (default: `localhost`) |
-| `--port <port>` | Terminal channel port (default: `7700`) |
-| `--token <token>` | Auth token (or `TERMINAL_TOKEN` env var) |
-| `--persona <name>` | Persona to connect to |
-| `--client-id <id>` | Stable client ID for thread persistence |
+| `--ipc-dir <path>` | Override the daemon IPC directory |
+| `--timeout <ms>` | Response timeout in milliseconds. Default: `5000` |
+
+### `chat`
+
+Connects to a configured terminal channel over WebSocket.
+
+```bash
+npx talonctl chat --token "$TERMINAL_TOKEN"
+npx talonctl chat --host 127.0.0.1 --port 7700 --token "$TERMINAL_TOKEN" --client-id my-laptop
+npx talonctl chat --host 127.0.0.1 --port 7700 --token "$TERMINAL_TOKEN" --persona researcher --tls
+```
+
+| Flag | Description |
+|---|---|
+| `--host <host>` | Terminal connector host. Default: `127.0.0.1` |
+| `--port <port>` | Terminal connector port. Default: `7700` |
+| `--token <token>` | Terminal auth token. If omitted, `TERMINAL_TOKEN` is used |
+| `--client-id <id>` | Stable client identity for persistent threads |
+| `--persona <name>` | Optional persona override for this session |
+| `--tls` | Use `wss://` instead of `ws://` |
 
 ---
 
-## Setup and first-run
+## Setup and diagnostics
 
-### setup
+### `setup`
 
-Interactive first-time setup. Checks the environment, creates directories, and generates a starter `talond.yaml`.
+Runs first-time setup steps: OS and Docker checks, data directory creation, starter config generation, migrations, and config validation.
 
 ```bash
 npx talonctl setup
 npx talonctl setup --config talond.yaml --data-dir data
 ```
 
-### doctor
+| Flag | Description |
+|---|---|
+| `--config <path>` | Path to write `talond.yaml`. Default: `talond.yaml` |
+| `--data-dir <path>` | Data directory path. Default: `data` |
 
-Run 7 diagnostic checks: OS compatibility, Node version, Docker, directories, config syntax, pending migrations, and deep config validation.
+### `doctor`
+
+Checks Node.js, Docker, config validity, database access, and data directories.
 
 ```bash
 npx talonctl doctor
 npx talonctl doctor --config talond.yaml
 ```
 
-### migrate
+### `migrate`
 
-Apply pending database schema migrations.
+Applies database migrations without needing a running daemon.
 
 ```bash
 npx talonctl migrate
 npx talonctl migrate --config talond.yaml
 ```
 
-### env-check
+### `env-check`
 
-Audit `talond.yaml` for `${ENV_VAR}` placeholders and report any that are missing from the environment.
+Scans `talond.yaml` for `${ENV_VAR}` placeholders and reports which ones are set.
 
 ```bash
 npx talonctl env-check
 npx talonctl env-check --config talond.yaml
 ```
 
-### config-show
+### `config-show`
 
-Display the fully resolved config with all secrets masked.
+Shows the config file after environment-variable substitution. Secrets are masked unless you opt in to showing them.
 
 ```bash
 npx talonctl config-show
-npx talonctl config-show --config talond.yaml
-```
-
----
-
-## Channel management
-
-### add-channel
-
-Add a channel connector to `talond.yaml`. Prompts interactively for connector-specific fields.
-
-```bash
-npx talonctl add-channel --name my-telegram --type telegram
-npx talonctl add-channel --name work-slack --type slack
+npx talonctl config-show --show-secrets
 ```
 
 | Flag | Description |
 |---|---|
-| `--name <name>` | Channel name |
-| `--type <type>` | `telegram`, `slack`, `discord`, `whatsappBusiness`, `whatsappBaileys`, `email`, `terminal` |
+| `--config <path>` | Path to `talond.yaml`. Default: `talond.yaml` |
+| `--show-secrets` | Print secret values instead of masking them |
 
-### list-channels
+---
 
-List all configured channels with type and enabled status.
+## Channels
+
+### `add-channel`
+
+Adds a channel entry with a placeholder `config` block.
+
+```bash
+npx talonctl add-channel --name my-telegram --type telegram
+npx talonctl add-channel --name my-terminal --type terminal
+```
+
+| Flag | Description |
+|---|---|
+| `--name <name>` | Required unique channel name |
+| `--type <type>` | Required channel type. Accepted by the CLI: `telegram`, `whatsapp`, `whatsappBusiness`, `whatsappBaileys`, `slack`, `email`, `discord`, `terminal` |
+| `--config <path>` | Path to `talond.yaml`. Default: `talond.yaml` |
+
+Note: the validated config schema uses `whatsappBusiness`; prefer that spelling in `talond.yaml`.
+
+### `list-channels`
+
+Lists configured channels.
 
 ```bash
 npx talonctl list-channels
 ```
 
-### remove-channel
+### `remove-channel`
 
-Remove a channel and cascade-delete its bindings.
+Removes a channel from config and also removes any config bindings that reference it.
 
 ```bash
-npx talonctl remove-channel --name old-slack
+npx talonctl remove-channel --name old-channel
 ```
 
 ---
 
-## Persona management
+## Personas
 
-### add-persona
+### `add-persona`
 
-Scaffold a persona directory and add it to `talond.yaml`. Uses `templates/<name>/system.md` if available.
+Scaffolds a persona directory, `system.md`, `personality/`, and `prompts/`, then adds the persona to config.
 
 ```bash
 npx talonctl add-persona --name assistant
-npx talonctl add-persona --name researcher
+npx talonctl add-persona --name researcher --provider gemini-cli
+npx talonctl add-persona --name triage --description "Triage and routing persona"
 ```
 
-### list-personas
+| Flag | Description |
+|---|---|
+| `--name <name>` | Required persona name |
+| `--config <path>` | Path to `talond.yaml`. Default: `talond.yaml` |
+| `--templates-dir <path>` | Template directory. Default: `templates` |
+| `--model <model>` | Optional model override |
+| `--provider <provider>` | Optional provider override |
+| `--capabilities <caps>` | Comma-separated allow-list labels |
+| `--require-approval <caps>` | Comma-separated approval-gated labels |
+| `--skills <skills>` | Comma-separated skill names |
+| `--system-prompt-file <path>` | Copy an existing system prompt file instead of generating one |
+| `--description <text>` | Persona description written into `system.md` frontmatter |
 
-List all configured personas with their bound channels.
+Default allow-list for a new persona:
+
+- `memory.access:thread`
+- `net.http:egress`
+- `schedule.manage:own`
+
+### `list-personas`
+
+Lists configured personas.
 
 ```bash
 npx talonctl list-personas
 ```
 
-### remove-persona
+### `remove-persona`
 
-Remove a persona, its directory, and all its bindings.
+Removes a persona from config and removes any config bindings that reference it. The persona directory on disk is not deleted.
 
 ```bash
 npx talonctl remove-persona --name old-persona
 ```
 
-### set-capabilities
+### `list-capabilities`
 
-Set capability labels for a persona.
-
-```bash
-npx talonctl set-capabilities --persona assistant \
-  --allow "channel.send:my-telegram,memory.access:*,net.http"
-```
-
-### list-capabilities
-
-List capability labels for all personas.
+Prints the known capability labels grouped by host tool.
 
 ```bash
 npx talonctl list-capabilities
 ```
 
+### `set-capabilities`
+
+Reads or updates a persona's capability labels.
+
+```bash
+npx talonctl set-capabilities --persona assistant --show
+npx talonctl set-capabilities --persona assistant --add "subagent.background,channel.send:my-telegram"
+npx talonctl set-capabilities --persona assistant --require-approval "db.query:own"
+```
+
+| Flag | Description |
+|---|---|
+| `--persona <name>` | Required persona name |
+| `--allow <labels>` | Replace the entire allow list |
+| `--add <labels>` | Add labels to the allow list |
+| `--remove <labels>` | Remove labels from the allow list |
+| `--require-approval <labels>` | Replace the entire `requireApproval` list |
+| `--show` | Print current capabilities without changing config |
+| `--config <path>` | Path to `talond.yaml`. Default: `talond.yaml` |
+
+`--allow` is mutually exclusive with `--add` and `--remove`.
+
 ---
 
 ## Bindings
 
-### bind
+### `bind`
 
-Bind a persona to a channel.
+Adds a persona-to-channel binding in config.
 
 ```bash
 npx talonctl bind --persona assistant --channel my-telegram
 ```
 
-The first binding for a channel automatically becomes the default.
+The first binding created for a channel becomes its default binding automatically.
 
-### unbind
+### `unbind`
 
-Remove a persona-channel binding.
+Removes a persona-to-channel binding from config.
 
 ```bash
 npx talonctl unbind --persona assistant --channel my-telegram
 ```
 
+If the removed binding was the default binding for that channel, Talon promotes the next remaining binding on that channel to default.
+
 ---
 
 ## Skills
 
-### add-skill
+### `add-skill`
 
-Scaffold a skill and attach it to a persona.
+Scaffolds a skill directory and attaches the skill name to a persona in config.
 
 ```bash
-# SKILL.md format (recommended)
 npx talonctl add-skill --name web-search --persona assistant --format skillmd
-
-# Legacy YAML format
 npx talonctl add-skill --name web-search --persona assistant --format yaml
-```
-
-### list-skills
-
-List all configured skills across all personas.
-
-```bash
-npx talonctl list-skills
-```
-
-### add-mcp
-
-Add an MCP server to a persona.
-
-```bash
-npx talonctl add-mcp --name brave-search \
-  --persona assistant \
-  --command npx \
-  --args "@modelcontextprotocol/server-brave-search" \
-  --transport stdio
 ```
 
 | Flag | Description |
 |---|---|
-| `--name <name>` | MCP server name |
-| `--persona <name>` | Target persona |
-| `--command <cmd>` | Command to launch the server |
-| `--args <args>` | Command arguments (comma-separated) |
-| `--transport <t>` | `stdio` or `http` |
+| `--name <name>` | Required skill name |
+| `--persona <persona>` | Required target persona |
+| `--format <format>` | `yaml` or `skillmd`. Default: `yaml` |
+| `--config <path>` | Path to `talond.yaml`. Default: `talond.yaml` |
+
+### `list-skills`
+
+Lists skills attached to personas. It reports the on-disk format when the skill directory exists.
+
+```bash
+npx talonctl list-skills
+npx talonctl list-skills --persona assistant
+```
+
+### `add-mcp`
+
+Creates `skills/<skill>/mcp/<name>.json`.
+
+```bash
+npx talonctl add-mcp --skill web-search --name brave-search \
+  --transport stdio --command npx --args @modelcontextprotocol/server-brave-search
+
+npx talonctl add-mcp --skill issue-tracker --name jira \
+  --transport http --url https://example.com/mcp
+```
+
+| Flag | Description |
+|---|---|
+| `--skill <name>` | Required skill name |
+| `--name <name>` | Required MCP server name |
+| `--transport <type>` | Required transport: `stdio`, `sse`, or `http` |
+| `--command <cmd>` | Required for `stdio` |
+| `--args <args...>` | Optional arguments for `stdio` |
+| `--url <url>` | Required for `sse` and `http` |
+| `--env <pairs>` | Optional comma-separated `KEY=VAL` pairs |
+| `--skills-dir <path>` | Skills directory. Default: `skills` |
 
 ---
 
 ## Scheduling
 
-### add-schedule
+### `add-schedule`
 
-Add a scheduled task manually.
+Creates a cron schedule directly in the database. This command only supports cron schedules.
 
 ```bash
 npx talonctl add-schedule \
   --persona assistant \
   --channel my-telegram \
-  --type cron \
-  --expression "0 9 * * 1-5" \
-  --prompt "Good morning. What should I focus on today?"
+  --cron "0 9 * * 1-5" \
+  --label "Morning summary" \
+  --prompt "Good morning. Summarize what I should focus on today."
 ```
 
 | Flag | Description |
 |---|---|
-| `--persona <name>` | Persona name |
-| `--channel <name>` | Channel name |
-| `--type <type>` | `cron`, `interval`, `once` |
-| `--expression <expr>` | Cron expression or interval in ms |
-| `--run-at <datetime>` | ISO 8601 datetime for `once` type |
-| `--prompt <text>` | Prompt to execute |
+| `--persona <name>` | Required persona name |
+| `--channel <name>` | Required channel name for the schedule thread |
+| `--cron <expr>` | Required 5-field cron expression |
+| `--label <label>` | Required human-readable label |
+| `--prompt <prompt>` | Required inline prompt text |
+| `--config <path>` | Path to `talond.yaml`. Default: `talond.yaml` |
 
-### list-schedules
+### `list-schedules`
 
-List all active schedules.
+Lists schedules from the database.
 
 ```bash
 npx talonctl list-schedules
+npx talonctl list-schedules --persona assistant
 ```
 
-### remove-schedule
+### `remove-schedule`
 
-Cancel and remove a schedule by ID.
+Deletes a schedule permanently by ID.
 
 ```bash
-npx talonctl remove-schedule --id <schedule-id>
+npx talonctl remove-schedule 123e4567-e89b-12d3-a456-426614174000
 ```
 
 ---
 
 ## Providers
 
-### add-provider
+### `list-providers`
 
-Add or configure an AI provider.
-
-```bash
-npx talonctl add-provider
-```
-
-### list-providers
-
-List configured providers.
+Lists providers from both `agentRunner.providers` and `backgroundAgent.providers`.
 
 ```bash
 npx talonctl list-providers
 ```
 
-### set-default-provider
+### `add-provider`
 
-Set the default provider for agent execution.
+Adds a provider to `agentRunner`, `backgroundAgent`, or both.
 
 ```bash
-npx talonctl set-default-provider --provider claude-code
+npx talonctl add-provider --name gemini-cli \
+  --command /usr/local/bin/gemini \
+  --context both \
+  --context-window 1000000 \
+  --enabled \
+  --default-model gemini-2.5-pro
 ```
 
-### test-provider
+| Flag | Description |
+|---|---|
+| `--name <name>` | Required provider name |
+| `--command <cmd>` | Required CLI command or absolute path |
+| `--context <ctx>` | `agent-runner`, `background`, or `both`. Default: `both` |
+| `--context-window <tokens>` | Context window size. Default: `200000` |
+| `--context-enabled <enabled>` | Enable or disable context management for `agent-runner` providers |
+| `--trigger-metric <metric>` | Context trigger metric |
+| `--threshold-ratio <ratio>` | Rotation threshold ratio. Default: `0.5` |
+| `--recent-message-count <count>` | Messages kept after rotation. Default: `10` |
+| `--summarizer <name>` | Summarizer sub-agent. Default: `session-summarizer` |
+| `--enabled` | Enable the provider immediately |
+| `--default-model <model>` | Write `options.defaultModel` |
+| `--config <path>` | Path to `talond.yaml`. Default: `talond.yaml` |
 
-Test connectivity and authentication for a provider.
+Notes:
+
+- Background providers do not get `contextManagement`.
+- If `--context-enabled` is omitted, `agent-runner` and `both` default to enabled context management.
+
+### `set-default-provider`
+
+Switches the default provider for one context.
 
 ```bash
-npx talonctl test-provider --provider claude-code
+npx talonctl set-default-provider --name claude-code --context agent-runner
+npx talonctl set-default-provider --name gemini-cli --context background
+```
+
+### `test-provider`
+
+Runs `--version` and a minimal test prompt against a configured provider.
+
+```bash
+npx talonctl test-provider --name claude-code
+npx talonctl test-provider --name gemini-cli --context background
 ```
 
 ---
 
 ## Sub-agents
 
-### run-subagent
+### `run-subagent`
 
-Invoke a sub-agent directly without a running daemon. Useful for testing.
+Loads and runs a sub-agent directly for testing.
 
 ```bash
-# File search
 npx talonctl run-subagent --name file-searcher \
-  --input '{"query": "deployment steps"}'
+  --input '{"query":"deployment steps"}'
 
-# Session summarizer
 npx talonctl run-subagent --name session-summarizer \
-  --input '{"transcript": "User: Hi\nAssistant: Hello!"}'
-
-# Custom sub-agents directory
-npx talonctl run-subagent --name my-agent --input '{}' \
-  --subagents-dir ./subagents
+  --input '{"transcript":"User: Hi\nAssistant: Hello!"}'
 ```
 
-Note: `memory-retriever` and `memory-groomer` require a running daemon (they need DB access).
+| Flag | Description |
+|---|---|
+| `--name <name>` | Required sub-agent name |
+| `--input <json>` | Required JSON object payload |
+| `--config <path>` | Path to `talond.yaml`. Default: `talond.yaml` |
+| `--subagents-dir <path>` | Override the sub-agents directory |
+
+Without `--subagents-dir`, Talon searches:
+
+- the bundled built-in subagents
+- `./subagents`
+- `<dataDir>/subagents`
 
 ---
 
 ## Operations
 
-### backup
+### `backup`
 
-Backup the database, config, personas, and skills.
+Creates a backup directory containing the database, config, personas, and skills.
 
 ```bash
 npx talonctl backup
-npx talonctl backup --config talond.yaml --output /backups/talon-$(date +%Y%m%d)
+npx talonctl backup --config talond.yaml --output data/backups/pre-upgrade
 ```
 
-### queue-purge
+### `queue-purge`
 
-Purge queue items by status.
+Purges queue items through IPC.
 
 ```bash
-# Purge completed, pending, and failed items (default)
 npx talonctl queue-purge
-
-# Purge specific statuses
 npx talonctl queue-purge --statuses dead_letter,failed
-
-# Purge ALL items including in-flight
 npx talonctl queue-purge --all
 ```
 
+| Flag | Description |
+|---|---|
+| `--ipc-dir <path>` | Override the daemon IPC directory |
+| `--timeout <ms>` | Response timeout in milliseconds. Default: `5000` |
+| `--statuses <list>` | Comma-separated statuses to purge |
+| `--all` | Purge all statuses, including in-flight items |
+
+Valid statuses: `pending`, `claimed`, `processing`, `completed`, `failed`, `dead_letter`.
+
 ---
 
-## WhatsApp authentication
+## WhatsApp Baileys authentication
 
-### whatsapp-auth
+### `whatsapp-auth`
 
-Authenticate a WhatsApp Baileys connector by scanning a QR code.
+Runs the QR-based auth flow for the `whatsappBaileys` connector.
 
 ```bash
 npx talonctl whatsapp-auth --auth-dir ./baileys-auth
@@ -393,5 +493,5 @@ npx talonctl whatsapp-auth --auth-dir ./baileys-auth --timeout 180
 
 | Flag | Description |
 |---|---|
-| `--auth-dir <path>` | Directory to save credentials |
-| `--timeout <seconds>` | QR code timeout in seconds (default: 120) |
+| `--auth-dir <path>` | Directory where Baileys session files are stored. Default: `./baileys-auth` |
+| `--timeout <seconds>` | QR scan timeout. Default: `120` |

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -134,7 +134,7 @@ For the context-management strategies and migration details, see [context-manage
 
 The `command` field needs to resolve on the server. If the binary isn't on PATH, use the full path. Run `which claude` or `which gemini` to find it.
 
-The `options.defaultModel` field is provider-specific. Gemini CLI picks its own model unless you override it here. Claude uses the persona's `model` field from the persona config (that field is ignored by Gemini).
+The `options.defaultModel` field is provider-specific. Gemini CLI uses it when the run does not provide an explicit model. Persona runs still pass the persona's `model` field through to the provider, so keep persona model names compatible with the provider you choose.
 
 Use `talonctl` to manage providers without editing YAML:
 
@@ -187,7 +187,6 @@ channels:
       botToken: ${TELEGRAM_BOT_TOKEN}
       allowedChatIds:
         - "123456789"
-      pollIntervalMs: 1000
 ```
 
 ### Personas
@@ -225,7 +224,7 @@ Task prompts are markdown files in `personas/<name>/prompts/` that the agent exe
 
 ### How schedules work
 
-The agent can create its own schedules using the `schedule.manage` capability. You define the prompt file, and either configure a schedule in `talond.yaml` or let the agent schedule it during conversation.
+The agent can create its own schedules using the `schedule.manage:own` capability. For reusable prompt files, put markdown files in `personas/<name>/prompts/` and reference them by basename through `promptFile`.
 
 To add a schedule via CLI:
 
@@ -301,7 +300,7 @@ npx talonctl add-schedule \
   --prompt "Run the memory-grooming task prompt"
 ```
 
-Running at 3 AM means it doesn't compete with interactive conversations. The agent uses `memory_access` to read, consolidate, and prune entries, then sends a summary of what it cleaned up.
+Running at 3 AM means it doesn't compete with interactive conversations. The agent uses the `memory_access` host tool to read, consolidate, and prune entries, then sends a summary of what it cleaned up.
 
 Every 2-3 days works well. Once a week is the minimum. If you skip this entirely, the agent's memory context gets increasingly noisy and you'll notice degraded recall quality after a few weeks.
 
@@ -313,7 +312,7 @@ Run Talon on its own VM or VPS. It doesn't need much (2 cores, 4GB RAM), but it 
 
 ### Notes in git
 
-Keep work notes, meeting notes, and reference docs in a git-synced folder on the same machine. The agent can read and write to it using the `fs.read` and `fs.write` capabilities, and you get version history for free.
+Keep work notes, meeting notes, and reference docs in a git-synced folder on the same machine. If you want Talon to work with that material, expose it explicitly through sandbox mounts or skill-provided MCP servers rather than assuming file access is available by default. Git still gives you version history for free.
 
 ```
 /home/talon/notes/
@@ -322,7 +321,7 @@ Keep work notes, meeting notes, and reference docs in a git-synced folder on the
   rfcs/          # design documents
 ```
 
-Sync with a private GitHub repo. The agent can commit and push changes when writing notes.
+Sync with a private GitHub repo if you want versioned notes and backups.
 
 ### Systemd service
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,116 +1,107 @@
 # Skills
 
-Skills are reusable capability bundles that attach to personas. Each skill provides prompt instructions and optionally MCP servers, tool manifests, and database migrations.
+Skills are reusable bundles attached to personas. A skill can contribute:
 
-## Skill Formats
+- prompt instructions
+- MCP server definitions
+- tool manifests
+- migration files
 
-Talon supports two on-disk formats.
+## Supported formats
 
-### SKILL.md (recommended)
+### `SKILL.md`
 
-A single file with YAML frontmatter and a markdown body:
-
-```
+```text
 skills/web-research/
-  SKILL.md              # frontmatter + instructions
-  mcp/                  # optional MCP server definitions
-  tools/                # optional tool manifests
-  migrations/           # optional SQL migrations
+  SKILL.md
+  mcp/
+  tools/
+  migrations/
 ```
 
-Example `SKILL.md`:
+Example:
 
 ```markdown
 ---
 name: web-research
 version: 0.1.0
-description: "Search the web and fetch pages for research tasks"
+description: Search the web and summarize findings
 requiredCapabilities:
-  - net.http:external
+  - net.http:egress
 ---
 
 # Web Research
 
-When the user asks you to research something, use the web search tool...
+Use web tools carefully and include sources.
 ```
 
-### skill.yaml + prompts/ (legacy)
+Supported frontmatter keys are:
 
-A YAML manifest with separate prompt fragment files:
+- `name`
+- `version`
+- `description`
+- `requiredCapabilities`
 
+### `skill.yaml`
+
+```text
+skills/web-research/
+  skill.yaml
+  prompts/main.md
+  mcp/brave.json
 ```
-skills/codex/
-  skill.yaml            # manifest
-  prompts/main.md       # prompt instructions
-  mcp/codex.json        # optional MCP server definitions
+
+Example:
+
+```yaml
+name: web-research
+version: 0.1.0
+description: Search the web and summarize findings
+requiredCapabilities:
+  - net.http:egress
 ```
 
-Both formats produce identical runtime behavior.
+The loader also supports optional arrays named:
 
-## Creating a Skill
+- `promptFragments`
+- `toolManifests`
+- `mcpServers`
+- `migrations`
+
+If those arrays are omitted, the loader auto-discovers files from the matching subdirectories.
+
+## Creating and listing skills
 
 ```bash
-# SKILL.md format (recommended)
 npx talonctl add-skill --name my-skill --persona assistant --format skillmd
+npx talonctl add-skill --name my-skill --persona assistant --format yaml
 
-# Legacy YAML format
-npx talonctl add-skill --name my-skill --persona assistant
-```
-
-## Listing Skills
-
-```bash
 npx talonctl list-skills
 npx talonctl list-skills --persona assistant
 ```
 
-Output shows persona, skill name, and format (yaml/skillmd).
+## Runtime loading
 
-## Lazy Loading
+Foreground agent runs use lazy loading:
 
-Skills use lazy loading by default. Only the skill name and description are included in the agent's system prompt. When the agent needs a skill's full instructions, it calls the `skill_load` tool.
+- the prompt contains only skill names and descriptions
+- the agent calls `skill_load` when it needs the full instructions
 
-This reduces token usage significantly:
+Background agents use eager loading instead and receive merged skill contents up front.
 
-| Scenario | Eager (old) | Lazy (current) |
-|---|---|---|
-| 7 skills, using 1 | ~21k tokens | ~3.7k tokens |
-| 20 skills, using 0 | ~60k tokens | ~2k tokens |
+## Required capabilities
 
-Background agents (spawned via the `background_agent` tool) use eager loading to ensure they have access to all skill instructions without needing to call `skill_load`.
+`requiredCapabilities` must be satisfied by the persona's combined `allow` and `requireApproval` labels.
 
-## MCP Servers in Skills
+Preferred examples:
 
-Skills can declare MCP servers in the `mcp/` subdirectory. These are JSON files:
+- `memory.access:thread`
+- `net.http:egress`
+- `schedule.manage:own`
+- `db.query:own`
 
-```json
-{
-  "name": "my-server",
-  "config": {
-    "transport": "stdio",
-    "command": "npx",
-    "args": ["my-mcp-server"],
-    "env": {
-      "API_KEY": "${MY_API_KEY}"
-    }
-  }
-}
-```
+Scope-less labels like `net.http` are accepted but logged with a warning.
 
-MCP servers from skills are connected eagerly at startup (the tools are available immediately), even though skill prompt instructions load lazily.
+## Reserved MCP server names
 
-## Required Capabilities
-
-Skills can declare `requiredCapabilities` in their manifest. These are capability labels that the persona must have in its `capabilities.allow` or `requireApproval` set for the skill to be usable.
-
-```yaml
-requiredCapabilities:
-  - net.http:external
-  - memory.access:thread
-```
-
-Format: `<domain>.<action>:<scope>` or `<domain>.<action>`.
-
-## Reserved Names
-
-MCP server names starting with `__talond_` are reserved for internal use. Skill-defined MCP servers using this prefix will be rejected at startup.
+Skill-defined MCP servers must not start with `__talond_`. That prefix is reserved for Talon's internal servers.

--- a/docs/tips-and-tricks.mdx
+++ b/docs/tips-and-tricks.mdx
@@ -49,15 +49,15 @@ bindings:
 
 ## Keep capabilities minimal
 
-The default-deny capability model only works if you treat it as default-deny. Avoid `channel.send:*` unless the persona genuinely needs to send to multiple channels. Grant `db.query` only to personas that explicitly need it, and put it in `requireApproval` by default.
+The default-deny capability model only works if you treat it as default-deny. Avoid `channel.send:*` unless the persona genuinely needs to send to multiple channels. Grant `db.query:own` only to personas that explicitly need it, and put it in `requireApproval` by default.
 
 ```yaml
 capabilities:
   allow:
     - channel.send:my-telegram   # specific, not *
-    - memory.access:*
+    - memory.access:thread
   requireApproval:
-    - db.query                   # user confirms each query
+    - db.query:own               # user confirms each query
 ```
 
 This catches mistakes early and makes the audit log meaningful.
@@ -97,7 +97,7 @@ Check my open tasks and any pending messages. Summarize:
 Keep it to 5 bullets.
 ```
 
-Tell the agent to use `schedule_manage` with `promptFile: prompts/morning-summary.md`. Update the file whenever the format needs to change — the schedule keeps working.
+Tell the agent to use `schedule_manage` with `promptFile: morning-summary`. Update the file `personas/<name>/prompts/morning-summary.md` whenever the format needs to change.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the source documentation for the [talond.dev](https://talond.dev) website.

Content lives in \`docs/\` and is pulled into the [talond-website](https://github.com/talond-dev/talond-website) repo during CI build.

## Contents

- **Getting started**: installation, quick start, configuration
- **Guides**: personas, channels, skills, scheduling, background agents
- **Reference**: config schema, host tools, talonctl CLI
- **Tips & tricks**
- **Landing page copy**

🤖 Generated with Claude Code