### PR TITLE
feat(prompts): enrich background agent tool instructions

### DIFF
--- a/templates/tool-instructions/subagent.background.md
+++ b/templates/tool-instructions/subagent.background.md
@@ -1,6 +1,33 @@
 ## Background Agents
 
-You can delegate work to specialized background agents. Use
-`background_agent action="profiles"` to discover what profiles are available.
-When asked about your capabilities or what agents you can use, always check
-profiles first rather than guessing.
+Use `background_agent` for long-running tasks. They don't block the
+conversation — the user gets an immediate response while work happens async.
+Use `background_agent action="profiles"` to discover available profiles.
+
+**When to use background agents** (3+ tool calls, no mid-way clarification needed):
+- Writing or updating notes, documents, or prompts
+- Research tasks (searching across multiple systems, compiling context)
+- Code review or analysis of large changesets
+- Multi-step tasks where the user doesn't need the result right now
+- Tasks that will fill up your context window while executing
+- Tasks involving file reads, edits, builds, tests — i.e. any coding work
+
+**When NOT to use them:**
+- Quick lookups (one tool call, instant answer)
+- Tasks that can be handled by sub-agents
+- Tasks where the user is waiting for the result to continue their thought
+- Interactive back-and-forth that requires clarification
+
+**Decision rule:** If the task involves more than ~3 tool calls and doesn't
+require user input mid-way, use a background agent. When in doubt, use a
+background agent. The cost of blocking the conversation is higher than the
+cost of spawning an agent.
+
+**Pattern:** Acknowledge the request immediately, spawn the agent, continue
+the conversation. Check the result when notified or when the user asks.
+
+**Prompt quality matters:** Give background agents full context — don't
+assume they know what you know. Include: file paths, what to change,
+expected outcomes, and the full sequence of steps. A well-prompted
+background agent should complete the task without coming back for
+clarification.


### PR DESCRIPTION
## Summary
- Promotes background agent decision rules, when-to-use guidance, and prompt quality tips from the assistant persona prompt into `templates/tool-instructions/subagent.background.md`
- All personas with `subagent.background` capability now get this guidance automatically via capability-gated injection (#142)

## Context
Companion to VM-side persona prompt cleanup: removed hardcoded `## Sub-Agents`, `## Background Agents`, and `## Host Tools Reference` sections from assistant, software-engineer, and webmaster prompts — now handled by tool instructions.

## Test plan
- [x] Content-only change (markdown template), no code affected
- [x] Builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)