### PR TITLE
docs: add blog with first 3 posts

### DIFF
--- a/docs/blog/2026-03-28-a2a-protocol.mdx
+++ b/docs/blog/2026-03-28-a2a-protocol.mdx
@@ -1,0 +1,91 @@
+---
+title: "A2A — Agent-to-Agent Communication in Talon"
+date: 2026-03-28
+description: Talon now has a durable A2A layer. Personas can delegate tasks to each other over an internal queue, with hop enforcement and persistence across restarts.
+---
+
+# A2A — Agent-to-Agent Communication in Talon
+
+Talon 1.x personas were isolated. Each ran in its own context, handled its own queue, had no way to talk to other personas. That worked fine until you wanted to split work — a coordinator that routes, a researcher that fetches, a writer that synthesizes. You'd have to orchestrate that externally.
+
+Not anymore.
+
+## What it is
+
+The A2A layer lets personas delegate tasks to each other over Talon's internal durable queue. A persona calls `persona_send` with a target persona name and a message. That message becomes a queue item for the target. The target processes it like any other message, runs its agent, and either returns a result or fires and forgets.
+
+Everything persists in SQLite. Tasks survive restarts. The queue handles retries. No external orchestration needed.
+
+## How it works
+
+When a persona calls `persona_send`, Talon:
+
+1. Validates the target persona exists and is loaded
+2. Checks the hop count hasn't exceeded `MAX_HOPS` (4)
+3. Inserts a new queue item for the target persona
+4. Either returns the task ID immediately (fire-and-forget) or polls until the task reaches a terminal state
+
+The hop count propagates through the execution context. If persona A delegates to B, and B tries to delegate to C, that's hop 2. Hit 4 and the task is rejected before it enters the queue. Prevents runaway chains.
+
+```
+Coordinator → Researcher (hop 1)
+Researcher  → Summarizer (hop 2)
+Summarizer  → (attempts delegation, hop 3)
+...rejected at hop 4
+```
+
+## Synchronous vs async delegation
+
+`await_reply: false` (the default) is fire-and-forget. The tool returns immediately with the task ID and state `submitted`. The target processes it on its own schedule.
+
+`await_reply: true` blocks the calling agent until the target reaches a terminal state — `completed`, `failed`, `canceled`, or `input-required`. It polls every 2 seconds with a 25-second cap. If the target doesn't finish in time, the tool returns `state: timeout`. The task keeps running; you just don't get the result inline.
+
+The 25-second cap is intentional. It sits just under the MCP bridge's 30-second request timeout, so you always get a clean result before the transport cuts the connection.
+
+## Discovery with persona_list
+
+Before calling `persona_send`, an agent can call `persona_list` to see what's available. It returns the live-loaded personas (not stale DB rows), excluding the caller itself:
+
+```json
+[
+  {
+    "name": "researcher",
+    "description": "Deep research and web search specialist",
+    "skills": ["web-search", "summarize"]
+  },
+  {
+    "name": "writer",
+    "description": "Long-form content and documentation",
+    "skills": ["write", "edit"]
+  }
+]
+```
+
+The description comes from the first line of the persona's system prompt file. Skills come from the persona config. This gives the calling agent enough context to decide who to delegate to.
+
+## Example workflow
+
+A coordinator persona receives a research request. It calls `persona_list`, picks the researcher, and delegates with `await_reply: true`:
+
+```
+User → Coordinator: "Summarize the latest news on WebAssembly runtimes"
+
+Coordinator calls persona_send:
+  target_persona: "researcher"
+  message: "Find and summarize recent news on WebAssembly runtimes. Focus on 2025-2026."
+  await_reply: true
+
+Researcher runs, fetches results, returns summary.
+
+Coordinator receives result, formats it, replies to user.
+```
+
+No infrastructure changes. No external queues. The whole thing runs on the same SQLite database that backs everything else in Talon.
+
+## Why this matters
+
+Multi-agent workflows typically require external orchestration — a separate service coordinating calls between agents, managing state, handling retries. Talon's A2A layer moves that into the daemon itself. Delegation is just a tool call. The queue handles durability. The capability system controls who can delegate to whom.
+
+You get composable agent workflows without adding operational complexity.
+
+See [persona_send and persona_list — A Practical Guide](./2026-03-29-persona-send-list) for configuration and usage details.

