### PR TITLE
feat(background-agent): inject channelContext and timeContext

### DIFF
--- a/src/subagents/background/background-agent-manager.ts
+++ b/src/subagents/background/background-agent-manager.ts
@@ -20,6 +20,10 @@ export interface SpawnBackgroundAgentInput {
   prompt: string;
   personaPrompt: string;
   threadContext?: string;
+  /** Pre-formatted channel list so the background agent knows which channels are available. */
+  channelContext?: string;
+  /** Pre-formatted timestamp string so the background agent can reason about time. */
+  timeContext?: string;
   mcpServers: Record<string, CanonicalMcpServer>;
   personaId: string;
   workerPersonaId: string;
@@ -175,6 +179,8 @@ export class BackgroundAgentManager {
       threadId: input.threadId,
       channelName: input.channelName,
       threadContext: input.threadContext,
+      channelContext: input.channelContext,
+      timeContext: input.timeContext,
     });
 
     const sandboxContextResult = input.sandbox
@@ -723,9 +729,13 @@ export class BackgroundAgentManager {
     threadId: string;
     channelName: string;
     threadContext?: string;
+    channelContext?: string;
+    timeContext?: string;
   }): string {
     return [
       options.personaPrompt,
+      options.channelContext || '',
+      options.timeContext || '',
       '## Background Task Context',
       `Task ID: ${options.taskId}`,
       `Thread ID: ${options.threadId}`,

--- a/src/tools/host-tools/background-agent.ts
+++ b/src/tools/host-tools/background-agent.ts
@@ -161,6 +161,34 @@ export class BackgroundAgentHandler {
       return this.errorResult(requestId, `Channel not found: ${threadResult.value.channel_id}`);
     }
 
+    // Build channel context so the background agent knows which channels are available.
+    const currentChannelName = channelResult.value.name;
+    const enabledChannelsResult = this.deps.channelRepository.findEnabled();
+    const allChannelNames = enabledChannelsResult.isOk()
+      ? enabledChannelsResult.value.map((c) => c.name)
+      : [currentChannelName];
+    const channelContext = [
+      'Available channels for channel_send tool:',
+      ...allChannelNames.map((name) =>
+        name === currentChannelName ? `  - ${name} (current thread)` : `  - ${name}`,
+      ),
+      `When sending messages, use channelId: "${currentChannelName}".`,
+    ].join('\n');
+
+    // Generate fresh timestamp so the background agent can reason about time.
+    const now_ = new Date();
+    const pad = (n: number): string => String(n).padStart(2, '0');
+    const offsetMin = now_.getTimezoneOffset();
+    const offsetSign = offsetMin <= 0 ? '+' : '-';
+    const absOffset = Math.abs(offsetMin);
+    const offsetStr = `${offsetSign}${pad(Math.floor(absOffset / 60))}:${pad(absOffset % 60)}`;
+    const localISO = `${now_.getFullYear()}-${pad(now_.getMonth() + 1)}-${pad(now_.getDate())}T${pad(now_.getHours())}:${pad(now_.getMinutes())}:${pad(now_.getSeconds())}${offsetStr}`;
+    const tzAbbr = Intl.DateTimeFormat('en', { timeZoneName: 'short' })
+      .formatToParts(now_)
+      .find((p) => p.type === 'timeZoneName')?.value ?? 'UTC';
+    const dayName = now_.toLocaleDateString('en', { weekday: 'long' });
+    const timeContext = `Current time: ${localISO} (${tzAbbr}, ${dayName})`;
+
     const loadedPersona = loadedPersonaResult.value;
     const workerPersonaRowResult = profileName
       ? this.deps.personaRepository.findByName(targetPersonaName)
@@ -231,6 +259,8 @@ export class BackgroundAgentHandler {
       prompt: args.prompt,
       personaPrompt: runtimeContext.personaPrompt,
       threadContext: previousContext,
+      channelContext,
+      timeContext,
       mcpServers: runtimeContext.mcpServers,
       personaId: context.personaId,
       workerPersonaId: workerPersonaRowResult.value.id,

--- a/tests/unit/subagents/background/background-agent-manager.test.ts
+++ b/tests/unit/subagents/background/background-agent-manager.test.ts
@@ -213,6 +213,42 @@ describe('BackgroundAgentManager', () => {
     expect(options.stdin).toBe('Refactor the auth module');
   });
 
+  it('includes channelContext in the system prompt when provided', async () => {
+    const manager = createManager();
+
+    await manager.spawn({
+      ...spawnInput,
+      channelContext: 'Available channels for channel_send tool:\n  - telegram-main (current thread)\n  - slack-general\nWhen sending messages, use channelId: "telegram-main".',
+    });
+
+    const systemPrompt = prepareBackgroundInvocation.mock.calls[0]?.[0]?.systemPrompt as string;
+    expect(systemPrompt).toContain('Available channels for channel_send tool:');
+    expect(systemPrompt).toContain('telegram-main (current thread)');
+    expect(systemPrompt).toContain('slack-general');
+  });
+
+  it('includes timeContext in the system prompt when provided', async () => {
+    const manager = createManager();
+
+    await manager.spawn({
+      ...spawnInput,
+      timeContext: 'Current time: 2026-03-30T15:04:13+02:00 (CEST, Monday)',
+    });
+
+    const systemPrompt = prepareBackgroundInvocation.mock.calls[0]?.[0]?.systemPrompt as string;
+    expect(systemPrompt).toContain('Current time: 2026-03-30T15:04:13+02:00 (CEST, Monday)');
+  });
+
+  it('omits channelContext and timeContext sections when not provided', async () => {
+    const manager = createManager();
+
+    await manager.spawn(spawnInput);
+
+    const systemPrompt = prepareBackgroundInvocation.mock.calls[0]?.[0]?.systemPrompt as string;
+    expect(systemPrompt).not.toContain('Available channels for channel_send tool:');
+    expect(systemPrompt).not.toContain('Current time:');
+  });
+
   it('provisions a sandbox env, injects host tools, and uses the control directory as cwd', async () => {
     const executionEnvManager = {
       create: vi.fn().mockResolvedValue(ok({

--- a/tests/unit/tools/background-agent.test.ts
+++ b/tests/unit/tools/background-agent.test.ts
@@ -95,6 +95,11 @@ function createHandler(overrides: Record<string, unknown> = {}) {
           name: 'telegram-main',
         }),
       ),
+      findEnabled: vi.fn().mockReturnValue(
+        ok([
+          { id: 'channel-1', name: 'telegram-main' },
+        ]),
+      ),
     } as any,
     skillResolver: {
       mergePromptFragments: vi.fn().mockReturnValue('Skill instructions.'),

--- a/tests/unit/tools/host-tools-bridge.test.ts
+++ b/tests/unit/tools/host-tools-bridge.test.ts
@@ -221,6 +221,10 @@ describe('HostToolsBridge', () => {
     } as any;
     mockCtx.repos.channel = {
       findById: vi.fn().mockReturnValue(ok({ id: 'channel-001', name: 'telegram-main' })),
+      findEnabled: vi.fn().mockReturnValue(ok([
+        { id: 'channel-001', name: 'telegram-main' },
+        { id: 'channel-002', name: 'slack-general' },
+      ])),
     } as any;
   });
 


### PR DESCRIPTION
## Summary
- Background agents were missing the channel list and current time context that foreground agents receive, so they couldn't use `channel_send` effectively or reason about dates/times.
- Added optional `channelContext` and `timeContext` fields to `SpawnBackgroundAgentInput`, built in the tool handler from `channelRepository.findEnabled()` and a fresh timestamp.
- Both are injected into `buildSystemPrompt()` between the persona prompt and background task context, and gracefully omitted when not provided.

## Test plan
- [x] 3 new unit tests: channelContext inclusion, timeContext inclusion, omission when not provided
- [x] Existing test mocks updated (`findEnabled` added to channel repo mocks)
- [x] Full test suite: **148 files passed, 2735 tests passed, 0 failures**
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Codex review: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)