### PR TITLE
fix(tools): clarify schedule_manage is durable, not session-bound

### DIFF
--- a/src/tools/host-tools-mcp-server.ts
+++ b/src/tools/host-tools-mcp-server.ts
@@ -208,7 +208,7 @@ class SocketClient {
 const TOOLS = [
   {
     name: 'schedule_manage',
-    description: 'Creates, updates, cancels, or lists scheduled tasks on behalf of a persona.',
+    description: 'Creates, updates, cancels, or lists scheduled tasks on behalf of a persona. Schedules are durable — persisted in SQLite and survive session resets and daemon restarts. Use this instead of CronCreate/CronDelete, which are session-bound and disappear when the conversation ends.',
     inputSchema: {
       type: 'object' as const,
       properties: {


### PR DESCRIPTION
## Summary

- Adds a clarification to the `schedule_manage` tool description: schedules are durable (SQLite-backed) and survive session resets and daemon restarts
- Explicitly warns against `CronCreate`/`CronDelete`, which are session-bound

## Why

A persona used Claude Code's native `CronCreate` instead of `schedule_manage`, then correctly warned the user that the crons were "session-bound". The tool description gave no hint that `schedule_manage` is the durable alternative.

Fixing this at the tool level means all personas benefit automatically — no persona-specific prompt guidance needed.

## Changes

`src/tools/host-tools-mcp-server.ts` — one-line description update for `schedule_manage`.

## Related

Spotted during investigation of #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)