--- a/docs/blog/2026-03-29-persona-send-list.mdx
+++ b/docs/blog/2026-03-29-persona-send-list.mdx
@@ -1,0 +1,152 @@
+---
+title: "persona_send and persona_list — A Practical Guide"
+date: 2026-03-29
+description: How to configure and use the two new host tools that enable agent-to-agent delegation. Config examples, call patterns, and what happens when await_reply is true.
+---
+
+# persona_send and persona_list — A Practical Guide
+
+Two new host tools shipped this week: `persona_send` and `persona_list`. Both require the `persona.send:*` capability. Neither requires any infrastructure changes — they run on the same internal queue and SQLite database as everything else.
+
+## Enabling the tools
+
+Add `persona.send:*` to the persona's capability allow list:
+
+```yaml
+personas:
+  - name: coordinator
+    model: claude-sonnet-4-6
+    systemPromptFile: personas/coordinator/system.md
+    capabilities:
+      allow:
+        - memory.access:thread
+        - net.http:egress
+        - persona.send:*   # enables both persona_send and persona_list
+```
+
+That single capability unlocks both tools. The target persona — the one receiving delegated tasks — doesn't need any special config. It just needs to be loaded.
+
+## persona_list
+
+Call this first. It returns all currently loaded personas except the caller:
+
+```json
+[
+  {
+    "name": "researcher",
+    "description": "Deep research and web search specialist",
+    "skills": ["web-search"]
+  },
+  {
+    "name": "writer",
+    "description": "Technical writer for docs and blog posts",
+    "skills": ["write"]
+  }
+]
+```
+
+`description` is pulled from the first non-blank line of the persona's system prompt file, with the `#` prefix stripped. If no system prompt file exists, `description` is `null`. Skills come from the persona's YAML config.
+
+The list reflects live-loaded personas only. If a persona is in the database but not currently running, it won't appear here.
+
+## persona_send — fire-and-forget
+
+`await_reply: false` is the default. The tool submits the task and returns immediately:
+
+```json
+{
+  "target_persona": "researcher",
+  "message": "Find the latest benchmarks comparing Bun and Node.js for HTTP workloads.",
+  "await_reply": false
+}
+```
+
+Response:
+
+```json
+{
+  "task_id": "01HXYZ...",
+  "state": "submitted"
+}
+```
+
+The task is in the queue. The researcher will process it when it gets there. You don't get the result — useful for background work where the calling persona doesn't need to wait.
+
+## persona_send — synchronous delegation
+
+`await_reply: true` blocks until the target finishes:
+
+```json
+{
+  "target_persona": "researcher",
+  "message": "Summarize the key changes in the Node.js 24 release notes.",
+  "await_reply": true
+}
+```
+
+The tool polls every 2 seconds, up to 25 seconds. If the task completes in time:
+
+```json
+{
+  "task_id": "01HXYZ...",
+  "state": "completed",
+  "result": "Node.js 24 ships with V8 13.6, drops support for..."
+}
+```
+
+If the target doesn't finish within 25 seconds:
+
+```json
+{
+  "task_id": "01HXYZ...",
+  "state": "timeout"
+}
+```
+
+Timeout doesn't cancel the task — it keeps running. You just don't get the result inline. For long-running work, fire-and-forget is the right pattern.
+
+If the target ends up in `input-required` state (it's waiting for human input), that surfaces too:
+
+```json
+{
+  "task_id": "01HXYZ...",
+  "state": "input-required"
+}
+```
+
+## Hop count and cycle prevention
+
+Every `persona_send` call increments the hop counter in the task's execution context. Maximum is 4. If a chain reaches hop 4, the next delegation attempt is rejected before it enters the queue:
+
+```
+A → B (hop 1) → C (hop 2) → D (hop 3) → E (rejected at hop 4)
+```
+
+This applies even if you're not trying to create a cycle — four levels of delegation is the hard limit. Design your workflows accordingly.
+
+## Full config example
+
+```yaml
+personas:
+  - name: coordinator
+    model: claude-sonnet-4-6
+    systemPromptFile: personas/coordinator/system.md
+    capabilities:
+      allow:
+        - memory.access:thread
+        - persona.send:*
+        - channel.send:my-slack
+
+  - name: researcher
+    model: claude-sonnet-4-6
+    systemPromptFile: personas/researcher/system.md
+    capabilities:
+      allow:
+        - memory.access:thread
+        - net.http:egress
+        # researcher doesn't have persona.send — it can't delegate further
+```
+
+The coordinator can delegate. The researcher receives tasks but can't re-delegate. Clean separation.
+
+For the architecture behind these tools, see [A2A — Agent-to-Agent Communication in Talon](./2026-03-28-a2a-protocol).

--- a/docs/blog/2026-03-29-sprint-recap.mdx
+++ b/docs/blog/2026-03-29-sprint-recap.mdx
@@ -1,0 +1,77 @@
+---
+title: "What We Shipped This Week — 2026-03-28/29"
+date: 2026-03-29
+description: A2A protocol, persona tools, queue fixes, and a full docs site. Quick changelog of everything that landed in the past two days.
+---
+
+# What We Shipped This Week — 2026-03-28/29
+
+Two days, eight merged PRs, ~4000 lines. Here's what landed.
+
+---
+
+## A2A Protocol — Milestone 1 ([#116](https://github.com/ivo-toby/talon/issues/116))
+
+Personas can now delegate tasks to each other over Talon's internal queue. The A2A layer is fully durable — tasks persist in SQLite, survive restarts, and go through the same retry logic as regular messages.
+
+Milestone 1 covers internal routing only: persona-to-persona delegation within a single daemon instance. The Hono HTTP server, Agent Cards, and external A2A endpoints are Milestone 2 ([#124](https://github.com/ivo-toby/talon/issues/124)).
+
+---
+
+## persona_send — MCP Host Tool ([#126](https://github.com/ivo-toby/talon/issues/126))
+
+New host tool: `persona_send`. Agents call it to submit tasks to other personas. Supports fire-and-forget (`await_reply: false`) and synchronous delegation (`await_reply: true`, 25s cap, 2s poll interval).
+
+The capability gate is `persona.send:*` — add it to a persona's allow list to unlock the tool.
+
+---
+
+## persona_list — Discovery Tool ([#130](https://github.com/ivo-toby/talon/issues/130))
+
+Companion to `persona_send`. Returns all live-loaded personas (excluding the caller) with name, description, and skills. Description is extracted from the first line of the persona's system prompt file.
+
+Agents use this to decide who to delegate to before calling `persona_send`.
+
+---
+
+## Queue Inflight Lock Bypass for A2A Collaboration
+
+Fixed a deadlock that occurred under `await_reply: true`. When persona A submits a task to B and waits for the result, A holds its queue item's inflight lock. If the queue processor refused to dequeue B's item while A was running, everything stalled.
+
+The fix: A2A collaboration items bypass the inflight lock check so they can be dequeued and processed while the source task is still in-flight.
+
+---
+
+## Configurable Query Timeout ([#117](https://github.com/ivo-toby/talon/issues/117))
+
+`DEFAULT_QUERY_TIMEOUT_MS` was 3 minutes. That's too short for complex tasks. It's now 10 minutes by default, configurable per persona via `queryTimeoutMinutes` in `talond.yaml`:
+
+```yaml
+personas:
+  - name: researcher
+    queryTimeoutMinutes: 20
+```
+
+The 3-minute default was causing silent failures on longer agent runs.
+
+---
+
+## input-required State in persona_send Polling
+
+When a target persona enters `input-required` state (waiting for human confirmation), that state now surfaces in the `persona_send` polling response. Previously it would just keep polling until timeout.
+
+---
+
+## Hop Count Propagation
+
+Hop count propagates through the tool execution context. Each `persona_send` call increments it. Tasks rejected at `MAX_HOPS` (4) get a clear error message. The counter flows correctly through nested delegation chains.
+
+---
+
+## Full Docs Site ([talond.dev](https://talond.dev))
+
+Docs shipped at talond.dev. Starlight (Astro) site covering installation, configuration, channels, personas, skills, scheduling, background agents, and A2A. Including this blog.
+
+---
+
+That's the week. Next up: A2A Milestone 2 (external HTTP endpoint + authentication) and M3 (runtime monitoring UI).

--- a/docs/blog/index.mdx
+++ b/docs/blog/index.mdx
@@ -1,0 +1,31 @@
+---
+title: Blog
+description: Updates, feature announcements, and technical deep dives from the Talon project
+---
+
+# Blog
+
+Technical updates from the Talon project. New features, architectural decisions, and the occasional opinion.
+
+---
+
+## Posts
+
+### [What We Shipped This Week — 2026-03-28/29](./2026-03-29-sprint-recap)
+*2026-03-29*
+
+A2A protocol, persona tools, queue fixes, and a full docs site. Quick changelog of everything that landed in the past two days.
+
+---
+
+### [persona_send and persona_list — A Practical Guide](./2026-03-29-persona-send-list)
+*2026-03-29*
+
+How to configure and use the two new host tools that enable agent-to-agent delegation. Config examples, call patterns, and what happens when `await_reply: true`.
+
+---
+
+### [A2A — Agent-to-Agent Communication in Talon](./2026-03-28-a2a-protocol)
+*2026-03-28*
+
+Talon now has a durable A2A layer. Personas can delegate tasks to each other over an internal queue, with hop enforcement and persistence across restarts.


### PR DESCRIPTION
Sets up a \`docs/blog/\` section and adds 3 inaugural posts covering the features shipped 2026-03-28/29.

## Posts

- **A2A — Agent-to-Agent Communication** — architecture overview: how the durable A2A layer works, hop enforcement, sync vs async delegation, discovery via persona_list
- **persona_send and persona_list — A Practical Guide** — config examples, call patterns, await_reply behavior, hop limits
- **What We Shipped This Week** — changelog for everything that landed: A2A M1 (#116), configurable timeout (#117), persona_send (#126), persona_list (#130), queue deadlock fix, input-required state, docs site

## Structure

No Astro project in this repo — docs are plain MDX files. Blog is \`docs/blog/\` with an index page and date-prefixed posts. Matches existing frontmatter pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)