### PR TITLE
[codex] implement workflow kernel sidecar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Channel Connector → MessagePipeline (normalize, dedup, route, persist)
 | Personas  | `src/personas/`            | Persona config loading + capability merging                         |
 | Skills    | `src/skills/`              | Declarative skill bundles with lazy loading (metadata-only in system prompt, full content on demand via `skill_load` tool) |
 | SubAgents | `src/subagents/`           | Loader, model resolver, runner with per-subagent model overrides and failover |
+| Workflow  | `src/workflow/`            | Workflow kernel service, policy packs, watchdogs, evidence adapters, read models |
 | Config    | `src/core/config/`         | Zod-validated YAML config loader (`config-schema.ts` is the schema) |
 | Database  | `src/core/database/`       | better-sqlite3 wrapper, 14 repositories, SQL migrations             |
 | IPC       | `src/ipc/`                 | Unix socket daemon↔CLI communication                                |
@@ -66,13 +67,13 @@ Channel Connector → MessagePipeline (normalize, dedup, route, persist)
 
 ### Database
 
-Schema in `src/core/database/migrations/001-initial-schema.sql`. Key tables: `channels`, `personas`, `bindings` (channel↔persona routing), `threads`, `messages`, `queue_items`, `runs`, `schedules`, `memory_items`, `artifacts`, `audit_log`, `tool_results`.
+Schema in `src/core/database/migrations/001-initial-schema.sql` plus follow-on numbered migrations. Key tables: `channels`, `personas`, `bindings` (channel↔persona routing), `threads`, `messages`, `queue_items`, `runs`, `schedules`, `memory_items`, `artifacts`, `audit_log`, `tool_results`, `a2a_tasks`, and the workflow tables (`workflow_items`, `workflow_claims`, `workflow_evidence`, `workflow_events`, `workflow_leases`, `workflow_interventions`).
 
 Table names to know: `memory_items` (not `memory`), `schedules` (column `expression` not `cron_expression`).
 
 ### Config
 
-YAML config validated by Zod schema in `config-schema.ts`. Supports `${ENV_VAR}` substitution. Example at `config/talond.example.yaml`.
+YAML config validated by Zod schema in `config-schema.ts`. Supports `${ENV_VAR}` substitution. Example at `config/talond.example.yaml`. Workflow rollout and watchdog settings live under the top-level `workflow` key.
 
 ## Code Conventions
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It is built for single-user or small-team deployments where you want persistent,
 - **Per-thread memory** — Each conversation thread gets its own workspace with transcript, working memory, and artifacts
 - **Skills** — Modular prompt and tool bundles with lazy loading (metadata-only in system prompt, full content on demand)
 - **MCP integration** — Connect external MCP tool servers via stdio, policy-enforced through host-tools bridge
+- **Workflow kernel sidecar** — Durable workflow items, claims, evidence, leases, watchdog checks, and one narrow authoritative orchestrator-task rollout
 
 ### Provider abstraction
 
@@ -397,6 +398,7 @@ dataDir: data
 | `queue`                | Retry/backoff/concurrency controls for durable queue processing               |
 | `agentRunner`          | Foreground provider config, including provider-scoped context management      |
 | `backgroundAgent`      | Enable and tune long-running background provider workers                      |
+| `workflow`             | Durable workflow kernel rollout, policy-pack bindings, and watchdog settings  |
 | `personas`             | Persona profiles: model, system prompt, skills, capabilities                  |
 | `channels`             | Channel connector entries with `type`, `name`, and connector `config` payload |
 | `bindings`             | Channel-to-persona routing with default persona per channel                   |
@@ -408,6 +410,32 @@ dataDir: data
 | `logLevel` / `dataDir` | Runtime logging level and data root                                           |
 
 For the context-management strategies and migration details, see [docs/context-management.md](docs/context-management.md).
+
+### Workflow kernel
+
+Talon now includes a domain-agnostic workflow sidecar. It stores workflow items, claims, evidence, append-only events, leases, and interventions in SQLite. The sidecar defaults to `observe` mode so it can track state without blocking the existing runtime path.
+
+The first authoritative rollout is intentionally narrow: explicit orchestrator delegations created through `persona_send` with `workflow_type: "orchestrator_task"`. That path creates a durable workflow item, links it to the A2A task, records A2A evidence, and enforces an evidence gate before authoritative completion transitions are accepted.
+
+You can inspect the current summary with `talonctl status` and list the operational rows with `talonctl list-workflows --db data/talond.sqlite`.
+
+Example configuration:
+
+```yaml
+workflow:
+  enabled: true
+  defaultRolloutMode: observe
+  defaultPolicyPack: observe-only
+  bindings:
+    - workflowType: orchestrator_task
+      policyPack: orchestrator-task
+      rolloutMode: authoritative
+  watchdog:
+    enabled: true
+    evaluationIntervalMs: 30000
+    freshnessThresholdMs: 900000
+    claimRejectionThreshold: 2
+```
 
 ### Environment Variable Substitution
 
@@ -2557,7 +2585,8 @@ Examples:
   "target_persona": "work-context-manager",
   "message": "Fetch the latest Jira and Confluence updates",
   "await_reply": true,
-  "timeout_ms": 300000
+  "timeout_ms": 300000,
+  "workflow_type": "orchestrator_task"
 }
 ```
 

--- a/config/talond.example.yaml
+++ b/config/talond.example.yaml
@@ -212,6 +212,20 @@ backgroundAgent:
         defaultModel: qwen3-coder:30b
         providerId: ollama
 
+workflow:
+  enabled: false
+  defaultRolloutMode: observe
+  defaultPolicyPack: observe-only
+  bindings:
+    - workflowType: orchestrator_task
+      policyPack: orchestrator-task
+      rolloutMode: authoritative
+  watchdog:
+    enabled: true
+    evaluationIntervalMs: 30000
+    freshnessThresholdMs: 900000
+    claimRejectionThreshold: 2
+
 scheduler:
   tickIntervalMs: 5000
 

--- a/specs/2026-04-04-domain-agnostic-workflow-kernel.md
+++ b/specs/2026-04-04-domain-agnostic-workflow-kernel.md
@@ -37,7 +37,7 @@ This spec proposes a **domain-agnostic workflow kernel sidecar** that bolts onto
 - Rewrite the queue, scheduler, or background-agent architecture before the sidecar proves value.
 - Force all work types into one rigid lifecycle.
 - Solve multi-agent planning quality through schema alone.
-- Implement this design in this branch.
+- Implement this design as part of this spec branch review cycle; implementation is expected later, after the spec is reviewed and approved.
 
 ## 4. Design Principles
 

--- a/specs/2026-04-04-domain-agnostic-workflow-kernel.md
+++ b/specs/2026-04-04-domain-agnostic-workflow-kernel.md
@@ -592,6 +592,11 @@ That is enough to prove the architecture before Talon makes the kernel authorita
 
 The next artifact after this spec should be a technical design, not an implementation plan.
 
+That follow-on work now exists in:
+
+- `specs/2026-04-04-workflow-kernel-technical-design.md`
+- `specs/plans/2026-04-04-workflow-kernel-implementation-plan.md`
+
 The spec now defines the problem, the concepts, and the product direction. A technical design should narrow that into:
 
 - concrete database changes

--- a/specs/2026-04-04-domain-agnostic-workflow-kernel.md
+++ b/specs/2026-04-04-domain-agnostic-workflow-kernel.md
@@ -461,15 +461,122 @@ Success criteria:
 
 The mitigation is to start narrow, keep the kernel sidecar-only at first, and introduce authoritative transitions only after the observed model is stable.
 
-## 16. Open Questions
+## 16. Review Decisions
 
-1. Should workflow items be created explicitly by personas, implicitly by scheduler rules, or both?
-2. What is the smallest claim/evidence schema that still improves reliability?
-3. Should policy packs live in code, config, plugins, or a hybrid model?
-4. How should claim/evidence capture integrate with MCP tool outputs and background-agent results?
-5. Which existing Talon workflow should be the first authoritative rollout candidate?
+### 16.1 Workflow item creation
 
-## 17. Recommendation
+Initially, workflow items should be created explicitly by personas, not implicitly by scheduler rules. The personas are the domain experts when prompted correctly, and they are in the best position to decide when work should become a first-class tracked item.
+
+Scheduler-created workflow items may be introduced later for narrowly defined system concerns such as stale-work intervention, automatic retries, or lease-based escalation, but they should not be the starting point for the model.
+
+### 16.2 Smallest useful claim and evidence schema
+
+The smallest useful schema is not fixed by domain semantics alone. Simple tasks such as creating a calendar appointment have a much smaller claim and evidence surface than complex workflows such as shipping a software feature.
+
+The kernel should therefore require a minimal core schema and allow domain packs to extend it:
+
+- claim core: `actor`, `action`, `target`, `asserted_outcome`, `timestamp`
+- evidence core: `type`, `source`, `locator`, `captured_at`, `provenance`
+
+This keeps the kernel generic while allowing policy packs to demand richer structured evidence where the domain requires it.
+
+### 16.3 Policy-pack placement
+
+Policy packs should use a hybrid placement model:
+
+- code owns the kernel contract, state machine enforcement, leases, watchdog rules, and transition validation
+- config owns pack selection, thresholds, rollout flags, and default bindings
+- plugins own domain-specific schemas, prompts, helper logic, and extension points
+
+This keeps the control plane deterministic without forcing every domain-specific behavior into Talon's core.
+
+### 16.4 MCP tools and background agents
+
+Claim and evidence capture should remain the responsibility of the agent that invokes MCP tools or spawns background agents. That agent is responsible for proving that the work is complete and for attaching the relevant evidence to the workflow item.
+
+If a background agent cannot complete the work, or if the calling agent lacks the tools or permissions to complete or verify the task itself, the kernel should record that as failed or blocked work. The watchdog layer should treat that as an intervention condition rather than allowing the work to remain in an ambiguous state.
+
+### 16.5 First authoritative rollout candidate
+
+The first authoritative rollout should be the orchestrator task lifecycle rather than the software engineering workflow.
+
+The orchestrator path already has the right shape:
+
+- explicit tasks
+- ownership
+- blocked and failed states
+- human review and approval
+- clear transitions between draft, ready, in progress, review, and done
+
+That makes it a better proving ground for authoritative workflow state than software delivery, which has a larger and more failure-prone surface area.
+
+## 17. Deeper Integration
+
+The workflow kernel starts as a sidecar. Deeper integration begins when Talon stops treating workflow state as an observational layer and starts using it as the canonical substrate for coordination.
+
+At that point:
+
+- personas emit claims against workflow items rather than only sending conversational status updates
+- MCP calls and background-agent runs produce evidence records with provenance that can be attached to claims
+- scheduler and heartbeat logic evaluate workflow state and policy rather than inferring progress from transcript text alone
+- human approvals, rejections, and escalations operate on workflow items directly
+- queueing, retries, and watchdog interventions become visible consequences of workflow state instead of separate hidden mechanisms
+
+The important boundary is that deeper integration should not require every tool or persona to understand the full kernel model. Helper APIs or host tools should make it easy to create claims, attach evidence, and transition state without forcing repeated boilerplate into prompts.
+
+## 18. End-User Visibility
+
+If this system becomes a real control plane, its state and transitions must be visible to the user without requiring transcript archaeology.
+
+Two visibility surfaces are required:
+
+### 18.1 Real-time operational view
+
+This view should show:
+
+- active workflow items
+- current state
+- assigned persona or owner
+- latest claim
+- latest evidence
+- current blocker or failure reason
+- lease expiry or stale-work deadline
+- next expected transition
+
+This is the view that answers, "What is happening right now?"
+
+### 18.2 Audit view
+
+This view should be append-only and reconstructable. It should show:
+
+- workflow item creation
+- every claim
+- every evidence attachment
+- every accepted or rejected transition
+- policy decisions
+- watchdog interventions
+- human approvals and rejections
+
+This is the view that answers, "Why did the system believe this work advanced, stall, or finish?"
+
+The dashboard should eventually expose both views in a way that supports drill-down from high-level company operations into a single item's full history.
+
+## 19. Relationship To Force
+
+This workflow kernel is a foundational building block for the Force concept.
+
+If Force is a digital representation of a company running on agents, then it needs more than message routing and persona prompts. It needs:
+
+- durable goals and work items
+- delegated ownership
+- explicit claims of progress
+- evidence attached to those claims
+- policy-based approval and escalation
+- end-user visibility into state, flow, and history
+
+Without those pieces, Force risks becoming an impressive chat surface without a reliable operating model. With them, it can evolve into a company-level control plane where goals, work, agents, approvals, and outcomes are all durable and inspectable.
+
+## 20. Recommendation
 
 Build this as a bolt-on sidecar, not as a rewrite. The smallest useful version is:
 
@@ -482,3 +589,15 @@ Build this as a bolt-on sidecar, not as a rewrite. The smallest useful version i
 - heartbeat prompts driven by workflow state
 
 That is enough to prove the architecture before Talon makes the kernel authoritative.
+
+The next artifact after this spec should be a technical design, not an implementation plan.
+
+The spec now defines the problem, the concepts, and the product direction. A technical design should narrow that into:
+
+- concrete database changes
+- host-tool or API surfaces for claim and evidence capture
+- dashboard data model and event stream shape
+- rollout boundaries for the first authoritative orchestrator workflow
+- migration strategy from observational sidecar to authoritative control
+
+After that design exists, an implementation plan can break the work into phases, tasks, and checkpoints. If you intend to implement this yourself in Claude Code to build intuition, that is the right sequence. It gives you a stronger mental model before you start making irreversible schema and orchestration decisions.

--- a/specs/2026-04-04-domain-agnostic-workflow-kernel.md
+++ b/specs/2026-04-04-domain-agnostic-workflow-kernel.md
@@ -1,0 +1,484 @@
+# Domain-Agnostic Workflow Kernel Sidecar
+
+**RFC** | 2026-04-04 | Talon Project
+**Status**: Draft v1
+**GitHub Issue**: https://github.com/ivo-toby/talon/issues/175
+**Last updated**: 2026-04-04
+
+---
+
+## 1. Problem Statement
+
+Talon can already drive long-running work with scheduled prompts and heartbeat-style reviews, but those prompts are advisory. They can ask an agent or persona to inspect work, summarize progress, or check alignment, yet they do not provide a durable control plane.
+
+This creates a reliability gap:
+
+- a prompt can be missed, misread, or interpreted incorrectly
+- the system cannot prove that required checkpoints were met
+- state transitions are implicit in conversation rather than explicit in data
+- stale or drifting work is hard to detect without re-reading transcripts
+- retries and escalations are probabilistic instead of policy-driven
+
+The result is that Talon has useful supervision, but not a workflow kernel.
+
+This spec proposes a **domain-agnostic workflow kernel sidecar** that bolts onto Talon's current execution model. The kernel provides durable state, event logging, claims, evidence, leases, and watchdog rules. Personas continue to do the work they do today; the new layer decides what is allowed to advance, what is stale, and what intervention is required.
+
+## 2. Goals
+
+1. Add a generic control layer for autonomous work that is not specific to software engineering.
+2. Keep the first phase bolt-on and compatible with Talon's current personas, scheduler, and queue model.
+3. Make progress depend on explicit claims plus durable evidence, not only on conversational assertions.
+4. Support domain-specific policy packs without forcing domain logic into the core kernel.
+5. Make heartbeats more useful by grounding them in structured state instead of free-form transcript review.
+
+## 3. Non-Goals
+
+- Replace the current persona model in the first iteration.
+- Rewrite the queue, scheduler, or background-agent architecture before the sidecar proves value.
+- Force all work types into one rigid lifecycle.
+- Solve multi-agent planning quality through schema alone.
+- Implement this design in this branch.
+
+## 4. Design Principles
+
+### 4.1 Deterministic control, probabilistic reasoning
+
+LLMs remain responsible for interpretation, diagnosis, planning, and proposal. The kernel is responsible for durable state, lifecycle guards, retries, leases, and intervention triggers.
+
+### 4.2 Claims do not advance work by themselves
+
+An agent saying "this is done" is a claim, not a state transition. Advancement requires policy evaluation against available evidence.
+
+### 4.3 Domain semantics live in policy packs
+
+The kernel only understands generic concepts such as states, claims, evidence, interventions, and role permissions. Software delivery, research, PM planning, or support triage semantics live outside the kernel in domain policy packs.
+
+### 4.4 Sidecar first
+
+The first implementation should observe and guide the current system before becoming authoritative. This keeps the migration bounded and lowers integration risk.
+
+## 5. Core Abstractions
+
+### 5.1 WorkItem
+
+The unit of work being progressed. A work item has:
+
+- a stable ID
+- a domain type
+- an objective
+- current state
+- declared deliverables
+- actors and ownership metadata
+- deadlines or freshness constraints
+
+### 5.2 Goal
+
+The success condition for a work item. This should be explicit and machine-readable enough to support policy checks, even if some evaluation still requires model judgment.
+
+### 5.3 State
+
+The current lifecycle position. The kernel does not mandate one universal workflow, but it does require explicit states and allowed transitions per workflow type.
+
+Example generic states:
+
+- `intake`
+- `ready`
+- `in_progress`
+- `awaiting_validation`
+- `blocked`
+- `escalated`
+- `done`
+- `cancelled`
+
+### 5.4 Claim
+
+A structured assertion by an actor about progress, findings, completion, blockage, or changed scope.
+
+Examples:
+
+- "I produced a draft spec"
+- "I am blocked on a missing credential"
+- "The deliverable appears complete"
+- "Scope changed and needs approval"
+
+### 5.5 Evidence
+
+Durable artifacts or observations attached to a claim.
+
+Examples:
+
+- file paths
+- test outputs
+- URLs
+- message IDs
+- issue or PR numbers
+- approval records
+- metrics or timestamps
+
+### 5.6 Policy
+
+Rules that determine:
+
+- who may act
+- which transitions are allowed
+- what evidence is required
+- when retries are valid
+- when work is stale
+- when escalation is mandatory
+
+### 5.7 Intervention
+
+A structured action triggered by policy or a watchdog when work becomes stale, inconsistent, or uncertain.
+
+Examples:
+
+- request status audit
+- renew or revoke lease
+- ask for missing evidence
+- requeue work
+- escalate to another persona
+- escalate to a human
+
+### 5.8 Role
+
+A permission boundary for who may create claims, validate evidence, approve scope changes, or close work.
+
+## 6. Why Heartbeat Alone Is Not Enough
+
+Heartbeat prompts are still useful, but they are not sufficient as the primary loop because they are:
+
+- advisory rather than authoritative
+- hard to make idempotent
+- weak at exactly-once transitions
+- poor at enforcing machine-checkable checkpoints
+- vulnerable to silent drift when the model fails to notice a required detail
+
+Heartbeat becomes much stronger once it is reduced to a specific intervention over structured state:
+
+- "audit stale work item `W-123`"
+- "evaluate whether evidence satisfies the goal"
+- "summarize risks before escalation"
+
+That is a better fit than asking the model to infer the entire workflow state from transcript alone.
+
+## 7. Proposed Architecture
+
+```text
+Scheduler / Trigger / External Event
+  -> WorkflowKernel
+       -> loads WorkItem + current state + lease + evidence summary
+       -> evaluates policy
+       -> chooses next action
+            - continue
+            - request claim
+            - validate
+            - wait
+            - retry
+            - escalate
+            - finish
+       -> emits durable workflow events
+  -> Existing Talon execution paths
+       - AgentRunner
+       - background_agent
+       - persona_send
+       - scheduler
+  -> Actor returns claim + evidence
+  -> WorkflowKernel validates transition
+```
+
+The important point is that the kernel does not replace Talon's execution engines. It sits beside them and decides how work should progress.
+
+## 8. Data Model
+
+### 8.1 Tables
+
+Suggested initial tables:
+
+#### `workflow_items`
+
+Top-level work item record.
+
+Fields:
+
+- `id`
+- `workflow_type`
+- `domain`
+- `title`
+- `goal_json`
+- `state`
+- `owner_actor_id`
+- `lease_expires_at`
+- `priority`
+- `created_at`
+- `updated_at`
+- `completed_at`
+
+#### `workflow_events`
+
+Append-only event log.
+
+Fields:
+
+- `id`
+- `workflow_item_id`
+- `event_type`
+- `actor_id`
+- `payload_json`
+- `created_at`
+
+#### `workflow_claims`
+
+Structured claims made by actors.
+
+Fields:
+
+- `id`
+- `workflow_item_id`
+- `claim_type`
+- `actor_id`
+- `summary`
+- `payload_json`
+- `status` (`pending`, `accepted`, `rejected`, `superseded`)
+- `created_at`
+- `resolved_at`
+
+#### `workflow_evidence`
+
+Durable evidence records linked to claims or directly to work items.
+
+Fields:
+
+- `id`
+- `workflow_item_id`
+- `claim_id`
+- `evidence_type`
+- `uri`
+- `payload_json`
+- `created_at`
+
+#### `workflow_policies`
+
+Versioned workflow and domain policy definitions.
+
+Fields:
+
+- `id`
+- `workflow_type`
+- `domain`
+- `version`
+- `definition_json`
+- `active`
+- `created_at`
+
+### 8.2 Event Types
+
+Initial event set:
+
+- `workflow.created`
+- `workflow.state_changed`
+- `workflow.lease_acquired`
+- `workflow.lease_expired`
+- `workflow.claim_submitted`
+- `workflow.claim_accepted`
+- `workflow.claim_rejected`
+- `workflow.evidence_added`
+- `workflow.intervention_requested`
+- `workflow.escalated`
+- `workflow.completed`
+- `workflow.cancelled`
+
+This event log becomes the durable source of truth for supervision and audit.
+
+## 9. Transition Model
+
+Each workflow type defines:
+
+- allowed states
+- allowed transitions
+- required evidence for specific transitions
+- which roles may approve which transitions
+- timeout thresholds and retry limits
+
+Example:
+
+- `ready -> in_progress` may require lease acquisition
+- `in_progress -> awaiting_validation` may require at least one claim with attached evidence
+- `awaiting_validation -> done` may require policy approval and zero unresolved blockers
+- `blocked -> escalated` may occur automatically after a timeout
+
+This allows Talon to stay generic while still supporting strict workflows where needed.
+
+## 10. Leases And Watchdogs
+
+### 10.1 Leases
+
+Every active worker can hold a lease on a work item. The lease records:
+
+- current actor
+- acquired timestamp
+- expiry timestamp
+- last renewal timestamp
+
+If the lease expires without renewal, the kernel does not assume success or failure. It emits `workflow.lease_expired` and evaluates the configured intervention policy.
+
+### 10.2 Watchdogs
+
+Watchdogs are deterministic checks over durable state, not conversational guesses.
+
+Examples:
+
+- no state change for 30 minutes while `in_progress`
+- repeated claim rejection without policy change
+- work item in `awaiting_validation` without validator activity
+- scope changed but no approval claim recorded
+- repeated `blocked -> in_progress -> blocked` oscillation
+
+Watchdogs can schedule interventions without guessing what happened in the transcript.
+
+## 11. Domain Policy Packs
+
+The workflow kernel is generic, but policies are not.
+
+Examples:
+
+### 11.1 Software Delivery
+
+Evidence examples:
+
+- failing test first
+- green test run
+- commit SHA
+- PR URL
+- code review status
+
+Policy examples:
+
+- cannot enter `done` without verification evidence
+- cannot close review feedback without a reply or a justified rejection
+
+### 11.2 Project Management
+
+Evidence examples:
+
+- approved spec
+- dependency resolution notes
+- stakeholder approval
+
+Policy examples:
+
+- scope changes require explicit approval
+- planning cannot complete while dependencies remain unresolved
+
+### 11.3 Research
+
+Evidence examples:
+
+- source links
+- synthesized notes
+- confidence score
+- open questions
+
+Policy examples:
+
+- high-impact recommendations require cited evidence
+- low-confidence findings trigger review instead of completion
+
+The kernel remains stable while domain packs evolve independently.
+
+## 12. Integration With Existing Talon Features
+
+### 12.1 Scheduler
+
+The scheduler should trigger policy evaluation, lease expiry checks, and interventions. It should stop issuing generic "check on this" prompts when a more specific intervention can be derived from workflow state.
+
+### 12.2 AgentRunner And Background Agents
+
+Current execution paths remain unchanged at first. They receive more structured assignments and should emit claims and evidence back into the kernel.
+
+### 12.3 Memory And Conversation History
+
+Conversation remains useful for context, but it is no longer the authoritative store for work progress. Memory can summarize state; the kernel owns state transitions.
+
+### 12.4 Personas
+
+Personas do not need a rewrite in phase 1. They keep producing outputs, but Talon starts asking for structured claims and evidence at key checkpoints.
+
+## 13. Migration Plan
+
+### Phase 1: Observing Sidecar
+
+- add workflow tables and event logging
+- create workflow items for selected task types
+- mirror current state transitions without enforcing them
+- emit lease and watchdog diagnostics only
+
+Success criteria:
+
+- durable visibility into stale work and missing checkpoints
+- no behavior change required for existing personas
+
+### Phase 2: Guided Interventions
+
+- route heartbeat prompts through workflow state
+- replace generic nudges with explicit interventions
+- require claims and evidence for selected transitions
+
+Success criteria:
+
+- fewer silent stalls
+- better auditability for progress and blockage
+
+### Phase 3: Evidence-Gated Workflows
+
+- make policy authoritative for selected workflow types
+- reject unsupported transitions
+- enforce lease expiry and escalation rules
+
+Success criteria:
+
+- completion depends on evidence, not conversational confidence
+- workflow status is reconstructable without transcript review
+
+### Phase 4: Policy-Pack Expansion
+
+- add first-class domain packs for software delivery, PM, research, and support
+- expose policy configuration in Talon config or plugin extension points
+
+## 14. Benefits
+
+- better reliability for autonomous loops
+- better auditability and postmortem quality
+- clearer separation between facts and judgment
+- safer retries and escalations
+- reusable workflow control across domains
+
+## 15. Risks
+
+- over-modeling simple tasks with unnecessary workflow overhead
+- creating two competing sources of truth during migration
+- adding too much schema complexity before one workflow proves out
+- requiring agents to emit structured claims without good UX or helper tooling
+
+The mitigation is to start narrow, keep the kernel sidecar-only at first, and introduce authoritative transitions only after the observed model is stable.
+
+## 16. Open Questions
+
+1. Should workflow items be created explicitly by personas, implicitly by scheduler rules, or both?
+2. What is the smallest claim/evidence schema that still improves reliability?
+3. Should policy packs live in code, config, plugins, or a hybrid model?
+4. How should claim/evidence capture integrate with MCP tool outputs and background-agent results?
+5. Which existing Talon workflow should be the first authoritative rollout candidate?
+
+## 17. Recommendation
+
+Build this as a bolt-on sidecar, not as a rewrite. The smallest useful version is:
+
+- `workflow_items`
+- `workflow_events`
+- `workflow_claims`
+- `workflow_evidence`
+- lease expiry checks
+- one watchdog loop
+- heartbeat prompts driven by workflow state
+
+That is enough to prove the architecture before Talon makes the kernel authoritative.

--- a/specs/2026-04-04-workflow-kernel-technical-design.md
+++ b/specs/2026-04-04-workflow-kernel-technical-design.md
@@ -1,0 +1,513 @@
+# Workflow Kernel Technical Design
+
+**Status**: Draft
+**Date**: 2026-04-04
+**GitHub Issue**: https://github.com/ivo-toby/talon/issues/175
+**Spec**: `specs/2026-04-04-domain-agnostic-workflow-kernel.md`
+
+## 1. Purpose
+
+This document narrows the workflow-kernel RFC into an implementable Talon design. It defines the concrete database model, internal service boundaries, claim and evidence capture APIs, rollout boundaries, and the path from an observational sidecar to authoritative workflow control.
+
+## 2. Design Goals
+
+- Add a durable workflow layer without rewriting Talon's queue, scheduler, persona, or background-agent model.
+- Make claims and evidence first-class, structured records that can be attached to real Talon executions.
+- Keep the kernel deterministic while letting domains evolve through policy packs.
+- Start with explicit persona-created workflow items.
+- Make the first authoritative rollout target narrow enough to prove the model before broad adoption.
+
+## 3. Non-Goals
+
+- No attempt to make all Talon work kernel-native in the first rollout.
+- No requirement that every tool prompt or persona understand the full workflow schema.
+- No full UI implementation in the first slice; this design defines the read model and event feed needed for one.
+- No replacement of transcript history, memory, queue items, or A2A task records as independent runtime artifacts.
+
+## 4. Recommended Architecture
+
+Introduce a new `src/workflow/` module that owns workflow state and policy evaluation while integrating with existing runtime surfaces.
+
+Core components:
+
+- `WorkflowKernelService`
+  - The main API for creating items, recording claims, attaching evidence, requesting transitions, and evaluating due policies.
+- `WorkflowPolicyRegistry`
+  - Resolves policy packs from code, config bindings, and plugin-provided extensions.
+- `WorkflowEvidenceAdapter`
+  - Normalizes tool results, background-task results, A2A task status, message references, and human approvals into workflow evidence records.
+- `WorkflowWatchdog`
+  - Runs deterministic stale-work, timeout, and escalation checks over durable workflow state.
+- `WorkflowReadModel`
+  - Provides operational and audit projections for dashboards, CLI, or host-tool inspection.
+
+The kernel remains a sidecar at first:
+
+- existing execution paths still run through `AgentRunner`, queue processing, `persona.send`, and background-agent flows
+- those paths call workflow helpers to emit claims, evidence, and transition requests
+- policy evaluation decides whether a requested transition is accepted, rejected, or left observational
+
+## 5. Policy Placement Model
+
+The RFC's hybrid model becomes concrete here:
+
+- code owns:
+  - workflow state machine primitives
+  - lease acquisition and expiry rules
+  - event emission
+  - transition validation
+  - watchdog scheduling
+- config owns:
+  - which policy pack is bound to which `workflow_type`
+  - rollout mode per workflow type
+  - thresholds, timeouts, and retry limits
+- plugins own:
+  - domain-specific claim/evidence extensions
+  - prompt guidance
+  - helper validators
+  - custom transition predicates where needed
+
+Policy definitions should not be authored primarily inside the database. The database should store the applied policy identifier and version for auditability, not act as the source authoring surface.
+
+## 6. Concrete Data Model
+
+### 6.1 Tables
+
+#### `workflow_items`
+
+Top-level durable workflow record.
+
+Fields:
+
+- `id`
+- `workflow_type`
+- `domain`
+- `title`
+- `goal_json`
+- `state`
+- `status_reason`
+- `rollout_mode` (`observe`, `guided`, `authoritative`)
+- `policy_pack`
+- `policy_version`
+- `owner_actor_id`
+- `source_thread_id`
+- `source_message_id`
+- `source_run_id`
+- `priority`
+- `created_at`
+- `updated_at`
+- `completed_at`
+
+Notes:
+
+- `rollout_mode` allows the same kernel to operate as a passive observer for some workflow types and an authority for others.
+- `source_*` fields give a stable bridge back to the originating Talon execution context.
+
+#### `workflow_claims`
+
+Structured actor assertions tied to workflow items.
+
+Fields:
+
+- `id`
+- `workflow_item_id`
+- `claim_type`
+- `actor_id`
+- `actor_kind` (`persona`, `human`, `system`, `background_agent`, `tool`)
+- `action`
+- `target`
+- `asserted_outcome`
+- `summary`
+- `payload_json`
+- `status` (`pending`, `accepted`, `rejected`, `superseded`)
+- `policy_decision_json`
+- `created_at`
+- `resolved_at`
+
+The kernel-level required fields are:
+
+- `actor`
+- `action`
+- `target`
+- `asserted_outcome`
+- `timestamp`
+
+Domain packs may require extra payload fields.
+
+#### `workflow_evidence`
+
+Durable evidence records tied to a claim or directly to a workflow item.
+
+Fields:
+
+- `id`
+- `workflow_item_id`
+- `claim_id`
+- `evidence_type`
+- `source`
+- `locator`
+- `captured_at`
+- `provenance_json`
+- `payload_json`
+- `created_at`
+
+The kernel-level required fields are:
+
+- `type`
+- `source`
+- `locator`
+- `captured_at`
+- `provenance`
+
+Examples:
+
+- `source = tool_result`, `locator = tool_result:<id>`
+- `source = background_task`, `locator = task:<task_id>`
+- `source = channel_message`, `locator = message:<id>`
+- `source = git`, `locator = sha:<commit>`
+
+#### `workflow_events`
+
+Append-only event log for audit and projection.
+
+Fields:
+
+- `id`
+- `workflow_item_id`
+- `event_type`
+- `actor_id`
+- `correlation_id`
+- `payload_json`
+- `created_at`
+
+#### `workflow_leases`
+
+Separate lease table instead of embedding mutable lease state into `workflow_items`.
+
+Fields:
+
+- `id`
+- `workflow_item_id`
+- `actor_id`
+- `actor_kind`
+- `lease_state` (`active`, `expired`, `released`)
+- `acquired_at`
+- `renewed_at`
+- `expires_at`
+- `released_at`
+
+Rationale:
+
+- preserves lease history
+- allows repeated leases over one work item
+- simplifies expiry auditing
+
+#### `workflow_interventions`
+
+Durable intervention and escalation records.
+
+Fields:
+
+- `id`
+- `workflow_item_id`
+- `intervention_type`
+- `reason`
+- `status` (`pending`, `applied`, `dismissed`)
+- `payload_json`
+- `created_at`
+- `resolved_at`
+
+### 6.2 Policy Definitions
+
+Policy packs should load from code and plugin manifests, with config binding them to workflow types. Persist only the bound identity on the workflow item and in relevant events:
+
+- `policy_pack`
+- `policy_version`
+
+If exact decision reproducibility becomes necessary, store a compact policy snapshot hash in event payloads rather than full JSON definitions in the database.
+
+### 6.3 Initial Indexes
+
+Recommended indexes:
+
+- `workflow_items(workflow_type, state, updated_at)`
+- `workflow_items(owner_actor_id, state)`
+- `workflow_claims(workflow_item_id, status, created_at)`
+- `workflow_evidence(workflow_item_id, created_at)`
+- `workflow_events(workflow_item_id, created_at)`
+- `workflow_leases(workflow_item_id, lease_state, expires_at)`
+- `workflow_interventions(workflow_item_id, status, created_at)`
+
+## 7. Internal Service Surface
+
+### 7.1 Core TypeScript Interface
+
+```ts
+export interface WorkflowKernelService {
+  createItem(input: CreateWorkflowItemInput): Result<WorkflowItem, WorkflowError>;
+  submitClaim(input: SubmitWorkflowClaimInput): Result<WorkflowClaim, WorkflowError>;
+  attachEvidence(input: AttachWorkflowEvidenceInput): Result<WorkflowEvidence, WorkflowError>;
+  requestTransition(input: RequestWorkflowTransitionInput): Result<WorkflowDecision, WorkflowError>;
+  acquireLease(input: AcquireWorkflowLeaseInput): Result<WorkflowLease, WorkflowError>;
+  renewLease(input: RenewWorkflowLeaseInput): Result<WorkflowLease, WorkflowError>;
+  releaseLease(input: ReleaseWorkflowLeaseInput): Result<void, WorkflowError>;
+  evaluateDueWork(now?: number): Result<WorkflowEvaluationSummary, WorkflowError>;
+}
+```
+
+### 7.2 Supporting Services
+
+- `WorkflowPolicyRegistry.resolve(workflowType, domain)`
+- `WorkflowReadModel.listOperationalView(filters)`
+- `WorkflowReadModel.listAuditEvents(workflowItemId, cursor)`
+- `WorkflowEvidenceAdapter.fromToolResult(...)`
+- `WorkflowEvidenceAdapter.fromBackgroundTask(...)`
+- `WorkflowEvidenceAdapter.fromPersonaTask(...)`
+- `WorkflowEvidenceAdapter.fromApproval(...)`
+
+### 7.3 Event Emission Contract
+
+Every successful mutation emits one append-only event. Rejected transition requests also emit events so the audit log explains why work did not advance.
+
+Initial event types:
+
+- `workflow.created`
+- `workflow.claim_submitted`
+- `workflow.claim_accepted`
+- `workflow.claim_rejected`
+- `workflow.evidence_added`
+- `workflow.transition_requested`
+- `workflow.state_changed`
+- `workflow.lease_acquired`
+- `workflow.lease_renewed`
+- `workflow.lease_expired`
+- `workflow.lease_released`
+- `workflow.intervention_requested`
+- `workflow.intervention_applied`
+- `workflow.completed`
+- `workflow.failed`
+- `workflow.cancelled`
+
+## 8. Claim And Evidence Capture Integration
+
+### 8.1 AgentRunner
+
+`AgentRunner` should remain execution-first, but gain optional workflow hooks:
+
+- create claims when a persona explicitly reports progress, blockage, completion, or scope change
+- attach run-level evidence such as `run_id`, generated output references, and verification summaries
+- request transitions instead of mutating workflow state directly
+
+### 8.2 MCP Tools And Host Tools
+
+The calling agent remains responsible for proving work. Tools should expose enough structured result data for the caller to attach evidence without re-parsing raw prose.
+
+Useful integration points:
+
+- `src/tools/host-tools-bridge.ts`
+- `src/tools/host-tools/persona-send.ts`
+- `src/tools/host-tools/background-agent.ts`
+- `src/tools/host-tools/channel-send.ts`
+
+Recommended behavior:
+
+- tool results can be wrapped as evidence with provenance pointing to tool name, request ID, and any durable record ID
+- helper functions should make this easy, but never auto-advance work without an explicit claim or transition request
+
+### 8.3 Background Agents
+
+Background-agent completion should not silently imply success.
+
+Required workflow behavior:
+
+- spawning may attach evidence that delegated work began
+- completion may attach evidence to a pending claim
+- timeout, failure, or missing result should create a blocked or failed claim path and trigger watchdog evaluation
+
+### 8.4 Persona Delegation / A2A
+
+`persona.send` and `a2a_tasks` are the best fit for the first authoritative slice because they already have:
+
+- durable task IDs
+- durable state transitions
+- explicit source and target personas
+- queue item linkage
+- timeout and error surfaces
+
+The kernel should not replace `a2a_tasks`. Instead:
+
+- workflow items reference the originating A2A task
+- A2A status changes produce claims and evidence
+- the kernel decides whether the task lifecycle may be considered complete for higher-level workflow purposes
+
+## 9. Transition And Policy Evaluation
+
+Transitions are requested, not assumed.
+
+Decision model:
+
+- `observe`
+  - record the request and emit events, but do not block the underlying runtime path
+- `guided`
+  - warn, intervene, or schedule follow-up when policy fails, but still leave the runtime path mostly intact
+- `authoritative`
+  - reject unsupported state transitions and require evidence gates to pass
+
+Each policy evaluation should return:
+
+- decision (`accepted`, `rejected`, `deferred`)
+- reason codes
+- missing evidence requirements
+- intervention recommendation if applicable
+
+This lets the watchdog, dashboard, and human operator see not just what happened, but why.
+
+## 10. Watchdogs And Interventions
+
+The watchdog loop should operate over durable workflow state, not transcript heuristics.
+
+Initial deterministic checks:
+
+- active lease expired
+- no claim or state change after configured freshness threshold
+- repeated claim rejection on the same item
+- blocked state without new evidence or approval activity
+- completed background task with no attached claim or transition request
+
+Intervention outputs:
+
+- enqueue a follow-up message
+- request human approval
+- mark item `blocked`
+- escalate to another persona
+- emit an audit event only in observational mode
+
+## 11. Operational View And Audit Feed
+
+### 11.1 Operational Read Model
+
+The operational view should answer "what is happening right now?" with one row per workflow item.
+
+Recommended fields:
+
+- `workflow_item_id`
+- `title`
+- `workflow_type`
+- `state`
+- `owner_actor_id`
+- `policy_pack`
+- `rollout_mode`
+- `latest_claim_summary`
+- `latest_evidence_locator`
+- `blocked_reason`
+- `lease_expires_at`
+- `next_expected_transition`
+- `updated_at`
+
+This can be implemented initially as a SQL view or a repository query rather than a separate projector.
+
+### 11.2 Audit Feed Envelope
+
+Recommended payload shape:
+
+```ts
+interface WorkflowEventEnvelope {
+  id: string;
+  workflowItemId: string;
+  type: string;
+  actorId?: string;
+  correlationId?: string;
+  createdAt: number;
+  payload: Record<string, unknown>;
+}
+```
+
+The dashboard or CLI can build:
+
+- item timelines
+- persona swimlanes
+- policy decision cards
+- blocker drill-down
+
+### 11.3 Delivery Model
+
+First delivery should support repository-internal consumers via:
+
+- repository queries
+- CLI inspection commands
+- optional polling for a dashboard
+
+Real-time push such as SSE or WebSocket should be deferred until the underlying event model is stable.
+
+## 12. First Authoritative Rollout Boundary
+
+The first authoritative rollout should target orchestrator-style delegated tasks, implemented on top of existing A2A and queue primitives.
+
+Boundary:
+
+- only explicit persona-created workflow items
+- only one workflow type in authoritative mode
+- only delegation/task-completion flows for orchestrator-owned work
+- no automatic item creation by the scheduler in the initial rollout
+
+Concrete starting point:
+
+- create a workflow item when an orchestrator persona delegates durable work through `persona.send`
+- map A2A task states into workflow transitions:
+  - `submitted` -> `ready`
+  - `working` -> `in_progress`
+  - `input-required` -> `blocked`
+  - `completed` -> `awaiting_validation` or `done`, depending on policy and evidence
+  - `failed` -> `escalated` or `blocked`
+  - `canceled` -> `cancelled`
+
+This gives Talon a narrow but real proving ground for authoritative transitions without forcing the full software-engineering lifecycle into the first rollout.
+
+## 13. Migration Strategy
+
+### Phase 1: Schema And Observational Sidecar
+
+- add workflow tables and repositories
+- expose `WorkflowKernelService`
+- create items explicitly from personas
+- attach claims and evidence without enforcement
+
+### Phase 2: Structured Runtime Hooks
+
+- add helper APIs in `AgentRunner`, `persona.send`, and `background-agent`
+- enable watchdog evaluation and intervention scheduling
+- introduce operational and audit read paths
+
+### Phase 3: Guided Policy Evaluation
+
+- activate `guided` mode for selected workflow types
+- surface missing evidence and stale-work interventions
+- require explicit transition requests for important lifecycle changes
+
+### Phase 4: Authoritative Orchestrator Workflow
+
+- bind one orchestrator task workflow type to authoritative mode
+- gate completion on policy evaluation and evidence
+- make watchdog decisions operationally meaningful
+
+### Phase 5: Broader Domain Packs
+
+- expand to software delivery, PM, research, and support policy packs
+- expose pack selection and thresholds through config and plugin extension points
+
+## 14. Risks And Mitigations
+
+- Risk: workflow capture becomes prompt boilerplate.
+  - Mitigation: provide helper APIs and evidence adapters at the runtime/tool layer.
+- Risk: policy packs become hardcoded core logic.
+  - Mitigation: keep kernel generic and bind domain logic through registry/config/plugins.
+- Risk: the first rollout is too broad.
+  - Mitigation: constrain authoritative mode to one orchestrator delegation workflow.
+- Risk: audit data becomes noisy but not useful.
+  - Mitigation: require event reason codes and durable correlation IDs from the start.
+
+## 15. Recommended Next Artifact
+
+The next artifact after this technical design is the implementation plan in:
+
+- `specs/plans/2026-04-04-workflow-kernel-implementation-plan.md`

--- a/specs/plans/2026-04-04-workflow-kernel-implementation-plan.md
+++ b/specs/plans/2026-04-04-workflow-kernel-implementation-plan.md
@@ -1,0 +1,328 @@
+# Workflow Kernel Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development or superpowers:executing-plans before implementing this plan. Steps use checkbox syntax for execution tracking.
+
+**Goal:** Implement the workflow kernel sidecar for Talon with durable workflow state, claim and evidence capture, watchdog evaluation, and one narrow authoritative rollout path for orchestrator-style delegated work.
+
+**Architecture:** Add a new `src/workflow/` module with repositories, service APIs, policy evaluation, evidence adapters, and read models. Integrate it into existing execution paths such as `AgentRunner`, `persona.send`, background-agent flows, scheduler/watchdog loops, and A2A task handling without rewriting Talon's queue or persona systems.
+
+**Tech Stack:** TypeScript, Node.js, SQLite, better-sqlite3, Zod, neverthrow, pino, vitest
+
+**Spec:** `specs/2026-04-04-domain-agnostic-workflow-kernel.md`
+**Design:** `specs/2026-04-04-workflow-kernel-technical-design.md`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+| --- | --- | --- |
+| Create | `src/workflow/workflow-types.ts` | Shared workflow item, claim, evidence, lease, intervention, and decision types |
+| Create | `src/workflow/workflow-service.ts` | Main kernel service API and orchestration logic |
+| Create | `src/workflow/workflow-policy-registry.ts` | Resolves policy packs from code, config, and plugins |
+| Create | `src/workflow/workflow-evidence-adapter.ts` | Converts tool/background/A2A results into evidence records |
+| Create | `src/workflow/workflow-watchdog.ts` | Deterministic stale-work and escalation evaluation |
+| Create | `src/workflow/workflow-read-model.ts` | Operational and audit query surfaces |
+| Create | `src/workflow/index.ts` | Public exports |
+| Create | `src/workflow/packs/orchestrator-task-pack.ts` | First authoritative workflow pack |
+| Create | `src/core/database/migrations/010-workflow-kernel.sql` | Workflow tables and indexes |
+| Create | `src/core/database/repositories/workflow-item-repository.ts` | Workflow item persistence |
+| Create | `src/core/database/repositories/workflow-claim-repository.ts` | Claim persistence |
+| Create | `src/core/database/repositories/workflow-evidence-repository.ts` | Evidence persistence |
+| Create | `src/core/database/repositories/workflow-event-repository.ts` | Append-only event persistence |
+| Create | `src/core/database/repositories/workflow-lease-repository.ts` | Lease persistence |
+| Create | `src/core/database/repositories/workflow-intervention-repository.ts` | Intervention persistence |
+| Modify | `src/core/database/repositories/index.ts` | Export workflow repositories |
+| Modify | `src/core/config/config-schema.ts` | Add workflow rollout and policy-pack config |
+| Modify | `src/core/config/config-types.ts` | Export workflow config types |
+| Modify | `src/daemon/daemon-context.ts` | Expose workflow service and read model |
+| Modify | `src/daemon/daemon-bootstrap.ts` | Initialize workflow services and repositories |
+| Modify | `src/daemon/daemon.ts` | Start and stop watchdog evaluation |
+| Modify | `src/daemon/agent-runner.ts` | Emit claims, evidence, and transition requests |
+| Modify | `src/daemon/watchdog.ts` | Run workflow watchdog checks |
+| Modify | `src/tools/host-tools/persona-send.ts` | Create workflow items for orchestrator delegation and attach A2A evidence |
+| Modify | `src/tools/host-tools/background-agent.ts` | Attach delegation, completion, timeout, and failure evidence |
+| Modify | `src/tools/host-tools-bridge.ts` | Provide durable tool metadata for evidence capture |
+| Modify | `src/a2a/a2a-task-mapper.ts` | Link A2A tasks to workflow items where appropriate |
+| Modify | `src/a2a/a2a-types.ts` | Add workflow link metadata if needed |
+| Modify | `src/subagents/background/background-agent-manager.ts` | Emit workflow-relevant completion and failure metadata |
+| Modify | `src/cli/commands/status.ts` | Surface workflow operational summary |
+| Create | `src/cli/commands/list-workflows.ts` | Inspect workflow items from CLI |
+| Modify | `talond.yaml.example` | Document workflow config |
+| Modify | `config/talond.yaml.example` | Mirror workflow config example if present |
+| Modify | `README.md` | Describe workflow-kernel capability and rollout flags |
+| Create | `tests/unit/workflow/workflow-service.test.ts` | Kernel service behavior |
+| Create | `tests/unit/workflow/workflow-policy-registry.test.ts` | Policy pack binding and validation |
+| Create | `tests/unit/workflow/workflow-evidence-adapter.test.ts` | Evidence normalization |
+| Create | `tests/unit/workflow/workflow-watchdog.test.ts` | Deterministic intervention checks |
+| Create | `tests/unit/workflow/workflow-read-model.test.ts` | Operational and audit query behavior |
+| Modify | `tests/unit/core/config/config-schema.test.ts` | Workflow config defaults and validation |
+| Modify | `tests/unit/daemon/agent-runner.test.ts` | Workflow claim/evidence hooks |
+| Modify | `tests/unit/daemon/daemon-bootstrap.test.ts` | Bootstrap wiring |
+| Modify | `tests/unit/daemon/daemon.test.ts` | Watchdog lifecycle |
+| Modify | `tests/unit/tools/host-tools/persona-send.test.ts` | A2A to workflow integration |
+| Modify | `tests/unit/tools/background-agent.test.ts` | Background-task evidence behavior |
+| Modify | `tests/integration/a2a/a2a-task-flow.test.ts` | End-to-end authoritative orchestrator slice |
+| Create | `tests/integration/workflow/workflow-kernel-sidecar.test.ts` | Sidecar observation path |
+
+## Chunk 1: Schema, Config, and Kernel Service Boundary
+
+### Task 1: Add durable workflow storage and bootstrap wiring
+
+**Files:**
+- Create workflow module and repositories
+- Create `010-workflow-kernel.sql`
+- Modify config and daemon bootstrap files
+- Add unit tests for config and workflow service boundary
+
+- [ ] **Step 1: Write the failing tests**
+
+Cover:
+
+- workflow config defaults to observational mode unless explicitly enabled
+- workflow repositories initialize cleanly on a fresh database
+- bootstrap wires `WorkflowKernelService` into `DaemonContext`
+- workflow item creation emits an initial `workflow.created` event
+- claim submission requires the core claim schema
+- evidence attachment requires the core evidence schema
+
+- [ ] **Step 2: Run the focused tests to confirm red**
+
+Run:
+
+```bash
+npx vitest run \
+  tests/unit/core/config/config-schema.test.ts \
+  tests/unit/daemon/daemon-bootstrap.test.ts \
+  tests/unit/workflow/workflow-service.test.ts
+```
+
+Expected:
+
+- FAIL because workflow config and modules do not exist yet
+
+- [ ] **Step 3: Implement the minimal production code**
+
+Add:
+
+- workflow tables and indexes
+- repository layer
+- workflow config types
+- kernel service with create-item, submit-claim, attach-evidence, and event emission
+- bootstrap wiring into daemon context
+
+- [ ] **Step 4: Re-run the focused tests to green**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/workflow src/core/database/migrations/010-workflow-kernel.sql src/core/database/repositories src/core/config/config-schema.ts src/core/config/config-types.ts src/daemon/daemon-context.ts src/daemon/daemon-bootstrap.ts tests/unit/workflow tests/unit/core/config/config-schema.test.ts tests/unit/daemon/daemon-bootstrap.test.ts
+git commit -m "feat(workflow): add kernel schema and service boundary"
+```
+
+## Chunk 2: Claim, Evidence, and Transition Hooks
+
+### Task 2: Integrate runtime claim and evidence capture
+
+**Files:**
+- Modify `src/daemon/agent-runner.ts`
+- Modify `src/tools/host-tools-bridge.ts`
+- Modify `src/tools/host-tools/background-agent.ts`
+- Add evidence adapter tests
+
+- [ ] **Step 1: Write the failing tests**
+
+Cover:
+
+- `AgentRunner` can attach a progress or blockage claim to an existing workflow item
+- tool-call metadata can be normalized into evidence with provenance
+- background-agent spawn, completion, timeout, and failure each produce distinct evidence records
+- transition requests emit `workflow.transition_requested` events instead of mutating state implicitly
+
+- [ ] **Step 2: Run the focused tests to confirm red**
+
+Run:
+
+```bash
+npx vitest run \
+  tests/unit/daemon/agent-runner.test.ts \
+  tests/unit/tools/background-agent.test.ts \
+  tests/unit/workflow/workflow-evidence-adapter.test.ts
+```
+
+- [ ] **Step 3: Implement the minimal production code**
+
+Add:
+
+- workflow helper calls in runtime paths
+- evidence adapters for tool results and background tasks
+- reason-coded transition decisions
+
+- [ ] **Step 4: Re-run the focused tests to green**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/daemon/agent-runner.ts src/tools/host-tools-bridge.ts src/tools/host-tools/background-agent.ts src/workflow tests/unit/daemon/agent-runner.test.ts tests/unit/tools/background-agent.test.ts tests/unit/workflow/workflow-evidence-adapter.test.ts
+git commit -m "feat(workflow): record claims and evidence from runtime paths"
+```
+
+## Chunk 3: Watchdogs, Leases, and Read Models
+
+### Task 3: Add deterministic stale-work evaluation and inspectable views
+
+**Files:**
+- Create `src/workflow/workflow-watchdog.ts`
+- Create `src/workflow/workflow-read-model.ts`
+- Modify daemon watchdog and CLI status surfaces
+
+- [ ] **Step 1: Write the failing tests**
+
+Cover:
+
+- active leases expire deterministically and emit `workflow.lease_expired`
+- repeated claim rejection produces an intervention request
+- operational view returns current state, owner, blocker, and next expected transition
+- audit feed returns append-only events in chronological order
+
+- [ ] **Step 2: Run the focused tests to confirm red**
+
+Run:
+
+```bash
+npx vitest run \
+  tests/unit/workflow/workflow-watchdog.test.ts \
+  tests/unit/workflow/workflow-read-model.test.ts \
+  tests/unit/daemon/daemon.test.ts
+```
+
+- [ ] **Step 3: Implement the minimal production code**
+
+Add:
+
+- lease repository logic
+- watchdog evaluator
+- intervention records
+- CLI or repository-level operational/audit views
+
+- [ ] **Step 4: Re-run the focused tests to green**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/workflow/workflow-watchdog.ts src/workflow/workflow-read-model.ts src/daemon/watchdog.ts src/daemon/daemon.ts src/cli/commands/status.ts src/cli/commands/list-workflows.ts tests/unit/workflow tests/unit/daemon/daemon.test.ts
+git commit -m "feat(workflow): add watchdog evaluation and read models"
+```
+
+## Chunk 4: Authoritative Orchestrator Rollout
+
+### Task 4: Bind one orchestrator-style delegated-task workflow to authoritative mode
+
+**Files:**
+- Create `src/workflow/packs/orchestrator-task-pack.ts`
+- Modify `src/tools/host-tools/persona-send.ts`
+- Modify `src/a2a/a2a-task-mapper.ts`
+- Modify `tests/unit/tools/host-tools/persona-send.test.ts`
+- Modify `tests/integration/a2a/a2a-task-flow.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Cover:
+
+- explicit orchestrator delegation through `persona.send` creates a workflow item
+- A2A state changes map to workflow transitions correctly
+- authoritative mode rejects completion without required evidence
+- timeout or `input-required` states produce blocked or escalated workflow outcomes
+
+- [ ] **Step 2: Run the focused tests to confirm red**
+
+Run:
+
+```bash
+npx vitest run \
+  tests/unit/tools/host-tools/persona-send.test.ts \
+  tests/integration/a2a/a2a-task-flow.test.ts
+```
+
+- [ ] **Step 3: Implement the minimal production code**
+
+Add:
+
+- orchestrator policy pack
+- A2A-to-workflow mapping
+- authoritative completion gates for this one workflow type
+
+- [ ] **Step 4: Re-run the focused tests to green**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/workflow/packs/orchestrator-task-pack.ts src/tools/host-tools/persona-send.ts src/a2a/a2a-task-mapper.ts src/a2a/a2a-types.ts tests/unit/tools/host-tools/persona-send.test.ts tests/integration/a2a/a2a-task-flow.test.ts
+git commit -m "feat(workflow): add authoritative orchestrator task rollout"
+```
+
+## Chunk 5: Docs, Config Examples, and Hardening
+
+### Task 5: Document the workflow kernel and verify the integrated system
+
+**Files:**
+- Modify `README.md`
+- Modify `talond.yaml.example`
+- Modify `config/talond.yaml.example`
+- Add or update integration coverage
+
+- [ ] **Step 1: Write the failing or missing tests**
+
+Cover:
+
+- sidecar mode does not block normal execution when policy evaluation fails
+- authoritative orchestrator mode blocks invalid completion transitions
+- config examples load successfully if the repo validates example config in tests
+
+- [ ] **Step 2: Run the focused tests to confirm red where applicable**
+
+- [ ] **Step 3: Implement the minimal production code and docs**
+
+Add:
+
+- workflow config examples
+- README documentation for rollout modes and workflow inspection
+- any final integration assertions needed for sidecar vs authoritative behavior
+
+- [ ] **Step 4: Run verification**
+
+Run at minimum:
+
+```bash
+npx vitest run tests/unit/workflow tests/unit/daemon tests/unit/tools tests/integration/a2a tests/integration/workflow
+```
+
+Then run the broader repo verification appropriate to the changed surfaces.
+
+- [ ] **Step 5: Request code review and address findings**
+
+Run Codex review in read-only mode before the final commit or PR.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md talond.yaml.example config/talond.yaml.example tests
+git commit -m "docs(workflow): document rollout and verification"
+```
+
+## Explicit Non-Goals For First Implementation
+
+- Do not convert all queue items into workflow items.
+- Do not auto-create workflow items from scheduler rules in the first slice.
+- Do not make real-time dashboard transport a prerequisite for the kernel.
+- Do not force the software-engineering workflow into authoritative mode before the orchestrator slice proves out.
+
+## Exit Criteria
+
+- workflow tables, repositories, and service exist
+- claims and evidence are durable, structured, and auditable
+- watchdog evaluation runs on durable workflow state
+- operational and audit read paths exist
+- one orchestrator-style delegated-task workflow runs in authoritative mode
+- documentation and config examples are updated
+- tests pass and code review has no unresolved critical or high-severity findings

--- a/src/a2a/a2a-task-mapper.ts
+++ b/src/a2a/a2a-task-mapper.ts
@@ -44,6 +44,8 @@ export interface SubmitTaskInput {
   parentTaskId?: string;
   /** Trace ID for observability. */
   traceId?: string;
+  /** Optional workflow item linked to this durable task. */
+  workflowItemId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,7 +86,7 @@ export class A2ATaskMapper {
    * @returns Ok(A2ATaskStatus) on success, Err(A2AError) on validation/persistence failure.
    */
   submitTask(input: SubmitTaskInput): Result<A2ATaskStatus, A2AError> {
-    const { sourcePersona, targetPersona, sourceThreadId, content, hopCount, parentTaskId, traceId } = input;
+    const { sourcePersona, targetPersona, sourceThreadId, content, hopCount, parentTaskId, traceId, workflowItemId } = input;
 
     // 1. Validate content
     if (!content.trim()) {
@@ -143,6 +145,7 @@ export class A2ATaskMapper {
         traceId,
         maxHops: MAX_HOPS,
         queueType: 'collaboration',
+        ...(workflowItemId ? { workflow: { workflowItemId } } : {}),
       },
     };
 
@@ -174,7 +177,7 @@ export class A2ATaskMapper {
           source_persona: sourcePersona,
           target_persona: targetPersona,
           thread_id: sourceThreadId,
-          request_payload: JSON.stringify({ content, sourcePersona, targetPersona, sourceThreadId, hopCount, parentTaskId, traceId }),
+          request_payload: JSON.stringify({ content, sourcePersona, targetPersona, sourceThreadId, hopCount, parentTaskId, traceId, workflowItemId }),
           hop_count: hopCount,
           parent_task_id: parentTaskId ?? null,
           submitted_at: now,
@@ -227,6 +230,7 @@ export class A2ATaskMapper {
       queueItemId,
       submittedAt: now,
       updatedAt: now,
+      ...(workflowItemId ? { workflowItemId } : {}),
     });
   }
 
@@ -255,6 +259,7 @@ export class A2ATaskMapper {
       submittedAt: row.submitted_at,
       updatedAt: row.updated_at,
       completedAt: row.completed_at ?? undefined,
+      ...this.extractWorkflowLink(row.request_payload),
     };
 
     if (row.result_payload) {
@@ -273,5 +278,16 @@ export class A2ATaskMapper {
     }
 
     return ok(status);
+  }
+
+  private extractWorkflowLink(requestPayload: string): { workflowItemId?: string } {
+    try {
+      const parsed = JSON.parse(requestPayload) as { workflowItemId?: unknown };
+      return typeof parsed.workflowItemId === 'string'
+        ? { workflowItemId: parsed.workflowItemId }
+        : {};
+    } catch {
+      return {};
+    }
   }
 }

--- a/src/a2a/a2a-types.ts
+++ b/src/a2a/a2a-types.ts
@@ -81,6 +81,9 @@ export interface A2ATaskPayload {
     traceId?: string;
     maxHops: number;
     queueType: 'collaboration';
+    workflow?: {
+      workflowItemId: string;
+    };
   };
 }
 
@@ -109,6 +112,7 @@ export interface A2ATaskStatus {
   submittedAt: number;
   updatedAt: number;
   completedAt?: number;
+  workflowItemId?: string;
   result?: {
     text: string;
   };

--- a/src/cli/cli-types.ts
+++ b/src/cli/cli-types.ts
@@ -90,6 +90,12 @@ export interface DaemonStatusData {
     /** Estimated cost in USD for the last 24 hours. */
     costUsd: number;
   };
+  /** Operational workflow summary when the workflow sidecar is enabled. */
+  workflowSummary?: {
+    totalItems: number;
+    blockedItems: number;
+    activeLeases: number;
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/list-workflows.ts
+++ b/src/cli/commands/list-workflows.ts
@@ -1,0 +1,44 @@
+import { createDatabase } from '../../core/database/connection.js';
+import { WorkflowReadModel } from '../../workflow/workflow-read-model.js';
+
+export async function listWorkflowsCommand(options: {
+  dbPath?: string;
+  limit?: number;
+} = {}): Promise<void> {
+  const dbPath = options.dbPath ?? 'data/talond.sqlite';
+  const limit = options.limit ?? 20;
+
+  const dbResult = createDatabase(dbPath, { readonly: true });
+  if (dbResult.isErr()) {
+    console.error(`Error: Failed to open database at ${dbPath}: ${dbResult.error.message}`);
+    process.exit(1);
+    return;
+  }
+
+  const db = dbResult.value;
+  try {
+    const readModel = new WorkflowReadModel(db);
+    const rowsResult = readModel.listOperationalView();
+    if (rowsResult.isErr()) {
+      console.error(`Error: Failed to list workflows: ${rowsResult.error.message}`);
+      process.exit(1);
+      return;
+    }
+
+    const rows = rowsResult.value.slice(0, limit);
+    if (rows.length === 0) {
+      console.log('No workflow items found.');
+      return;
+    }
+
+    console.log('workflow items');
+    console.log('--------------');
+    for (const row of rows) {
+      console.log(
+        `${row.workflowItemId.slice(0, 8)}  ${row.state.padEnd(18)}  ${row.workflowType.padEnd(20)}  ${row.title}`,
+      );
+    }
+  } finally {
+    db.close();
+  }
+}

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -182,6 +182,11 @@ function displayStatus(data: Partial<DaemonStatusData>): void {
   console.log(`Dead-letter items: ${data.deadLetterCount ?? 'unknown'}`);
   console.log(`Personas:          ${data.personaCount ?? 'unknown'}`);
   console.log(`Channels:          ${data.channelCount ?? 'unknown'}`);
+  if (data.workflowSummary) {
+    console.log(`Workflow items:    ${data.workflowSummary.totalItems}`);
+    console.log(`Blocked workflows: ${data.workflowSummary.blockedItems}`);
+    console.log(`Active leases:     ${data.workflowSummary.activeLeases}`);
+  }
 
   if (data.tokenUsage24h !== undefined) {
     const { inputTokens, outputTokens, cacheReadTokens = 0, cacheWriteTokens = 0, costUsd } = data.tokenUsage24h;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -48,6 +48,7 @@ import { resetProviderAffinityCommand } from './commands/reset-provider-affinity
 import { whatsappAuthCommand } from './commands/whatsapp-auth.js';
 import { setCapabilitiesCommand } from './commands/set-capabilities.js';
 import { a2aListCommand, a2aSendCommand } from './commands/a2a.js';
+import { listWorkflowsCommand } from './commands/list-workflows.js';
 
 // Load .env before anything else so ${VAR} substitution works in config.
 const envPath = resolve(process.env.TALOND_ENV_FILE || '.env');
@@ -92,6 +93,18 @@ program
     await statusCommand({
       ipcDir: opts.ipcDir,
       timeoutMs: parseInt(opts.timeout, 10),
+    });
+  });
+
+program
+  .command('list-workflows')
+  .description('Inspect workflow items from the local SQLite database')
+  .option('--db <path>', 'Path to the SQLite database', 'data/talond.sqlite')
+  .option('--limit <n>', 'Maximum workflows to print', '20')
+  .action(async (opts: { db: string; limit: string }) => {
+    await listWorkflowsCommand({
+      dbPath: opts.db,
+      limit: parseInt(opts.limit, 10),
     });
   });
 

--- a/src/core/config/config-schema.ts
+++ b/src/core/config/config-schema.ts
@@ -10,6 +10,7 @@
  */
 
 import { z } from 'zod';
+import { WorkflowRolloutModeSchema } from '../../workflow/workflow-types.js';
 
 // ---------------------------------------------------------------------------
 // Storage
@@ -267,6 +268,31 @@ export const BackgroundAgentConfigSchema = z.object({
   claudePath: z.string().optional(),
 });
 
+// ---------------------------------------------------------------------------
+// Workflow kernel
+// ---------------------------------------------------------------------------
+
+export const WorkflowPolicyBindingSchema = z.object({
+  workflowType: z.string().min(1),
+  policyPack: z.string().min(1),
+  rolloutMode: WorkflowRolloutModeSchema.default('observe'),
+});
+
+export const WorkflowWatchdogConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  evaluationIntervalMs: z.number().int().min(1000).default(30_000),
+  freshnessThresholdMs: z.number().int().min(1000).default(15 * 60 * 1000),
+  claimRejectionThreshold: z.number().int().min(1).default(2),
+});
+
+export const WorkflowConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  defaultRolloutMode: WorkflowRolloutModeSchema.default('observe'),
+  defaultPolicyPack: z.string().default('observe-only'),
+  bindings: z.array(WorkflowPolicyBindingSchema).default([]),
+  watchdog: WorkflowWatchdogConfigSchema.default(() => WorkflowWatchdogConfigSchema.parse({})),
+});
+
 export const SpritesConfigSchema = z
   .object({
     enabled: z.boolean().default(false),
@@ -368,6 +394,7 @@ export const TalondConfigSchema = z.object({
   auth: AuthConfigSchema.default(() => AuthConfigSchema.parse({})),
   agentRunner: AgentRunnerConfigSchema.default(() => AgentRunnerConfigSchema.parse({})),
   backgroundAgent: BackgroundAgentConfigSchema.default(() => BackgroundAgentConfigSchema.parse({})),
+  workflow: WorkflowConfigSchema.default(() => WorkflowConfigSchema.parse({})),
   sprites: SpritesConfigSchema.default(() => SpritesConfigSchema.parse({})),
   langfuse: LangfuseConfigSchema.default(() => LangfuseConfigSchema.parse({})),
   subagents: SubAgentsConfigSchema.default({}),

--- a/src/core/config/config-types.ts
+++ b/src/core/config/config-types.ts
@@ -24,6 +24,9 @@ import type {
   AuthConfigSchema,
   AgentRunnerConfigSchema,
   BackgroundAgentConfigSchema,
+  WorkflowConfigSchema,
+  WorkflowPolicyBindingSchema,
+  WorkflowWatchdogConfigSchema,
   LangfuseConfigSchema,
   ProviderConfigSchema,
   SubAgentsConfigSchema,
@@ -86,6 +89,15 @@ export type AgentRunnerConfig = z.infer<typeof AgentRunnerConfigSchema>;
 
 /** Background Claude Code worker settings. */
 export type BackgroundAgentConfig = z.infer<typeof BackgroundAgentConfigSchema>;
+
+/** Workflow kernel rollout and policy-pack configuration. */
+export type WorkflowConfig = z.infer<typeof WorkflowConfigSchema>;
+
+/** Per-workflow-type policy binding. */
+export type WorkflowPolicyBindingConfig = z.infer<typeof WorkflowPolicyBindingSchema>;
+
+/** Workflow watchdog thresholds and cadence. */
+export type WorkflowWatchdogConfig = z.infer<typeof WorkflowWatchdogConfigSchema>;
 
 /** Sprites provider settings. */
 export type SpritesConfig = z.infer<typeof SpritesConfigSchema>;

--- a/src/core/database/migrations/010-workflow-kernel.sql
+++ b/src/core/database/migrations/010-workflow-kernel.sql
@@ -1,0 +1,117 @@
+CREATE TABLE workflow_items (
+  id                TEXT PRIMARY KEY,
+  workflow_type     TEXT NOT NULL,
+  domain            TEXT NOT NULL,
+  title             TEXT NOT NULL,
+  goal_json         TEXT NOT NULL,
+  state             TEXT NOT NULL
+                    CHECK (state IN ('intake', 'ready', 'in_progress', 'awaiting_validation', 'blocked', 'escalated', 'done', 'cancelled')),
+  status_reason     TEXT,
+  rollout_mode      TEXT NOT NULL
+                    CHECK (rollout_mode IN ('observe', 'guided', 'authoritative')),
+  policy_pack       TEXT NOT NULL,
+  policy_version    TEXT NOT NULL,
+  owner_actor_id    TEXT,
+  source_thread_id  TEXT,
+  source_message_id TEXT,
+  source_run_id     TEXT,
+  priority          INTEGER NOT NULL DEFAULT 0,
+  created_at        INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL,
+  completed_at      INTEGER
+);
+
+CREATE TABLE workflow_claims (
+  id                   TEXT PRIMARY KEY,
+  workflow_item_id     TEXT NOT NULL,
+  claim_type           TEXT NOT NULL,
+  actor_id             TEXT NOT NULL,
+  actor_kind           TEXT NOT NULL
+                       CHECK (actor_kind IN ('persona', 'human', 'system', 'background_agent', 'tool')),
+  action               TEXT NOT NULL,
+  target               TEXT NOT NULL,
+  asserted_outcome     TEXT NOT NULL,
+  summary              TEXT NOT NULL,
+  payload_json         TEXT NOT NULL,
+  status               TEXT NOT NULL
+                       CHECK (status IN ('pending', 'accepted', 'rejected', 'superseded')),
+  policy_decision_json TEXT,
+  created_at           INTEGER NOT NULL,
+  resolved_at          INTEGER,
+  FOREIGN KEY (workflow_item_id) REFERENCES workflow_items(id) ON DELETE CASCADE
+);
+
+CREATE TABLE workflow_evidence (
+  id              TEXT PRIMARY KEY,
+  workflow_item_id TEXT NOT NULL,
+  claim_id        TEXT,
+  evidence_type   TEXT NOT NULL,
+  source          TEXT NOT NULL,
+  locator         TEXT NOT NULL,
+  captured_at     INTEGER NOT NULL,
+  provenance_json TEXT NOT NULL,
+  payload_json    TEXT NOT NULL,
+  created_at      INTEGER NOT NULL,
+  FOREIGN KEY (workflow_item_id) REFERENCES workflow_items(id) ON DELETE CASCADE,
+  FOREIGN KEY (claim_id) REFERENCES workflow_claims(id) ON DELETE SET NULL
+);
+
+CREATE TABLE workflow_events (
+  id              TEXT PRIMARY KEY,
+  workflow_item_id TEXT NOT NULL,
+  event_type      TEXT NOT NULL,
+  actor_id        TEXT,
+  correlation_id  TEXT,
+  payload_json    TEXT NOT NULL,
+  created_at      INTEGER NOT NULL,
+  FOREIGN KEY (workflow_item_id) REFERENCES workflow_items(id) ON DELETE CASCADE
+);
+
+CREATE TABLE workflow_leases (
+  id              TEXT PRIMARY KEY,
+  workflow_item_id TEXT NOT NULL,
+  actor_id        TEXT NOT NULL,
+  actor_kind      TEXT NOT NULL
+                  CHECK (actor_kind IN ('persona', 'human', 'system', 'background_agent', 'tool')),
+  lease_state     TEXT NOT NULL
+                  CHECK (lease_state IN ('active', 'expired', 'released')),
+  acquired_at     INTEGER NOT NULL,
+  renewed_at      INTEGER,
+  expires_at      INTEGER NOT NULL,
+  released_at     INTEGER,
+  FOREIGN KEY (workflow_item_id) REFERENCES workflow_items(id) ON DELETE CASCADE
+);
+
+CREATE TABLE workflow_interventions (
+  id                TEXT PRIMARY KEY,
+  workflow_item_id  TEXT NOT NULL,
+  intervention_type TEXT NOT NULL,
+  reason            TEXT NOT NULL,
+  status            TEXT NOT NULL
+                    CHECK (status IN ('pending', 'applied', 'dismissed')),
+  payload_json      TEXT NOT NULL,
+  created_at        INTEGER NOT NULL,
+  resolved_at       INTEGER,
+  FOREIGN KEY (workflow_item_id) REFERENCES workflow_items(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_workflow_items_type_state_updated
+  ON workflow_items(workflow_type, state, updated_at);
+
+CREATE INDEX idx_workflow_items_owner_state
+  ON workflow_items(owner_actor_id, state);
+
+CREATE INDEX idx_workflow_claims_item_status_created
+  ON workflow_claims(workflow_item_id, status, created_at);
+
+CREATE INDEX idx_workflow_evidence_item_created
+  ON workflow_evidence(workflow_item_id, created_at);
+
+CREATE INDEX idx_workflow_events_item_created
+  ON workflow_events(workflow_item_id, created_at);
+
+CREATE INDEX idx_workflow_leases_item_state_expires
+  ON workflow_leases(workflow_item_id, lease_state, expires_at);
+
+CREATE INDEX idx_workflow_interventions_item_status_created
+  ON workflow_interventions(workflow_item_id, status, created_at);

--- a/src/core/database/repositories/index.ts
+++ b/src/core/database/repositories/index.ts
@@ -60,6 +60,13 @@ export { AuditRepository } from './audit-repository.js';
 export type { ToolResultRow, ToolResultStatus, InsertToolResultInput } from './tool-result-repository.js';
 export { ToolResultRepository } from './tool-result-repository.js';
 
+export { WorkflowItemRepository } from './workflow-item-repository.js';
+export { WorkflowClaimRepository } from './workflow-claim-repository.js';
+export { WorkflowEvidenceRepository } from './workflow-evidence-repository.js';
+export { WorkflowEventRepository } from './workflow-event-repository.js';
+export { WorkflowLeaseRepository } from './workflow-lease-repository.js';
+export { WorkflowInterventionRepository } from './workflow-intervention-repository.js';
+
 export { BackgroundTaskRepository } from './background-task-repository.js';
 export type { InsertA2ATaskInput } from './a2a-task-repository.js';
 export { A2ATaskRepository } from './a2a-task-repository.js';

--- a/src/core/database/repositories/workflow-claim-repository.ts
+++ b/src/core/database/repositories/workflow-claim-repository.ts
@@ -1,0 +1,154 @@
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+import { DbError } from '../../errors/index.js';
+import { BaseRepository } from './base-repository.js';
+import type { WorkflowClaim } from '../../../workflow/workflow-types.js';
+
+interface WorkflowClaimRow {
+  id: string;
+  workflow_item_id: string;
+  claim_type: string;
+  actor_id: string;
+  actor_kind: string;
+  action: string;
+  target: string;
+  asserted_outcome: string;
+  summary: string;
+  payload_json: string;
+  status: string;
+  policy_decision_json: string | null;
+  created_at: number;
+  resolved_at: number | null;
+}
+
+function parseJson(value: string): Record<string, unknown> {
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+function rowToWorkflowClaim(row: WorkflowClaimRow): WorkflowClaim {
+  return {
+    id: row.id,
+    workflowItemId: row.workflow_item_id,
+    claimType: row.claim_type,
+    actorId: row.actor_id,
+    actorKind: row.actor_kind as WorkflowClaim['actorKind'],
+    action: row.action,
+    target: row.target,
+    assertedOutcome: row.asserted_outcome,
+    summary: row.summary,
+    payload: parseJson(row.payload_json),
+    status: row.status as WorkflowClaim['status'],
+    policyDecision: row.policy_decision_json ? parseJson(row.policy_decision_json) : null,
+    createdAt: row.created_at,
+    resolvedAt: row.resolved_at,
+  };
+}
+
+export class WorkflowClaimRepository extends BaseRepository {
+  private readonly insertStmt: Database.Statement;
+  private readonly listByWorkflowItemIdStmt: Database.Statement;
+  private readonly findByIdStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    super(db);
+
+    this.insertStmt = db.prepare(`
+      INSERT INTO workflow_claims (
+        id,
+        workflow_item_id,
+        claim_type,
+        actor_id,
+        actor_kind,
+        action,
+        target,
+        asserted_outcome,
+        summary,
+        payload_json,
+        status,
+        policy_decision_json,
+        created_at,
+        resolved_at
+      ) VALUES (
+        @id,
+        @workflow_item_id,
+        @claim_type,
+        @actor_id,
+        @actor_kind,
+        @action,
+        @target,
+        @asserted_outcome,
+        @summary,
+        @payload_json,
+        @status,
+        @policy_decision_json,
+        @created_at,
+        @resolved_at
+      )
+    `);
+
+    this.listByWorkflowItemIdStmt = db.prepare(`
+      SELECT * FROM workflow_claims
+      WHERE workflow_item_id = ?
+      ORDER BY created_at ASC
+    `);
+
+    this.findByIdStmt = db.prepare(`SELECT * FROM workflow_claims WHERE id = ?`);
+  }
+
+  insert(claim: WorkflowClaim): Result<WorkflowClaim, DbError> {
+    try {
+      this.insertStmt.run({
+        id: claim.id,
+        workflow_item_id: claim.workflowItemId,
+        claim_type: claim.claimType,
+        actor_id: claim.actorId,
+        actor_kind: claim.actorKind,
+        action: claim.action,
+        target: claim.target,
+        asserted_outcome: claim.assertedOutcome,
+        summary: claim.summary,
+        payload_json: JSON.stringify(claim.payload),
+        status: claim.status,
+        policy_decision_json: claim.policyDecision ? JSON.stringify(claim.policyDecision) : null,
+        created_at: claim.createdAt,
+        resolved_at: claim.resolvedAt,
+      });
+      return ok(claim);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to insert workflow claim: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  findById(id: string): Result<WorkflowClaim | null, DbError> {
+    try {
+      const row = this.findByIdStmt.get(id) as WorkflowClaimRow | undefined;
+      return ok(row ? rowToWorkflowClaim(row) : null);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to find workflow claim by id: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  listByWorkflowItemId(workflowItemId: string): Result<WorkflowClaim[], DbError> {
+    try {
+      const rows = this.listByWorkflowItemIdStmt.all(workflowItemId) as WorkflowClaimRow[];
+      return ok(rows.map(rowToWorkflowClaim));
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to list workflow claims by item: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+}

--- a/src/core/database/repositories/workflow-event-repository.ts
+++ b/src/core/database/repositories/workflow-event-repository.ts
@@ -1,0 +1,102 @@
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+import { DbError } from '../../errors/index.js';
+import { BaseRepository } from './base-repository.js';
+import type { WorkflowEvent } from '../../../workflow/workflow-types.js';
+
+interface WorkflowEventRow {
+  id: string;
+  workflow_item_id: string;
+  event_type: string;
+  actor_id: string | null;
+  correlation_id: string | null;
+  payload_json: string;
+  created_at: number;
+}
+
+function parseJson(value: string): Record<string, unknown> {
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+function rowToWorkflowEvent(row: WorkflowEventRow): WorkflowEvent {
+  return {
+    id: row.id,
+    workflowItemId: row.workflow_item_id,
+    eventType: row.event_type,
+    actorId: row.actor_id,
+    correlationId: row.correlation_id,
+    payload: parseJson(row.payload_json),
+    createdAt: row.created_at,
+  };
+}
+
+export class WorkflowEventRepository extends BaseRepository {
+  private readonly insertStmt: Database.Statement;
+  private readonly listByWorkflowItemIdStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    super(db);
+
+    this.insertStmt = db.prepare(`
+      INSERT INTO workflow_events (
+        id,
+        workflow_item_id,
+        event_type,
+        actor_id,
+        correlation_id,
+        payload_json,
+        created_at
+      ) VALUES (
+        @id,
+        @workflow_item_id,
+        @event_type,
+        @actor_id,
+        @correlation_id,
+        @payload_json,
+        @created_at
+      )
+    `);
+
+    this.listByWorkflowItemIdStmt = db.prepare(`
+      SELECT * FROM workflow_events
+      WHERE workflow_item_id = ?
+      ORDER BY created_at ASC, rowid ASC
+    `);
+  }
+
+  insert(event: WorkflowEvent): Result<WorkflowEvent, DbError> {
+    try {
+      this.insertStmt.run({
+        id: event.id,
+        workflow_item_id: event.workflowItemId,
+        event_type: event.eventType,
+        actor_id: event.actorId,
+        correlation_id: event.correlationId,
+        payload_json: JSON.stringify(event.payload),
+        created_at: event.createdAt,
+      });
+      return ok(event);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to insert workflow event: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  listByWorkflowItemId(workflowItemId: string): Result<WorkflowEvent[], DbError> {
+    try {
+      const rows = this.listByWorkflowItemIdStmt.all(workflowItemId) as WorkflowEventRow[];
+      return ok(rows.map(rowToWorkflowEvent));
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to list workflow events by item: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+}

--- a/src/core/database/repositories/workflow-evidence-repository.ts
+++ b/src/core/database/repositories/workflow-evidence-repository.ts
@@ -1,0 +1,117 @@
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+import { DbError } from '../../errors/index.js';
+import { BaseRepository } from './base-repository.js';
+import type { WorkflowEvidence } from '../../../workflow/workflow-types.js';
+
+interface WorkflowEvidenceRow {
+  id: string;
+  workflow_item_id: string;
+  claim_id: string | null;
+  evidence_type: string;
+  source: string;
+  locator: string;
+  captured_at: number;
+  provenance_json: string;
+  payload_json: string;
+  created_at: number;
+}
+
+function parseJson(value: string): Record<string, unknown> {
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+function rowToWorkflowEvidence(row: WorkflowEvidenceRow): WorkflowEvidence {
+  return {
+    id: row.id,
+    workflowItemId: row.workflow_item_id,
+    claimId: row.claim_id,
+    evidenceType: row.evidence_type,
+    source: row.source,
+    locator: row.locator,
+    capturedAt: row.captured_at,
+    provenance: parseJson(row.provenance_json),
+    payload: parseJson(row.payload_json),
+    createdAt: row.created_at,
+  };
+}
+
+export class WorkflowEvidenceRepository extends BaseRepository {
+  private readonly insertStmt: Database.Statement;
+  private readonly listByWorkflowItemIdStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    super(db);
+
+    this.insertStmt = db.prepare(`
+      INSERT INTO workflow_evidence (
+        id,
+        workflow_item_id,
+        claim_id,
+        evidence_type,
+        source,
+        locator,
+        captured_at,
+        provenance_json,
+        payload_json,
+        created_at
+      ) VALUES (
+        @id,
+        @workflow_item_id,
+        @claim_id,
+        @evidence_type,
+        @source,
+        @locator,
+        @captured_at,
+        @provenance_json,
+        @payload_json,
+        @created_at
+      )
+    `);
+
+    this.listByWorkflowItemIdStmt = db.prepare(`
+      SELECT * FROM workflow_evidence
+      WHERE workflow_item_id = ?
+      ORDER BY created_at ASC
+    `);
+  }
+
+  insert(evidence: WorkflowEvidence): Result<WorkflowEvidence, DbError> {
+    try {
+      this.insertStmt.run({
+        id: evidence.id,
+        workflow_item_id: evidence.workflowItemId,
+        claim_id: evidence.claimId,
+        evidence_type: evidence.evidenceType,
+        source: evidence.source,
+        locator: evidence.locator,
+        captured_at: evidence.capturedAt,
+        provenance_json: JSON.stringify(evidence.provenance),
+        payload_json: JSON.stringify(evidence.payload),
+        created_at: evidence.createdAt,
+      });
+      return ok(evidence);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to insert workflow evidence: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  listByWorkflowItemId(workflowItemId: string): Result<WorkflowEvidence[], DbError> {
+    try {
+      const rows = this.listByWorkflowItemIdStmt.all(workflowItemId) as WorkflowEvidenceRow[];
+      return ok(rows.map(rowToWorkflowEvidence));
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to list workflow evidence by item: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+}

--- a/src/core/database/repositories/workflow-intervention-repository.ts
+++ b/src/core/database/repositories/workflow-intervention-repository.ts
@@ -1,0 +1,107 @@
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+import { DbError } from '../../errors/index.js';
+import { BaseRepository } from './base-repository.js';
+import type { WorkflowIntervention } from '../../../workflow/workflow-types.js';
+
+interface WorkflowInterventionRow {
+  id: string;
+  workflow_item_id: string;
+  intervention_type: string;
+  reason: string;
+  status: string;
+  payload_json: string;
+  created_at: number;
+  resolved_at: number | null;
+}
+
+function parseJson(value: string): Record<string, unknown> {
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+function rowToWorkflowIntervention(row: WorkflowInterventionRow): WorkflowIntervention {
+  return {
+    id: row.id,
+    workflowItemId: row.workflow_item_id,
+    interventionType: row.intervention_type,
+    reason: row.reason,
+    status: row.status as WorkflowIntervention['status'],
+    payload: parseJson(row.payload_json),
+    createdAt: row.created_at,
+    resolvedAt: row.resolved_at,
+  };
+}
+
+export class WorkflowInterventionRepository extends BaseRepository {
+  private readonly insertStmt: Database.Statement;
+  private readonly listByWorkflowItemIdStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    super(db);
+
+    this.insertStmt = db.prepare(`
+      INSERT INTO workflow_interventions (
+        id,
+        workflow_item_id,
+        intervention_type,
+        reason,
+        status,
+        payload_json,
+        created_at,
+        resolved_at
+      ) VALUES (
+        @id,
+        @workflow_item_id,
+        @intervention_type,
+        @reason,
+        @status,
+        @payload_json,
+        @created_at,
+        @resolved_at
+      )
+    `);
+
+    this.listByWorkflowItemIdStmt = db.prepare(`
+      SELECT * FROM workflow_interventions
+      WHERE workflow_item_id = ?
+      ORDER BY created_at ASC
+    `);
+  }
+
+  insert(intervention: WorkflowIntervention): Result<WorkflowIntervention, DbError> {
+    try {
+      this.insertStmt.run({
+        id: intervention.id,
+        workflow_item_id: intervention.workflowItemId,
+        intervention_type: intervention.interventionType,
+        reason: intervention.reason,
+        status: intervention.status,
+        payload_json: JSON.stringify(intervention.payload),
+        created_at: intervention.createdAt,
+        resolved_at: intervention.resolvedAt,
+      });
+      return ok(intervention);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to insert workflow intervention: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  listByWorkflowItemId(workflowItemId: string): Result<WorkflowIntervention[], DbError> {
+    try {
+      const rows = this.listByWorkflowItemIdStmt.all(workflowItemId) as WorkflowInterventionRow[];
+      return ok(rows.map(rowToWorkflowIntervention));
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to list workflow interventions by item: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+}

--- a/src/core/database/repositories/workflow-item-repository.ts
+++ b/src/core/database/repositories/workflow-item-repository.ts
@@ -1,0 +1,202 @@
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+import { DbError } from '../../errors/index.js';
+import { BaseRepository } from './base-repository.js';
+import type { WorkflowItem } from '../../../workflow/workflow-types.js';
+
+interface WorkflowItemRow {
+  id: string;
+  workflow_type: string;
+  domain: string;
+  title: string;
+  goal_json: string;
+  state: string;
+  status_reason: string | null;
+  rollout_mode: string;
+  policy_pack: string;
+  policy_version: string;
+  owner_actor_id: string | null;
+  source_thread_id: string | null;
+  source_message_id: string | null;
+  source_run_id: string | null;
+  priority: number;
+  created_at: number;
+  updated_at: number;
+  completed_at: number | null;
+}
+
+function parseJson(value: string): Record<string, unknown> {
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+function rowToWorkflowItem(row: WorkflowItemRow): WorkflowItem {
+  return {
+    id: row.id,
+    workflowType: row.workflow_type,
+    domain: row.domain,
+    title: row.title,
+    goal: parseJson(row.goal_json),
+    state: row.state as WorkflowItem['state'],
+    statusReason: row.status_reason,
+    rolloutMode: row.rollout_mode as WorkflowItem['rolloutMode'],
+    policyPack: row.policy_pack,
+    policyVersion: row.policy_version,
+    ownerActorId: row.owner_actor_id,
+    sourceThreadId: row.source_thread_id,
+    sourceMessageId: row.source_message_id,
+    sourceRunId: row.source_run_id,
+    priority: row.priority,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+export class WorkflowItemRepository extends BaseRepository {
+  private readonly insertStmt: Database.Statement;
+  private readonly findByIdStmt: Database.Statement;
+  private readonly listAllStmt: Database.Statement;
+  private readonly updateStateStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    super(db);
+
+    this.insertStmt = db.prepare(`
+      INSERT INTO workflow_items (
+        id,
+        workflow_type,
+        domain,
+        title,
+        goal_json,
+        state,
+        status_reason,
+        rollout_mode,
+        policy_pack,
+        policy_version,
+        owner_actor_id,
+        source_thread_id,
+        source_message_id,
+        source_run_id,
+        priority,
+        created_at,
+        updated_at,
+        completed_at
+      ) VALUES (
+        @id,
+        @workflow_type,
+        @domain,
+        @title,
+        @goal_json,
+        @state,
+        @status_reason,
+        @rollout_mode,
+        @policy_pack,
+        @policy_version,
+        @owner_actor_id,
+        @source_thread_id,
+        @source_message_id,
+        @source_run_id,
+        @priority,
+        @created_at,
+        @updated_at,
+        @completed_at
+      )
+    `);
+
+    this.findByIdStmt = db.prepare(`SELECT * FROM workflow_items WHERE id = ?`);
+    this.listAllStmt = db.prepare(`SELECT * FROM workflow_items ORDER BY created_at ASC`);
+    this.updateStateStmt = db.prepare(`
+      UPDATE workflow_items
+      SET state = @state,
+          status_reason = @status_reason,
+          updated_at = @updated_at,
+          completed_at = @completed_at
+      WHERE id = @id
+    `);
+  }
+
+  insert(item: WorkflowItem): Result<WorkflowItem, DbError> {
+    try {
+      this.insertStmt.run({
+        id: item.id,
+        workflow_type: item.workflowType,
+        domain: item.domain,
+        title: item.title,
+        goal_json: JSON.stringify(item.goal),
+        state: item.state,
+        status_reason: item.statusReason,
+        rollout_mode: item.rolloutMode,
+        policy_pack: item.policyPack,
+        policy_version: item.policyVersion,
+        owner_actor_id: item.ownerActorId,
+        source_thread_id: item.sourceThreadId,
+        source_message_id: item.sourceMessageId,
+        source_run_id: item.sourceRunId,
+        priority: item.priority,
+        created_at: item.createdAt,
+        updated_at: item.updatedAt,
+        completed_at: item.completedAt,
+      });
+      return ok(item);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to insert workflow item: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  findById(id: string): Result<WorkflowItem | null, DbError> {
+    try {
+      const row = this.findByIdStmt.get(id) as WorkflowItemRow | undefined;
+      return ok(row ? rowToWorkflowItem(row) : null);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to find workflow item by id: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  listAll(): Result<WorkflowItem[], DbError> {
+    try {
+      const rows = this.listAllStmt.all() as WorkflowItemRow[];
+      return ok(rows.map(rowToWorkflowItem));
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to list workflow items: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  updateState(
+    id: string,
+    state: WorkflowItem['state'],
+    options: { statusReason?: string | null; updatedAt: number; completedAt?: number | null },
+  ): Result<void, DbError> {
+    try {
+      this.updateStateStmt.run({
+        id,
+        state,
+        status_reason: options.statusReason ?? null,
+        updated_at: options.updatedAt,
+        completed_at: options.completedAt ?? null,
+      });
+      return ok(undefined);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to update workflow item state: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+}

--- a/src/core/database/repositories/workflow-lease-repository.ts
+++ b/src/core/database/repositories/workflow-lease-repository.ts
@@ -1,0 +1,161 @@
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+import { DbError } from '../../errors/index.js';
+import { BaseRepository } from './base-repository.js';
+import type { WorkflowLease } from '../../../workflow/workflow-types.js';
+
+interface WorkflowLeaseRow {
+  id: string;
+  workflow_item_id: string;
+  actor_id: string;
+  actor_kind: string;
+  lease_state: string;
+  acquired_at: number;
+  renewed_at: number | null;
+  expires_at: number;
+  released_at: number | null;
+}
+
+function rowToWorkflowLease(row: WorkflowLeaseRow): WorkflowLease {
+  return {
+    id: row.id,
+    workflowItemId: row.workflow_item_id,
+    actorId: row.actor_id,
+    actorKind: row.actor_kind as WorkflowLease['actorKind'],
+    leaseState: row.lease_state as WorkflowLease['leaseState'],
+    acquiredAt: row.acquired_at,
+    renewedAt: row.renewed_at,
+    expiresAt: row.expires_at,
+    releasedAt: row.released_at,
+  };
+}
+
+export class WorkflowLeaseRepository extends BaseRepository {
+  private readonly insertStmt: Database.Statement;
+  private readonly listByWorkflowItemIdStmt: Database.Statement;
+  private readonly listActiveExpiringBeforeStmt: Database.Statement;
+  private readonly updateStateStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    super(db);
+
+    this.insertStmt = db.prepare(`
+      INSERT INTO workflow_leases (
+        id,
+        workflow_item_id,
+        actor_id,
+        actor_kind,
+        lease_state,
+        acquired_at,
+        renewed_at,
+        expires_at,
+        released_at
+      ) VALUES (
+        @id,
+        @workflow_item_id,
+        @actor_id,
+        @actor_kind,
+        @lease_state,
+        @acquired_at,
+        @renewed_at,
+        @expires_at,
+        @released_at
+      )
+    `);
+
+    this.listByWorkflowItemIdStmt = db.prepare(`
+      SELECT * FROM workflow_leases
+      WHERE workflow_item_id = ?
+      ORDER BY acquired_at ASC
+    `);
+
+    this.listActiveExpiringBeforeStmt = db.prepare(`
+      SELECT * FROM workflow_leases
+      WHERE lease_state = 'active' AND expires_at <= ?
+      ORDER BY expires_at ASC
+    `);
+
+    this.updateStateStmt = db.prepare(`
+      UPDATE workflow_leases
+      SET lease_state = @lease_state,
+          renewed_at = COALESCE(@renewed_at, renewed_at),
+          released_at = COALESCE(@released_at, released_at)
+      WHERE id = @id
+    `);
+  }
+
+  insert(lease: WorkflowLease): Result<WorkflowLease, DbError> {
+    try {
+      this.insertStmt.run({
+        id: lease.id,
+        workflow_item_id: lease.workflowItemId,
+        actor_id: lease.actorId,
+        actor_kind: lease.actorKind,
+        lease_state: lease.leaseState,
+        acquired_at: lease.acquiredAt,
+        renewed_at: lease.renewedAt,
+        expires_at: lease.expiresAt,
+        released_at: lease.releasedAt,
+      });
+      return ok(lease);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to insert workflow lease: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  listByWorkflowItemId(workflowItemId: string): Result<WorkflowLease[], DbError> {
+    try {
+      const rows = this.listByWorkflowItemIdStmt.all(workflowItemId) as WorkflowLeaseRow[];
+      return ok(rows.map(rowToWorkflowLease));
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to list workflow leases by item: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  listActiveExpiringBefore(expiresAt: number): Result<WorkflowLease[], DbError> {
+    try {
+      const rows = this.listActiveExpiringBeforeStmt.all(expiresAt) as WorkflowLeaseRow[];
+      return ok(rows.map(rowToWorkflowLease));
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to list expiring workflow leases: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  updateState(
+    id: string,
+    leaseState: WorkflowLease['leaseState'],
+    options: { renewedAt?: number | null; releasedAt?: number | null } = {},
+  ): Result<void, DbError> {
+    try {
+      this.updateStateStmt.run({
+        id,
+        lease_state: leaseState,
+        renewed_at: options.renewedAt ?? null,
+        released_at: options.releasedAt ?? null,
+      });
+      return ok(undefined);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to update workflow lease state: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+}

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -232,6 +232,12 @@ export class AgentRunner {
       });
     }
 
+    this.recordWorkflowRuntimeHooks(item, {
+      personaId,
+      runId,
+      providerName: providerEntry.provider.name,
+    });
+
     const content = typeof item.payload.content === 'string' ? item.payload.content : '';
     let runFinalized = false;
 
@@ -1265,6 +1271,144 @@ export class AgentRunner {
         'agent-runner: failed to mark A2A task as failed',
       );
     });
+  }
+
+  private recordWorkflowRuntimeHooks(
+    item: QueueItem,
+    params: { personaId: string; runId: string; providerName: string },
+  ): void {
+    const workflow = this.parseWorkflowRuntimePayload(item);
+    if (!workflow) {
+      return;
+    }
+
+    if (workflow.claim) {
+      const claimResult = this.ctx.workflowService.submitClaim({
+        id: uuidv4(),
+        workflowItemId: workflow.workflowItemId,
+        claimType: workflow.claim.claimType,
+        actorId: params.personaId,
+        actorKind: 'persona',
+        action: workflow.claim.action,
+        target: workflow.claim.target,
+        assertedOutcome: workflow.claim.assertedOutcome,
+        summary: workflow.claim.summary,
+        payload: {
+          runId: params.runId,
+          providerName: params.providerName,
+          ...(workflow.claim.payload ?? {}),
+        },
+      });
+
+      if (claimResult.isErr()) {
+        this.ctx.logger.warn(
+          {
+            workflowItemId: workflow.workflowItemId,
+            err: claimResult.error.message,
+          },
+          'agent-runner: failed to record workflow claim',
+        );
+      }
+    }
+
+    if (workflow.transition) {
+      const transitionResult = this.ctx.workflowService.requestTransition({
+        workflowItemId: workflow.workflowItemId,
+        requestedState: workflow.transition.requestedState,
+        actorId: params.personaId,
+        reason: workflow.transition.reason,
+        correlationId: workflow.transition.correlationId,
+      });
+
+      if (transitionResult.isErr()) {
+        this.ctx.logger.warn(
+          {
+            workflowItemId: workflow.workflowItemId,
+            err: transitionResult.error.message,
+          },
+          'agent-runner: failed to request workflow transition',
+        );
+      }
+    }
+  }
+
+  private parseWorkflowRuntimePayload(item: QueueItem): {
+    workflowItemId: string;
+    claim?: {
+      claimType: string;
+      action: string;
+      target: string;
+      assertedOutcome: string;
+      summary: string;
+      payload?: Record<string, unknown>;
+    };
+    transition?: {
+      requestedState: 'intake' | 'ready' | 'in_progress' | 'awaiting_validation' | 'blocked' | 'escalated' | 'done' | 'cancelled';
+      reason: string;
+      correlationId?: string;
+    };
+  } | null {
+    const workflow =
+      typeof item.payload?.workflow === 'object' && item.payload.workflow !== null
+        ? item.payload.workflow as Record<string, unknown>
+        : null;
+    const workflowItemId =
+      workflow && typeof workflow.workflowItemId === 'string'
+        ? workflow.workflowItemId
+        : null;
+
+    if (!workflow || !workflowItemId) {
+      return null;
+    }
+
+    const claim =
+      typeof workflow.claim === 'object' && workflow.claim !== null
+        ? workflow.claim as Record<string, unknown>
+        : null;
+    const transition =
+      typeof workflow.transition === 'object' && workflow.transition !== null
+        ? workflow.transition as Record<string, unknown>
+        : null;
+
+    const parsedClaim =
+      claim &&
+      typeof claim.claimType === 'string' &&
+      typeof claim.action === 'string' &&
+      typeof claim.target === 'string' &&
+      typeof claim.assertedOutcome === 'string' &&
+      typeof claim.summary === 'string'
+        ? {
+            claimType: claim.claimType,
+            action: claim.action,
+            target: claim.target,
+            assertedOutcome: claim.assertedOutcome,
+            summary: claim.summary,
+            payload:
+              typeof claim.payload === 'object' && claim.payload !== null
+                ? claim.payload as Record<string, unknown>
+                : undefined,
+          }
+        : undefined;
+
+    const parsedTransition =
+      transition &&
+      typeof transition.requestedState === 'string' &&
+      typeof transition.reason === 'string'
+        ? {
+            requestedState: transition.requestedState as 'intake' | 'ready' | 'in_progress' | 'awaiting_validation' | 'blocked' | 'escalated' | 'done' | 'cancelled',
+            reason: transition.reason,
+            correlationId:
+              typeof transition.correlationId === 'string'
+                ? transition.correlationId
+                : undefined,
+          }
+        : undefined;
+
+    return {
+      workflowItemId,
+      ...(parsedClaim ? { claim: parsedClaim } : {}),
+      ...(parsedTransition ? { transition: parsedTransition } : {}),
+    };
   }
 
   private parseBackgroundTaskNotification(item: QueueItem): {

--- a/src/daemon/daemon-bootstrap.ts
+++ b/src/daemon/daemon-bootstrap.ts
@@ -32,6 +32,12 @@ import {
   BindingRepository,
   MemoryRepository,
   A2ATaskRepository,
+  WorkflowItemRepository,
+  WorkflowClaimRepository,
+  WorkflowEvidenceRepository,
+  WorkflowEventRepository,
+  WorkflowLeaseRepository,
+  WorkflowInterventionRepository,
 } from '../core/database/repositories/index.js';
 import { buildAgentCardRegistry, A2ATaskMapper, A2AServer } from '../a2a/index.js';
 
@@ -71,6 +77,10 @@ import { createObservabilityService } from '../observability/langfuse/index.js';
 import { NoopObservabilityService } from '../observability/langfuse/noop-observability.js';
 import type { ObservabilityService } from '../observability/langfuse/observability-types.js';
 import { wrapProviderOptions } from '../subagents/provider-options.js';
+import { WorkflowKernelService } from '../workflow/workflow-service.js';
+import { WorkflowWatchdog } from '../workflow/workflow-watchdog.js';
+import { WorkflowReadModel } from '../workflow/workflow-read-model.js';
+import { WorkflowPolicyRegistry } from '../workflow/workflow-policy-registry.js';
 
 // ---------------------------------------------------------------------------
 // Bootstrap
@@ -147,7 +157,36 @@ export async function bootstrap(
     binding: new BindingRepository(db),
     memory: new MemoryRepository(db),
     a2aTask: new A2ATaskRepository(db),
+    workflowItem: new WorkflowItemRepository(db),
+    workflowClaim: new WorkflowClaimRepository(db),
+    workflowEvidence: new WorkflowEvidenceRepository(db),
+    workflowEvent: new WorkflowEventRepository(db),
+    workflowLease: new WorkflowLeaseRepository(db),
+    workflowIntervention: new WorkflowInterventionRepository(db),
   };
+
+  const workflowReadModel = new WorkflowReadModel(db);
+  const workflowPolicyRegistry = new WorkflowPolicyRegistry(config.workflow);
+  const workflowWatchdog = new WorkflowWatchdog({
+    itemRepository: repos.workflowItem,
+    claimRepository: repos.workflowClaim,
+    eventRepository: repos.workflowEvent,
+    leaseRepository: repos.workflowLease,
+    interventionRepository: repos.workflowIntervention,
+    claimRejectionThreshold: config.workflow.watchdog.claimRejectionThreshold,
+  });
+  const workflowServiceWithWatchdog = new WorkflowKernelService({
+    itemRepository: repos.workflowItem,
+    claimRepository: repos.workflowClaim,
+    evidenceRepository: repos.workflowEvidence,
+    eventRepository: repos.workflowEvent,
+    leaseRepository: repos.workflowLease,
+    interventionRepository: repos.workflowIntervention,
+    defaultRolloutMode: config.workflow.defaultRolloutMode,
+    defaultPolicyPack: config.workflow.defaultPolicyPack,
+    evaluateDueWorkFn: (now) => workflowWatchdog.evaluate(now),
+    policyRegistry: workflowPolicyRegistry,
+  });
 
   // 5. Audit logger
   const auditStore = new RepositoryAuditStore(repos.audit);
@@ -633,6 +672,8 @@ export async function bootstrap(
     toolInstructions,
     messagePipeline,
     observability,
+    workflowService: workflowServiceWithWatchdog,
+    workflowReadModel,
     subAgentRunner,
     providerRegistry,
     backgroundAgentManager,

--- a/src/daemon/daemon-context.ts
+++ b/src/daemon/daemon-context.ts
@@ -27,6 +27,12 @@ import type {
   BindingRepository,
   MemoryRepository,
   A2ATaskRepository,
+  WorkflowItemRepository,
+  WorkflowClaimRepository,
+  WorkflowEvidenceRepository,
+  WorkflowEventRepository,
+  WorkflowLeaseRepository,
+  WorkflowInterventionRepository,
 } from '../core/database/repositories/index.js';
 import type { ChannelRegistry } from '../channels/channel-registry.js';
 import type { QueueManager } from '../queue/queue-manager.js';
@@ -48,6 +54,8 @@ import type { ContextAssembler } from './context-assembler.js';
 import type { ObservabilityService } from '../observability/langfuse/observability-types.js';
 import type { A2AServer } from '../a2a/a2a-server.js';
 import type { A2ATaskMapper } from '../a2a/a2a-task-mapper.js';
+import type { WorkflowKernelService } from '../workflow/workflow-service.js';
+import type { WorkflowReadModel } from '../workflow/workflow-read-model.js';
 
 // ---------------------------------------------------------------------------
 // Repository bundle
@@ -69,6 +77,12 @@ export interface DaemonRepos {
   readonly binding: BindingRepository;
   readonly memory: MemoryRepository;
   readonly a2aTask: A2ATaskRepository;
+  readonly workflowItem: WorkflowItemRepository;
+  readonly workflowClaim: WorkflowClaimRepository;
+  readonly workflowEvidence: WorkflowEvidenceRepository;
+  readonly workflowEvent: WorkflowEventRepository;
+  readonly workflowLease: WorkflowLeaseRepository;
+  readonly workflowIntervention: WorkflowInterventionRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +116,8 @@ export interface DaemonContext {
   readonly loadedSkills: LoadedSkill[];
   readonly messagePipeline: MessagePipeline;
   readonly observability: ObservabilityService;
+  readonly workflowService: WorkflowKernelService;
+  readonly workflowReadModel: WorkflowReadModel;
   readonly hostToolsBridge: HostToolsBridge;
   readonly providerRegistry: ProviderRegistry<AgentRunnerProviderConfig>;
   readonly subAgentRunner: SubAgentRunner | null;

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -22,7 +22,7 @@ import { McpRegistry } from '../mcp/mcp-registry.js';
 import { bootstrap } from './daemon-bootstrap.js';
 import { AgentRunner } from './agent-runner.js';
 import { writePidFile, removePidFile } from './lifecycle.js';
-import { WatchdogNotifier } from './watchdog.js';
+import { WatchdogNotifier, WorkflowWatchdogScheduler } from './watchdog.js';
 import { registerChannels, injectSiblingBotIds } from '../channels/channel-setup.js';
 
 import type { DaemonContext } from './daemon-context.js';
@@ -43,6 +43,7 @@ export class TalondDaemon {
   private agentRunner: AgentRunner | null = null;
   private ipcServer: DaemonIpcServer | null = null;
   private watchdog: WatchdogNotifier | null = null;
+  private workflowWatchdog: WorkflowWatchdogScheduler | null = null;
   private mcpRegistry: McpRegistry | null = null;
 
   constructor(private readonly logger: pino.Logger) {}
@@ -149,6 +150,16 @@ export class TalondDaemon {
     this.watchdog.start();
     this.watchdog.notifyReady();
 
+    const workflowConfig = this.ctx.config.workflow;
+    if (workflowConfig?.enabled && workflowConfig.watchdog.enabled) {
+      this.workflowWatchdog = new WorkflowWatchdogScheduler({
+        intervalMs: workflowConfig.watchdog.evaluationIntervalMs,
+        logger: this.logger,
+        tick: (now) => this.ctx!.workflowService.evaluateDueWork(now),
+      });
+      this.workflowWatchdog.start();
+    }
+
     return ok(undefined);
   }
 
@@ -168,6 +179,11 @@ export class TalondDaemon {
       this.watchdog.notifyStopping();
       this.watchdog.stop();
       this.watchdog = null;
+    }
+
+    if (this.workflowWatchdog !== null) {
+      this.workflowWatchdog.stop();
+      this.workflowWatchdog = null;
     }
 
     if (this.ctx !== null) {
@@ -422,6 +438,10 @@ export class TalondDaemon {
             channelCount:
               this.ctx?.config.channels.filter((channel) => channel.enabled).length ?? 0,
             deadLetterCount: healthData.queueStats.deadLetter,
+            ...(this.ctx?.workflowReadModel.summarizeOperationalView().match(
+              (summary) => ({ workflowSummary: summary }),
+              () => ({}),
+            ) ?? {}),
             ...(tokenUsage24h !== undefined ? { tokenUsage24h } : {}),
           },
         };

--- a/src/daemon/watchdog.ts
+++ b/src/daemon/watchdog.ts
@@ -16,6 +16,8 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type pino from 'pino';
+import type { Result } from 'neverthrow';
+import type { WorkflowEvaluationSummary } from '../workflow/workflow-types.js';
 
 // ---------------------------------------------------------------------------
 // WatchdogNotifier
@@ -158,6 +160,53 @@ export class WatchdogNotifier {
     } catch (cause) {
       this.logger.warn({ cause, name }, 'watchdog: failed to write status file');
     }
+  }
+}
+
+export interface WorkflowWatchdogSchedulerOptions {
+  intervalMs: number;
+  logger: pino.Logger;
+  tick: (now: number) => Result<WorkflowEvaluationSummary, Error>;
+}
+
+export class WorkflowWatchdogScheduler {
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly options: WorkflowWatchdogSchedulerOptions) {}
+
+  start(): void {
+    if (this.timer !== null) {
+      return;
+    }
+
+    this.timer = setInterval(() => {
+      const result = this.options.tick(Date.now());
+      if (result.isErr()) {
+        this.options.logger.warn(
+          { error: result.error.message },
+          'workflow-watchdog: evaluation failed',
+        );
+        return;
+      }
+
+      this.options.logger.debug(
+        { summary: result.value },
+        'workflow-watchdog: evaluation complete',
+      );
+    }, this.options.intervalMs);
+
+    if (typeof this.timer.unref === 'function') {
+      this.timer.unref();
+    }
+  }
+
+  stop(): void {
+    if (this.timer === null) {
+      return;
+    }
+
+    clearInterval(this.timer);
+    this.timer = null;
   }
 }
 

--- a/src/tools/host-tools-bridge.ts
+++ b/src/tools/host-tools-bridge.ts
@@ -83,6 +83,7 @@ export class HostToolsBridge {
         taskMapper: ctx.a2aTaskMapper,
         taskRepo: ctx.repos.a2aTask,
         personaRepo: ctx.repos.persona,
+        workflowService: ctx.workflowService,
         logger: ctx.logger,
       });
       this.personaTaskStatusHandler = new PersonaTaskStatusHandler({
@@ -323,13 +324,20 @@ export class HostToolsBridge {
               }),
             ]);
 
+            const annotatedResult = this.annotateWorkflowMetadata(
+              toolResult,
+              normalizedTool,
+              args,
+              context,
+            );
+
             toolObservation.update({
-              output: toolResult,
+              output: annotatedResult,
               level: toolResult.status === 'error' ? 'ERROR' : undefined,
               statusMessage: toolResult.status === 'error' ? toolResult.error : undefined,
             });
 
-            return toolResult;
+            return annotatedResult;
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             toolObservation.update({
@@ -355,6 +363,57 @@ export class HostToolsBridge {
 
   private sendResponse(socket: net.Socket, response: BridgeResponse): void {
     socket.write(JSON.stringify(response) + '\n');
+  }
+
+  private annotateWorkflowMetadata(
+    result: ToolCallResult,
+    tool: string,
+    args: Record<string, unknown>,
+    context: ToolExecutionContext,
+  ): ToolCallResult {
+    if (result.workflowMetadata?.evidence) {
+      return {
+        ...result,
+        workflowMetadata: {
+          ...result.workflowMetadata,
+          evidence: {
+            ...result.workflowMetadata.evidence,
+            provenance: {
+              runId: context.runId,
+              threadId: context.threadId,
+              personaId: context.personaId,
+              requestId: context.requestId ?? null,
+              tool,
+              ...result.workflowMetadata.evidence.provenance,
+            },
+          },
+        },
+      };
+    }
+
+    return {
+      ...result,
+      workflowMetadata: {
+        evidence: {
+          evidenceType: 'tool_call_result',
+          source: 'tool_result',
+          locator: `tool_result:${context.runId}:${context.requestId ?? tool}`,
+          capturedAt: Date.now(),
+          provenance: {
+            runId: context.runId,
+            threadId: context.threadId,
+            personaId: context.personaId,
+            requestId: context.requestId ?? null,
+            tool,
+          },
+          payload: {
+            args,
+            status: result.status,
+          },
+        },
+        transitionRequest: result.workflowMetadata?.transitionRequest,
+      },
+    };
   }
 
   private resolveSkillContent(personaId: string, skillName: string): string | null {

--- a/src/tools/host-tools/background-agent.ts
+++ b/src/tools/host-tools/background-agent.ts
@@ -10,7 +10,7 @@ import type { SkillResolver } from '../../skills/skill-resolver.js';
 import type { ContextAssembler } from '../../daemon/context-assembler.js';
 import type { LoadedSkill } from '../../skills/skill-types.js';
 import { buildPersonaRuntimeContext } from '../../personas/persona-runtime-context.js';
-import type { BackgroundTask } from '../../subagents/background/background-agent-types.js';
+import type { BackgroundTask, BackgroundTaskResult } from '../../subagents/background/background-agent-types.js';
 import { BackgroundAgentError } from '../../core/errors/error-types.js';
 import { filterAllowedMcpTools } from '../tool-filter.js';
 import { resolveToolInstructions } from '../tool-instructions.js';
@@ -294,6 +294,28 @@ export class BackgroundAgentHandler {
       tool: BackgroundAgentHandler.manifest.name,
       status: 'success',
       result: { taskId: spawnResult.value },
+      workflowMetadata: {
+        evidence: {
+          evidenceType: 'background_task_spawned',
+          source: 'background_task',
+          locator: `task:${spawnResult.value}`,
+          capturedAt: Date.now(),
+          provenance: {
+            tool: BackgroundAgentHandler.manifest.name,
+            requestId,
+            runId: context.runId,
+            threadId: context.threadId,
+            personaId: context.personaId,
+          },
+          payload: {
+            status: 'running',
+            provider: resolvedProvider ?? null,
+            workingDirectory: args.workingDirectory ?? null,
+            timeoutMinutes: args.timeoutMinutes ?? null,
+            sandbox,
+          },
+        },
+      },
     };
   }
 
@@ -380,6 +402,7 @@ export class BackgroundAgentHandler {
       tool: BackgroundAgentHandler.manifest.name,
       status: 'success',
       result: result.value,
+      workflowMetadata: this.workflowMetadataForTask(ownership.task, result.value),
     };
   }
 
@@ -445,5 +468,51 @@ export class BackgroundAgentHandler {
       status: 'error',
       error,
     };
+  }
+
+  private workflowMetadataForTask(
+    task: BackgroundTask,
+    taskResult: BackgroundTaskResult | null,
+  ): ToolCallResult['workflowMetadata'] {
+    const status = taskResult?.status ?? task.status;
+    const evidenceType = this.backgroundTaskEvidenceType(status);
+
+    return {
+      evidence: {
+        evidenceType,
+        source: 'background_task',
+        locator: `task:${task.id}`,
+        capturedAt: task.completedAt ?? task.createdAt,
+        provenance: {
+          tool: BackgroundAgentHandler.manifest.name,
+          taskId: task.id,
+          providerName: task.providerName,
+          threadId: task.threadId,
+          personaId: task.personaId,
+        },
+        payload: {
+          status,
+          output: taskResult?.output ?? task.output,
+          error: taskResult?.error ?? task.error,
+          durationSeconds: taskResult?.durationSeconds ?? null,
+          workingDirectory: task.workingDirectory,
+          sandboxEnabled: task.sandboxEnabled,
+          primaryExecutionEnvId: task.primaryExecutionEnvId,
+        },
+      },
+    };
+  }
+
+  private backgroundTaskEvidenceType(status: BackgroundTask['status']): string {
+    switch (status) {
+      case 'completed':
+        return 'background_task_completed';
+      case 'timed_out':
+        return 'background_task_timed_out';
+      case 'failed':
+        return 'background_task_failed';
+      default:
+        return 'background_task_spawned';
+    }
   }
 }

--- a/src/tools/host-tools/persona-send.ts
+++ b/src/tools/host-tools/persona-send.ts
@@ -4,6 +4,7 @@
  * Submits a task to another persona over Talon's internal A2A layer.
  */
 
+import { randomUUID } from 'node:crypto';
 import { err, ok, type Result } from 'neverthrow';
 import type pino from 'pino';
 import type { A2ATaskMapper } from '../../a2a/a2a-task-mapper.js';
@@ -18,6 +19,12 @@ import {
   PERSONA_TASK_WAIT_MAX_MS,
   resolvePersonaTaskWaitMs,
 } from '../tool-timeouts.js';
+import type { WorkflowKernelService } from '../../workflow/workflow-service.js';
+import {
+  mapA2ATaskStateToWorkflowState,
+  ORCHESTRATOR_TASK_WORKFLOW_TYPE,
+  orchestratorTaskDefaults,
+} from '../../workflow/packs/orchestrator-task-pack.js';
 
 export interface PersonaSendTool {
   readonly manifest: ToolManifest;
@@ -28,6 +35,7 @@ export interface PersonaSendArgs {
   message: string;
   await_reply?: boolean;
   timeout_ms?: number;
+  workflow_type?: string;
 }
 
 type PersonaSendState = A2ATaskState | 'timeout';
@@ -35,6 +43,7 @@ type PersonaSendState = A2ATaskState | 'timeout';
 interface PersonaSendOutput {
   task_id: string;
   state: PersonaSendState;
+  workflow_item_id?: string;
   result?: string;
   error?: string;
 }
@@ -61,6 +70,7 @@ export class PersonaSendHandler {
       taskMapper: A2ATaskMapper;
       taskRepo: A2ATaskRepository;
       personaRepo: PersonaRepository;
+      workflowService?: WorkflowKernelService;
       logger: pino.Logger;
       maxWaitMs?: number;
       pollIntervalMs?: number;
@@ -94,12 +104,19 @@ export class PersonaSendHandler {
       return this.errorResult(requestId, sourcePersona.error.message);
     }
 
+    const workflowItemIdResult = this.maybeCreateWorkflowItem(validatedArgs.value, context);
+    if (workflowItemIdResult.isErr()) {
+      return this.errorResult(requestId, workflowItemIdResult.error.message);
+    }
+    const workflowItemId = workflowItemIdResult.value;
+
     const submitResult = this.deps.taskMapper.submitTask({
       sourcePersona: sourcePersona.value,
       targetPersona: validatedArgs.value.target_persona,
       sourceThreadId: context.threadId,
       content: validatedArgs.value.message,
       hopCount: (context.a2aHopCount ?? 0) + 1,
+      ...(workflowItemId ? { workflowItemId } : {}),
       ...(context.a2aTaskId ? { parentTaskId: context.a2aTaskId } : {}),
     });
 
@@ -112,16 +129,20 @@ export class PersonaSendHandler {
       return this.errorResult(requestId, message);
     }
 
+    this.recordWorkflowSubmission(workflowItemId, submitResult.value.taskId, context);
+
     if (!validatedArgs.value.await_reply) {
       return this.successResult(requestId, {
         task_id: submitResult.value.taskId,
         state: 'submitted',
+        ...(workflowItemId ? { workflow_item_id: workflowItemId } : {}),
       });
     }
 
     const awaitedResult = await this.pollUntilTerminal(
       submitResult.value.taskId,
       resolvePersonaTaskWaitMs(validatedArgs.value.timeout_ms, this.deps.maxWaitMs),
+      workflowItemId,
     );
     if (awaitedResult.isErr()) {
       this.deps.logger.error({ requestId, taskId: submitResult.value.taskId }, awaitedResult.error.message);
@@ -155,11 +176,21 @@ export class PersonaSendHandler {
       );
     }
 
+    if (
+      args.workflow_type !== undefined &&
+      args.workflow_type !== ORCHESTRATOR_TASK_WORKFLOW_TYPE
+    ) {
+      return err(
+        new ToolError(`persona.send: workflow_type must be "${ORCHESTRATOR_TASK_WORKFLOW_TYPE}" when provided`),
+      );
+    }
+
     return ok({
       target_persona: args.target_persona.trim(),
       message: args.message.trim(),
       await_reply: args.await_reply ?? false,
       ...(args.timeout_ms !== undefined ? { timeout_ms: args.timeout_ms } : {}),
+      ...(args.workflow_type !== undefined ? { workflow_type: args.workflow_type } : {}),
     });
   }
 
@@ -181,9 +212,11 @@ export class PersonaSendHandler {
   private async pollUntilTerminal(
     taskId: string,
     maxWaitMs: number = PERSONA_SEND_DEFAULT_MAX_WAIT_MS,
+    workflowItemId?: string,
   ): Promise<Result<PersonaSendOutput, ToolError>> {
     const pollIntervalMs = this.deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     const deadline = Date.now() + maxWaitMs;
+    let lastObservedState: A2ATaskState | null = null;
 
     while (true) {
       const rowResult = this.deps.taskRepo.findById(taskId);
@@ -197,8 +230,13 @@ export class PersonaSendHandler {
 
       this.deps.logger.debug({ taskId, state: rowResult.value.state }, 'persona.send: polled task state');
 
+      if (workflowItemId && rowResult.value.state !== lastObservedState) {
+        this.recordWorkflowTaskState(workflowItemId, rowResult.value);
+        lastObservedState = rowResult.value.state;
+      }
+
       if (TERMINAL_STATES.has(rowResult.value.state)) {
-        return ok(this.toOutput(rowResult.value));
+        return ok(this.toOutput(rowResult.value, workflowItemId));
       }
 
       const remaining = deadline - Date.now();
@@ -214,16 +252,18 @@ export class PersonaSendHandler {
     return ok({
       task_id: taskId,
       state: 'timeout',
+      ...(workflowItemId ? { workflow_item_id: workflowItemId } : {}),
       error: 'Timed out waiting for delegated persona reply. The delegated task may still complete asynchronously. Use persona_task_status with this task_id to fetch the final result later.',
     });
   }
 
-  private toOutput(row: A2ATaskRow): PersonaSendOutput {
+  private toOutput(row: A2ATaskRow, workflowItemId?: string): PersonaSendOutput {
     if (row.state === 'completed') {
       const result = this.parseResultPayload(row.result_payload);
       return {
         task_id: row.id,
         state: 'completed',
+        ...(workflowItemId ? { workflow_item_id: workflowItemId } : {}),
         ...(result ? { result } : {}),
       };
     }
@@ -232,6 +272,7 @@ export class PersonaSendHandler {
       return {
         task_id: row.id,
         state: 'failed',
+        ...(workflowItemId ? { workflow_item_id: workflowItemId } : {}),
         error: row.error_message ?? row.error_code ?? 'Task failed',
       };
     }
@@ -240,6 +281,7 @@ export class PersonaSendHandler {
     return {
       task_id: row.id,
       state: row.state,
+      ...(workflowItemId ? { workflow_item_id: workflowItemId } : {}),
     };
   }
 
@@ -272,5 +314,111 @@ export class PersonaSendHandler {
       status: 'error',
       error,
     };
+  }
+
+  private maybeCreateWorkflowItem(
+    args: PersonaSendArgs,
+    context: ToolExecutionContext,
+  ): Result<string | undefined, ToolError> {
+    if (args.workflow_type !== ORCHESTRATOR_TASK_WORKFLOW_TYPE) {
+      return ok(undefined);
+    }
+
+    if (!this.deps.workflowService) {
+      return err(new ToolError('persona.send: workflow service is not available'));
+    }
+
+    const defaults = orchestratorTaskDefaults();
+    const createItem = this.deps.workflowService.createItem({
+      id: randomUUID(),
+      workflowType: defaults.workflowType,
+      domain: 'operations',
+      title: `Delegate to ${args.target_persona}`,
+      goal: {
+        targetPersona: args.target_persona,
+        message: args.message,
+      },
+      priority: 0,
+      ownerActorId: context.personaId,
+      sourceThreadId: context.threadId,
+      sourceRunId: context.runId,
+      rolloutMode: defaults.rolloutMode,
+      policyPack: defaults.policyPack,
+      policyVersion: defaults.policyVersion,
+    });
+    if (createItem.isErr()) {
+      return err(new ToolError(`persona.send: failed to create workflow item: ${createItem.error.message}`));
+    }
+
+    return ok(createItem.value.id);
+  }
+
+  private recordWorkflowSubmission(
+    workflowItemId: string | undefined,
+    taskId: string,
+    context: ToolExecutionContext,
+  ): void {
+    if (!workflowItemId || !this.deps.workflowService) {
+      return;
+    }
+
+    this.deps.workflowService.attachEvidence({
+      id: randomUUID(),
+      workflowItemId,
+      claimId: null,
+      evidenceType: 'a2a_task_submitted',
+      source: 'a2a_task',
+      locator: `task:${taskId}`,
+      capturedAt: Date.now(),
+      provenance: {
+        tool: 'persona.send',
+        runId: context.runId,
+        threadId: context.threadId,
+        personaId: context.personaId,
+      },
+      payload: {
+        state: 'submitted',
+      },
+    });
+    this.deps.workflowService.requestTransition({
+      workflowItemId,
+      requestedState: 'ready',
+      actorId: context.personaId,
+      reason: 'a2a_submitted',
+      correlationId: taskId,
+    });
+  }
+
+  private recordWorkflowTaskState(workflowItemId: string, row: A2ATaskRow): void {
+    if (!this.deps.workflowService) {
+      return;
+    }
+
+    if (row.state === 'completed') {
+      this.deps.workflowService.attachEvidence({
+        id: randomUUID(),
+        workflowItemId,
+        claimId: null,
+        evidenceType: 'a2a_task_completed',
+        source: 'a2a_task',
+        locator: `task:${row.id}`,
+        capturedAt: row.completed_at ?? row.updated_at,
+        provenance: {
+          taskId: row.id,
+          state: row.state,
+        },
+        payload: {
+          resultPayload: row.result_payload,
+        },
+      });
+    }
+
+    this.deps.workflowService.requestTransition({
+      workflowItemId,
+      requestedState: mapA2ATaskStateToWorkflowState(row.state),
+      actorId: row.source_persona,
+      reason: `a2a_${row.state}`,
+      correlationId: row.id,
+    });
   }
 }

--- a/src/tools/tool-types.ts
+++ b/src/tools/tool-types.ts
@@ -106,4 +106,27 @@ export interface ToolCallResult {
   result?: unknown;
   /** Human-readable error message when status is `error`. */
   error?: string;
+  /** Optional structured workflow metadata used to derive durable claims/evidence. */
+  workflowMetadata?: ToolCallWorkflowMetadata;
+}
+
+export interface WorkflowEvidenceMetadata {
+  evidenceType: string;
+  source: string;
+  locator: string;
+  capturedAt: number;
+  provenance: Record<string, unknown>;
+  payload: Record<string, unknown>;
+}
+
+export interface WorkflowTransitionRequestMetadata {
+  workflowItemId: string;
+  requestedState: string;
+  reason: string;
+  correlationId?: string;
+}
+
+export interface ToolCallWorkflowMetadata {
+  evidence?: WorkflowEvidenceMetadata;
+  transitionRequest?: WorkflowTransitionRequestMetadata;
 }

--- a/src/workflow/index.ts
+++ b/src/workflow/index.ts
@@ -1,0 +1,45 @@
+export { WorkflowKernelService } from './workflow-service.js';
+export { WorkflowEvidenceAdapter } from './workflow-evidence-adapter.js';
+export { WorkflowWatchdog } from './workflow-watchdog.js';
+export { WorkflowReadModel } from './workflow-read-model.js';
+export { WorkflowPolicyRegistry } from './workflow-policy-registry.js';
+export {
+  ORCHESTRATOR_TASK_POLICY_PACK,
+  ORCHESTRATOR_TASK_POLICY_VERSION,
+  ORCHESTRATOR_TASK_WORKFLOW_TYPE,
+  orchestratorTaskDefaults,
+  orchestratorTaskPack,
+  mapA2ATaskStateToWorkflowState,
+} from './packs/orchestrator-task-pack.js';
+export type {
+  AcquireWorkflowLeaseInput,
+  AttachWorkflowEvidenceInput,
+  CreateWorkflowItemInput,
+  ReleaseWorkflowLeaseInput,
+  RenewWorkflowLeaseInput,
+  RequestWorkflowTransitionInput,
+  SubmitWorkflowClaimInput,
+  WorkflowClaim,
+  WorkflowDecision,
+  WorkflowEvaluationSummary,
+  WorkflowEvent,
+  WorkflowEvidence,
+  WorkflowIntervention,
+  WorkflowItem,
+  WorkflowLease,
+  WorkflowRolloutMode,
+  WorkflowState,
+} from './workflow-types.js';
+export {
+  WorkflowError,
+  WorkflowRolloutModeSchema,
+  WorkflowStateSchema,
+  WorkflowActorKindSchema,
+  WorkflowClaimStatusSchema,
+  WorkflowLeaseStateSchema,
+  WorkflowInterventionStatusSchema,
+  WorkflowDecisionStateSchema,
+  CreateWorkflowItemInputSchema,
+  SubmitWorkflowClaimInputSchema,
+  AttachWorkflowEvidenceInputSchema,
+} from './workflow-types.js';

--- a/src/workflow/packs/orchestrator-task-pack.ts
+++ b/src/workflow/packs/orchestrator-task-pack.ts
@@ -1,0 +1,82 @@
+import type { A2ATaskState } from '../../a2a/a2a-types.js';
+import type {
+  WorkflowDecision,
+  WorkflowEvidence,
+  WorkflowItem,
+  WorkflowRolloutMode,
+  WorkflowState,
+} from '../workflow-types.js';
+
+export interface WorkflowPolicyPack {
+  name: string;
+  version: string;
+  evaluateTransition(input: {
+    item: WorkflowItem;
+    requestedState: WorkflowState;
+    evidence: WorkflowEvidence[];
+  }): WorkflowDecision;
+}
+
+export const ORCHESTRATOR_TASK_WORKFLOW_TYPE = 'orchestrator_task';
+export const ORCHESTRATOR_TASK_POLICY_PACK = 'orchestrator-task';
+export const ORCHESTRATOR_TASK_POLICY_VERSION = '1';
+
+const REQUIRED_COMPLETION_EVIDENCE = new Set(['a2a_task_completed']);
+
+export const orchestratorTaskPack: WorkflowPolicyPack = {
+  name: ORCHESTRATOR_TASK_POLICY_PACK,
+  version: ORCHESTRATOR_TASK_POLICY_VERSION,
+  evaluateTransition(input) {
+    if (input.requestedState === 'done') {
+      const hasCompletionEvidence = input.evidence.some((evidence) =>
+        REQUIRED_COMPLETION_EVIDENCE.has(evidence.evidenceType),
+      );
+      if (!hasCompletionEvidence) {
+        return {
+          decision: 'rejected',
+          reasonCodes: ['missing_required_evidence'],
+          missingEvidence: ['a2a_task_completed'],
+          recommendedIntervention: 'request_missing_evidence',
+        };
+      }
+    }
+
+    return {
+      decision: 'accepted',
+      reasonCodes: ['transition_accepted'],
+      missingEvidence: [],
+      recommendedIntervention: null,
+    };
+  },
+};
+
+export function orchestratorTaskDefaults(): {
+  workflowType: string;
+  rolloutMode: WorkflowRolloutMode;
+  policyPack: string;
+  policyVersion: string;
+} {
+  return {
+    workflowType: ORCHESTRATOR_TASK_WORKFLOW_TYPE,
+    rolloutMode: 'authoritative',
+    policyPack: ORCHESTRATOR_TASK_POLICY_PACK,
+    policyVersion: ORCHESTRATOR_TASK_POLICY_VERSION,
+  };
+}
+
+export function mapA2ATaskStateToWorkflowState(state: A2ATaskState): WorkflowState {
+  switch (state) {
+    case 'submitted':
+      return 'ready';
+    case 'working':
+      return 'in_progress';
+    case 'input-required':
+      return 'blocked';
+    case 'completed':
+      return 'done';
+    case 'failed':
+      return 'escalated';
+    case 'canceled':
+      return 'cancelled';
+  }
+}

--- a/src/workflow/workflow-evidence-adapter.ts
+++ b/src/workflow/workflow-evidence-adapter.ts
@@ -1,0 +1,90 @@
+import { v4 as uuidv4 } from 'uuid';
+import { err, ok, type Result } from 'neverthrow';
+
+import type { ToolCallResult } from '../tools/tool-types.js';
+import type { BackgroundTask, BackgroundTaskResult } from '../subagents/background/background-agent-types.js';
+import type { AttachWorkflowEvidenceInput } from './workflow-types.js';
+import { WorkflowError } from './workflow-types.js';
+
+export class WorkflowEvidenceAdapter {
+  fromToolResult(input: {
+    workflowItemId: string;
+    claimId?: string | null;
+    toolResult: ToolCallResult;
+  }): Result<AttachWorkflowEvidenceInput, WorkflowError> {
+    const evidence = input.toolResult.workflowMetadata?.evidence;
+    if (!evidence) {
+      return err(new WorkflowError('Tool result does not carry workflow evidence metadata'));
+    }
+
+    return ok({
+      id: uuidv4(),
+      workflowItemId: input.workflowItemId,
+      claimId: input.claimId ?? null,
+      evidenceType: evidence.evidenceType,
+      source: evidence.source,
+      locator: evidence.locator,
+      capturedAt: evidence.capturedAt,
+      provenance: evidence.provenance,
+      payload: {
+        tool: input.toolResult.tool,
+        requestId: input.toolResult.requestId,
+        status: input.toolResult.status,
+        ...evidence.payload,
+      },
+    });
+  }
+
+  fromBackgroundTask(input: {
+    workflowItemId: string;
+    claimId?: string | null;
+    task: BackgroundTask;
+    taskResult?: BackgroundTaskResult | null;
+  }): Result<AttachWorkflowEvidenceInput, WorkflowError> {
+    const status = input.taskResult?.status ?? input.task.status;
+    const evidenceType = this.backgroundTaskEvidenceType(status);
+    if (!evidenceType) {
+      return err(new WorkflowError(`Unsupported background task status for workflow evidence: ${status}`));
+    }
+
+    return ok({
+      id: uuidv4(),
+      workflowItemId: input.workflowItemId,
+      claimId: input.claimId ?? null,
+      evidenceType,
+      source: 'background_task',
+      locator: `task:${input.task.id}`,
+      capturedAt: input.task.completedAt ?? input.task.createdAt,
+      provenance: {
+        taskId: input.task.id,
+        providerName: input.task.providerName,
+        threadId: input.task.threadId,
+        personaId: input.task.personaId,
+      },
+      payload: {
+        status,
+        output: input.taskResult?.output ?? input.task.output,
+        error: input.taskResult?.error ?? input.task.error,
+        durationSeconds: input.taskResult?.durationSeconds ?? null,
+        workingDirectory: input.task.workingDirectory,
+        sandboxEnabled: input.task.sandboxEnabled,
+        primaryExecutionEnvId: input.task.primaryExecutionEnvId,
+      },
+    });
+  }
+
+  private backgroundTaskEvidenceType(status: BackgroundTask['status']): string | null {
+    switch (status) {
+      case 'running':
+        return 'background_task_spawned';
+      case 'completed':
+        return 'background_task_completed';
+      case 'timed_out':
+        return 'background_task_timed_out';
+      case 'failed':
+        return 'background_task_failed';
+      default:
+        return null;
+    }
+  }
+}

--- a/src/workflow/workflow-policy-registry.ts
+++ b/src/workflow/workflow-policy-registry.ts
@@ -1,0 +1,45 @@
+import type { WorkflowConfig } from '../core/config/config-types.js';
+import type { WorkflowRolloutMode } from './workflow-types.js';
+import {
+  orchestratorTaskPack,
+  type WorkflowPolicyPack,
+} from './packs/orchestrator-task-pack.js';
+
+export interface WorkflowPolicyResolution {
+  workflowType: string;
+  rolloutMode: WorkflowRolloutMode;
+  policyPack: string;
+  policyVersion: string;
+  pack: WorkflowPolicyPack | null;
+}
+
+export class WorkflowPolicyRegistry {
+  private readonly bindings: WorkflowConfig['bindings'];
+  private readonly packs = new Map<string, WorkflowPolicyPack>([
+    [orchestratorTaskPack.name, orchestratorTaskPack],
+  ]);
+
+  constructor(config: Pick<WorkflowConfig, 'bindings'>) {
+    this.bindings = config.bindings;
+  }
+
+  resolve(workflowType: string): WorkflowPolicyResolution | null {
+    const binding = this.bindings.find((candidate) => candidate.workflowType === workflowType);
+    if (!binding) {
+      return null;
+    }
+
+    const pack = this.packs.get(binding.policyPack) ?? null;
+    return {
+      workflowType,
+      rolloutMode: binding.rolloutMode,
+      policyPack: binding.policyPack,
+      policyVersion: pack?.version ?? '1',
+      pack,
+    };
+  }
+
+  getPack(policyPack: string): WorkflowPolicyPack | null {
+    return this.packs.get(policyPack) ?? null;
+  }
+}

--- a/src/workflow/workflow-read-model.ts
+++ b/src/workflow/workflow-read-model.ts
@@ -1,0 +1,208 @@
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+
+import type { WorkflowEvent } from './workflow-types.js';
+import { WorkflowError } from './workflow-types.js';
+
+interface WorkflowOperationalViewRow {
+  workflow_item_id: string;
+  title: string;
+  workflow_type: string;
+  state: string;
+  owner_actor_id: string | null;
+  policy_pack: string;
+  rollout_mode: string;
+  latest_claim_summary: string | null;
+  latest_evidence_locator: string | null;
+  blocked_reason: string | null;
+  lease_expires_at: number | null;
+  updated_at: number;
+}
+
+interface WorkflowEventRow {
+  id: string;
+  workflow_item_id: string;
+  event_type: string;
+  actor_id: string | null;
+  correlation_id: string | null;
+  payload_json: string;
+  created_at: number;
+}
+
+function parseJson(value: string): Record<string, unknown> {
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+export interface WorkflowOperationalView {
+  workflowItemId: string;
+  title: string;
+  workflowType: string;
+  state: string;
+  ownerActorId: string | null;
+  policyPack: string;
+  rolloutMode: string;
+  latestClaimSummary: string | null;
+  latestEvidenceLocator: string | null;
+  blockedReason: string | null;
+  leaseExpiresAt: number | null;
+  nextExpectedTransition: string;
+  updatedAt: number;
+}
+
+export interface WorkflowOperationalSummary {
+  totalItems: number;
+  blockedItems: number;
+  activeLeases: number;
+}
+
+export class WorkflowReadModel {
+  private readonly listOperationalViewStmt: Database.Statement;
+  private readonly listAuditEventsStmt: Database.Statement;
+  private readonly summarizeStmt: Database.Statement;
+
+  constructor(private readonly db: Database.Database) {
+    this.listOperationalViewStmt = db.prepare(`
+      SELECT
+        i.id AS workflow_item_id,
+        i.title,
+        i.workflow_type,
+        i.state,
+        i.owner_actor_id,
+        i.policy_pack,
+        i.rollout_mode,
+        (
+          SELECT c.summary
+          FROM workflow_claims c
+          WHERE c.workflow_item_id = i.id
+          ORDER BY c.created_at DESC
+          LIMIT 1
+        ) AS latest_claim_summary,
+        (
+          SELECT e.locator
+          FROM workflow_evidence e
+          WHERE e.workflow_item_id = i.id
+          ORDER BY e.created_at DESC
+          LIMIT 1
+        ) AS latest_evidence_locator,
+        i.status_reason AS blocked_reason,
+        (
+          SELECT l.expires_at
+          FROM workflow_leases l
+          WHERE l.workflow_item_id = i.id AND l.lease_state = 'active'
+          ORDER BY l.expires_at DESC
+          LIMIT 1
+        ) AS lease_expires_at,
+        i.updated_at
+      FROM workflow_items i
+      ORDER BY i.updated_at DESC, i.created_at DESC
+    `);
+
+    this.listAuditEventsStmt = db.prepare(`
+      SELECT *
+      FROM workflow_events
+      WHERE workflow_item_id = ?
+      ORDER BY created_at ASC, rowid ASC
+    `);
+
+    this.summarizeStmt = db.prepare(`
+      SELECT
+        COUNT(*) AS total_items,
+        SUM(CASE WHEN state = 'blocked' THEN 1 ELSE 0 END) AS blocked_items,
+        (
+          SELECT COUNT(*)
+          FROM workflow_leases
+          WHERE lease_state = 'active'
+        ) AS active_leases
+      FROM workflow_items
+    `);
+  }
+
+  listOperationalView(): Result<WorkflowOperationalView[], WorkflowError> {
+    try {
+      const rows = this.listOperationalViewStmt.all() as WorkflowOperationalViewRow[];
+      return ok(
+        rows.map((row) => ({
+          workflowItemId: row.workflow_item_id,
+          title: row.title,
+          workflowType: row.workflow_type,
+          state: row.state,
+          ownerActorId: row.owner_actor_id,
+          policyPack: row.policy_pack,
+          rolloutMode: row.rollout_mode,
+          latestClaimSummary: row.latest_claim_summary,
+          latestEvidenceLocator: row.latest_evidence_locator,
+          blockedReason: row.blocked_reason,
+          leaseExpiresAt: row.lease_expires_at,
+          nextExpectedTransition: this.nextExpectedTransition(row.state),
+          updatedAt: row.updated_at,
+        })),
+      );
+    } catch (cause) {
+      return err(
+        new WorkflowError(
+          `Failed to build workflow operational view: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  listAuditEvents(workflowItemId: string): Result<WorkflowEvent[], WorkflowError> {
+    try {
+      const rows = this.listAuditEventsStmt.all(workflowItemId) as WorkflowEventRow[];
+      return ok(
+        rows.map((row) => ({
+          id: row.id,
+          workflowItemId: row.workflow_item_id,
+          eventType: row.event_type,
+          actorId: row.actor_id,
+          correlationId: row.correlation_id,
+          payload: parseJson(row.payload_json),
+          createdAt: row.created_at,
+        })),
+      );
+    } catch (cause) {
+      return err(
+        new WorkflowError(
+          `Failed to load workflow audit events: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  summarizeOperationalView(): Result<WorkflowOperationalSummary, WorkflowError> {
+    try {
+      const row = this.summarizeStmt.get() as {
+        total_items: number | null;
+        blocked_items: number | null;
+        active_leases: number | null;
+      };
+      return ok({
+        totalItems: row.total_items ?? 0,
+        blockedItems: row.blocked_items ?? 0,
+        activeLeases: row.active_leases ?? 0,
+      });
+    } catch (cause) {
+      return err(
+        new WorkflowError(
+          `Failed to summarize workflow operational view: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  private nextExpectedTransition(state: string): string {
+    switch (state) {
+      case 'blocked':
+        return 'resolve_blocker';
+      case 'in_progress':
+        return 'claim_update';
+      case 'awaiting_validation':
+        return 'validation_decision';
+      default:
+        return 'transition_request';
+    }
+  }
+}

--- a/src/workflow/workflow-service.ts
+++ b/src/workflow/workflow-service.ts
@@ -1,0 +1,443 @@
+import { err, ok, type Result } from 'neverthrow';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  AttachWorkflowEvidenceInputSchema,
+  CreateWorkflowItemInputSchema,
+  SubmitWorkflowClaimInputSchema,
+  type AcquireWorkflowLeaseInput,
+  type AttachWorkflowEvidenceInput,
+  type CreateWorkflowItemInput,
+  type ReleaseWorkflowLeaseInput,
+  type RenewWorkflowLeaseInput,
+  type RequestWorkflowTransitionInput,
+  type SubmitWorkflowClaimInput,
+  type WorkflowClaim,
+  type WorkflowDecision,
+  type WorkflowEvaluationSummary,
+  type WorkflowEvidence,
+  type WorkflowEvent,
+  type WorkflowIntervention,
+  type WorkflowItem,
+  type WorkflowLease,
+  type WorkflowRolloutMode,
+  WorkflowError,
+} from './workflow-types.js';
+import type {
+  WorkflowClaimRepository,
+  WorkflowEvidenceRepository,
+  WorkflowEventRepository,
+  WorkflowInterventionRepository,
+  WorkflowItemRepository,
+  WorkflowLeaseRepository,
+} from '../core/database/repositories/index.js';
+import type {
+  WorkflowPolicyRegistry,
+  WorkflowPolicyResolution,
+} from './workflow-policy-registry.js';
+import { orchestratorTaskPack } from './packs/orchestrator-task-pack.js';
+
+interface WorkflowKernelServiceOptions {
+  itemRepository: WorkflowItemRepository;
+  claimRepository: WorkflowClaimRepository;
+  evidenceRepository: WorkflowEvidenceRepository;
+  eventRepository: WorkflowEventRepository;
+  leaseRepository: WorkflowLeaseRepository;
+  interventionRepository: WorkflowInterventionRepository;
+  defaultRolloutMode?: WorkflowRolloutMode;
+  defaultPolicyPack?: string;
+  defaultPolicyVersion?: string;
+  evaluateDueWorkFn?: (now?: number) => Result<WorkflowEvaluationSummary, WorkflowError>;
+  policyRegistry?: WorkflowPolicyRegistry;
+  now?: () => number;
+}
+
+export class WorkflowKernelService {
+  private readonly itemRepository: WorkflowItemRepository;
+  private readonly claimRepository: WorkflowClaimRepository;
+  private readonly evidenceRepository: WorkflowEvidenceRepository;
+  private readonly eventRepository: WorkflowEventRepository;
+  private readonly leaseRepository: WorkflowLeaseRepository;
+  private readonly interventionRepository: WorkflowInterventionRepository;
+  private readonly defaultRolloutMode: WorkflowRolloutMode;
+  private readonly defaultPolicyPack: string;
+  private readonly defaultPolicyVersion: string;
+  private readonly evaluateDueWorkFn?: (now?: number) => Result<WorkflowEvaluationSummary, WorkflowError>;
+  private readonly policyRegistry?: WorkflowPolicyRegistry;
+  private readonly now: () => number;
+
+  constructor(options: WorkflowKernelServiceOptions) {
+    this.itemRepository = options.itemRepository;
+    this.claimRepository = options.claimRepository;
+    this.evidenceRepository = options.evidenceRepository;
+    this.eventRepository = options.eventRepository;
+    this.leaseRepository = options.leaseRepository;
+    this.interventionRepository = options.interventionRepository;
+    this.defaultRolloutMode = options.defaultRolloutMode ?? 'observe';
+    this.defaultPolicyPack = options.defaultPolicyPack ?? 'observe-only';
+    this.defaultPolicyVersion = options.defaultPolicyVersion ?? '1';
+    this.evaluateDueWorkFn = options.evaluateDueWorkFn;
+    this.policyRegistry = options.policyRegistry;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  createItem(input: CreateWorkflowItemInput): Result<WorkflowItem, WorkflowError> {
+    const parsed = CreateWorkflowItemInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return err(new WorkflowError(parsed.error.issues.map((issue) => issue.message).join('; ')));
+    }
+
+    const now = this.now();
+    const resolvedPolicy = this.resolvePolicy(parsed.data.workflowType);
+    const item: WorkflowItem = {
+      id: parsed.data.id,
+      workflowType: parsed.data.workflowType,
+      domain: parsed.data.domain,
+      title: parsed.data.title,
+      goal: parsed.data.goal,
+      state: 'intake',
+      statusReason: null,
+      rolloutMode:
+        parsed.data.rolloutMode
+        ?? resolvedPolicy?.rolloutMode
+        ?? this.defaultRolloutMode,
+      policyPack:
+        parsed.data.policyPack
+        ?? resolvedPolicy?.policyPack
+        ?? this.defaultPolicyPack,
+      policyVersion:
+        parsed.data.policyVersion
+        ?? resolvedPolicy?.policyVersion
+        ?? this.defaultPolicyVersion,
+      ownerActorId: parsed.data.ownerActorId ?? null,
+      sourceThreadId: parsed.data.sourceThreadId ?? null,
+      sourceMessageId: parsed.data.sourceMessageId ?? null,
+      sourceRunId: parsed.data.sourceRunId ?? null,
+      priority: parsed.data.priority,
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+    };
+
+    try {
+      this.itemRepository.transaction(() => {
+        const insertItem = this.itemRepository.insert(item);
+        if (insertItem.isErr()) {
+          throw insertItem.error;
+        }
+
+        const event = this.buildEvent({
+          workflowItemId: item.id,
+          eventType: 'workflow.created',
+          actorId: item.ownerActorId,
+          payload: {
+            state: item.state,
+            rolloutMode: item.rolloutMode,
+            policyPack: item.policyPack,
+          },
+        });
+        const insertEvent = this.eventRepository.insert(event);
+        if (insertEvent.isErr()) {
+          throw insertEvent.error;
+        }
+      });
+
+      return ok(item);
+    } catch (cause) {
+      return err(this.wrapError('Failed to create workflow item', cause));
+    }
+  }
+
+  submitClaim(input: SubmitWorkflowClaimInput): Result<WorkflowClaim, WorkflowError> {
+    const parsed = SubmitWorkflowClaimInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return err(new WorkflowError(parsed.error.issues.map((issue) => issue.message).join('; ')));
+    }
+
+    const itemResult = this.ensureWorkflowItem(parsed.data.workflowItemId);
+    if (itemResult.isErr()) {
+      return err(itemResult.error);
+    }
+
+    const now = this.now();
+    const claim: WorkflowClaim = {
+      id: parsed.data.id,
+      workflowItemId: parsed.data.workflowItemId,
+      claimType: parsed.data.claimType,
+      actorId: parsed.data.actorId,
+      actorKind: parsed.data.actorKind,
+      action: parsed.data.action,
+      target: parsed.data.target,
+      assertedOutcome: parsed.data.assertedOutcome,
+      summary: parsed.data.summary,
+      payload: parsed.data.payload,
+      status: 'pending',
+      policyDecision: null,
+      createdAt: now,
+      resolvedAt: null,
+    };
+
+    try {
+      this.itemRepository.transaction(() => {
+        const insertClaim = this.claimRepository.insert(claim);
+        if (insertClaim.isErr()) {
+          throw insertClaim.error;
+        }
+
+        const event = this.buildEvent({
+          workflowItemId: claim.workflowItemId,
+          eventType: 'workflow.claim_submitted',
+          actorId: claim.actorId,
+          correlationId: claim.id,
+          payload: {
+            claimType: claim.claimType,
+            action: claim.action,
+            target: claim.target,
+            assertedOutcome: claim.assertedOutcome,
+            status: claim.status,
+          },
+        });
+        const insertEvent = this.eventRepository.insert(event);
+        if (insertEvent.isErr()) {
+          throw insertEvent.error;
+        }
+      });
+
+      return ok(claim);
+    } catch (cause) {
+      return err(this.wrapError('Failed to submit workflow claim', cause));
+    }
+  }
+
+  attachEvidence(input: AttachWorkflowEvidenceInput): Result<WorkflowEvidence, WorkflowError> {
+    const parsed = AttachWorkflowEvidenceInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return err(new WorkflowError(parsed.error.issues.map((issue) => issue.message).join('; ')));
+    }
+
+    const itemResult = this.ensureWorkflowItem(parsed.data.workflowItemId);
+    if (itemResult.isErr()) {
+      return err(itemResult.error);
+    }
+
+    if (parsed.data.claimId) {
+      const claimResult = this.claimRepository.findById(parsed.data.claimId);
+      if (claimResult.isErr()) {
+        return err(this.wrapError('Failed to validate workflow claim for evidence', claimResult.error));
+      }
+      if (claimResult.value === null) {
+        return err(new WorkflowError(`Workflow claim ${parsed.data.claimId} does not exist`));
+      }
+    }
+
+    const evidence: WorkflowEvidence = {
+      id: parsed.data.id,
+      workflowItemId: parsed.data.workflowItemId,
+      claimId: parsed.data.claimId ?? null,
+      evidenceType: parsed.data.evidenceType,
+      source: parsed.data.source,
+      locator: parsed.data.locator,
+      capturedAt: parsed.data.capturedAt,
+      provenance: parsed.data.provenance,
+      payload: parsed.data.payload,
+      createdAt: this.now(),
+    };
+
+    try {
+      this.itemRepository.transaction(() => {
+        const insertEvidence = this.evidenceRepository.insert(evidence);
+        if (insertEvidence.isErr()) {
+          throw insertEvidence.error;
+        }
+
+        const event = this.buildEvent({
+          workflowItemId: evidence.workflowItemId,
+          eventType: 'workflow.evidence_added',
+          correlationId: evidence.id,
+          payload: {
+            claimId: evidence.claimId,
+            evidenceType: evidence.evidenceType,
+            source: evidence.source,
+            locator: evidence.locator,
+          },
+        });
+        const insertEvent = this.eventRepository.insert(event);
+        if (insertEvent.isErr()) {
+          throw insertEvent.error;
+        }
+      });
+
+      return ok(evidence);
+    } catch (cause) {
+      return err(this.wrapError('Failed to attach workflow evidence', cause));
+    }
+  }
+
+  requestTransition(_input: RequestWorkflowTransitionInput): Result<WorkflowDecision, WorkflowError> {
+    const itemResult = this.ensureWorkflowItem(_input.workflowItemId);
+    if (itemResult.isErr()) {
+      return err(itemResult.error);
+    }
+    const item = itemResult.value;
+    const decisionResult = this.evaluateTransitionDecision(item, _input.requestedState);
+    if (decisionResult.isErr()) {
+      return decisionResult;
+    }
+    const decision = decisionResult.value;
+    const now = this.now();
+
+    try {
+      this.itemRepository.transaction(() => {
+        const event = this.buildEvent({
+          workflowItemId: item.id,
+          eventType: 'workflow.transition_requested',
+          actorId: _input.actorId,
+          correlationId: _input.correlationId,
+          payload: {
+            requestedState: _input.requestedState,
+            reason: _input.reason,
+            decision: decision.decision,
+            reasonCodes: decision.reasonCodes,
+            missingEvidence: decision.missingEvidence,
+          },
+        });
+        const insertEvent = this.eventRepository.insert(event);
+        if (insertEvent.isErr()) {
+          throw insertEvent.error;
+        }
+
+        if (item.rolloutMode !== 'observe' && decision.decision === 'accepted') {
+          const updateItem = this.itemRepository.updateState(item.id, _input.requestedState, {
+            updatedAt: now,
+            completedAt:
+              _input.requestedState === 'done' || _input.requestedState === 'cancelled'
+                ? now
+                : item.completedAt,
+          });
+          if (updateItem.isErr()) {
+            throw updateItem.error;
+          }
+
+          const stateChangedEvent = this.buildEvent({
+            workflowItemId: item.id,
+            eventType: 'workflow.state_changed',
+            actorId: _input.actorId,
+            correlationId: _input.correlationId,
+            payload: {
+              fromState: item.state,
+              toState: _input.requestedState,
+              reason: _input.reason,
+            },
+          });
+          const insertStateChangedEvent = this.eventRepository.insert(stateChangedEvent);
+          if (insertStateChangedEvent.isErr()) {
+            throw insertStateChangedEvent.error;
+          }
+        }
+      });
+
+      return ok(decision);
+    } catch (cause) {
+      return err(this.wrapError('Failed to request workflow transition', cause));
+    }
+  }
+
+  acquireLease(_input: AcquireWorkflowLeaseInput): Result<WorkflowLease, WorkflowError> {
+    return err(new WorkflowError('Workflow lease acquisition is not implemented yet'));
+  }
+
+  renewLease(_input: RenewWorkflowLeaseInput): Result<WorkflowLease, WorkflowError> {
+    return err(new WorkflowError('Workflow lease renewal is not implemented yet'));
+  }
+
+  releaseLease(_input: ReleaseWorkflowLeaseInput): Result<void, WorkflowError> {
+    return err(new WorkflowError('Workflow lease release is not implemented yet'));
+  }
+
+  evaluateDueWork(_now?: number): Result<WorkflowEvaluationSummary, WorkflowError> {
+    return this.evaluateDueWorkFn?.(_now) ?? ok({ evaluatedItems: 0, interventionsRequested: 0 });
+  }
+
+  private ensureWorkflowItem(workflowItemId: string): Result<WorkflowItem, WorkflowError> {
+    const itemResult = this.itemRepository.findById(workflowItemId);
+    if (itemResult.isErr()) {
+      return err(this.wrapError('Failed to load workflow item', itemResult.error));
+    }
+    if (itemResult.value === null) {
+      return err(new WorkflowError(`Workflow item ${workflowItemId} does not exist`));
+    }
+    return ok(itemResult.value);
+  }
+
+  private buildEvent(input: {
+    workflowItemId: string;
+    eventType: string;
+    actorId?: string | null;
+    correlationId?: string | null;
+    payload: Record<string, unknown>;
+  }): WorkflowEvent {
+    return {
+      id: uuidv4(),
+      workflowItemId: input.workflowItemId,
+      eventType: input.eventType,
+      actorId: input.actorId ?? null,
+      correlationId: input.correlationId ?? null,
+      payload: input.payload,
+      createdAt: this.now(),
+    };
+  }
+
+  private wrapError(message: string, cause: unknown): WorkflowError {
+    if (cause instanceof WorkflowError) {
+      return cause;
+    }
+    return new WorkflowError(message, cause instanceof Error ? cause : undefined);
+  }
+
+  private resolvePolicy(workflowType: string): WorkflowPolicyResolution | null {
+    return this.policyRegistry?.resolve(workflowType) ?? null;
+  }
+
+  private evaluateTransitionDecision(
+    item: WorkflowItem,
+    requestedState: RequestWorkflowTransitionInput['requestedState'],
+  ): Result<WorkflowDecision, WorkflowError> {
+    if (item.rolloutMode !== 'authoritative') {
+      return ok({
+        decision: 'accepted',
+        reasonCodes: ['transition_recorded'],
+        missingEvidence: [],
+        recommendedIntervention: null,
+      });
+    }
+
+    const pack =
+      this.policyRegistry?.getPack(item.policyPack)
+      ?? (item.policyPack === orchestratorTaskPack.name ? orchestratorTaskPack : null);
+    if (!pack) {
+      return ok({
+        decision: 'rejected',
+        reasonCodes: ['policy_pack_not_found'],
+        missingEvidence: [],
+        recommendedIntervention: null,
+      });
+    }
+
+    const evidenceResult = this.evidenceRepository.listByWorkflowItemId(item.id);
+    if (evidenceResult.isErr()) {
+      return err(
+        this.wrapError(
+          'Failed to load workflow evidence for transition decision',
+          evidenceResult.error,
+        ),
+      );
+    }
+
+    return ok(
+      pack.evaluateTransition({
+        item,
+        requestedState,
+        evidence: evidenceResult.value,
+      }),
+    );
+  }
+}

--- a/src/workflow/workflow-types.ts
+++ b/src/workflow/workflow-types.ts
@@ -1,0 +1,203 @@
+import { z } from 'zod';
+
+const JsonRecordSchema = z.record(z.string(), z.unknown());
+
+export const WorkflowStateSchema = z.enum([
+  'intake',
+  'ready',
+  'in_progress',
+  'awaiting_validation',
+  'blocked',
+  'escalated',
+  'done',
+  'cancelled',
+]);
+
+export const WorkflowRolloutModeSchema = z.enum(['observe', 'guided', 'authoritative']);
+export const WorkflowActorKindSchema = z.enum(['persona', 'human', 'system', 'background_agent', 'tool']);
+export const WorkflowClaimStatusSchema = z.enum(['pending', 'accepted', 'rejected', 'superseded']);
+export const WorkflowLeaseStateSchema = z.enum(['active', 'expired', 'released']);
+export const WorkflowInterventionStatusSchema = z.enum(['pending', 'applied', 'dismissed']);
+export const WorkflowDecisionStateSchema = z.enum(['accepted', 'rejected', 'deferred']);
+
+export type WorkflowState = z.infer<typeof WorkflowStateSchema>;
+export type WorkflowRolloutMode = z.infer<typeof WorkflowRolloutModeSchema>;
+export type WorkflowActorKind = z.infer<typeof WorkflowActorKindSchema>;
+export type WorkflowClaimStatus = z.infer<typeof WorkflowClaimStatusSchema>;
+export type WorkflowLeaseState = z.infer<typeof WorkflowLeaseStateSchema>;
+export type WorkflowInterventionStatus = z.infer<typeof WorkflowInterventionStatusSchema>;
+export type WorkflowDecisionState = z.infer<typeof WorkflowDecisionStateSchema>;
+export type WorkflowJson = Record<string, unknown>;
+
+export interface WorkflowItem {
+  id: string;
+  workflowType: string;
+  domain: string;
+  title: string;
+  goal: WorkflowJson;
+  state: WorkflowState;
+  statusReason: string | null;
+  rolloutMode: WorkflowRolloutMode;
+  policyPack: string;
+  policyVersion: string;
+  ownerActorId: string | null;
+  sourceThreadId: string | null;
+  sourceMessageId: string | null;
+  sourceRunId: string | null;
+  priority: number;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+}
+
+export interface WorkflowClaim {
+  id: string;
+  workflowItemId: string;
+  claimType: string;
+  actorId: string;
+  actorKind: WorkflowActorKind;
+  action: string;
+  target: string;
+  assertedOutcome: string;
+  summary: string;
+  payload: WorkflowJson;
+  status: WorkflowClaimStatus;
+  policyDecision: WorkflowJson | null;
+  createdAt: number;
+  resolvedAt: number | null;
+}
+
+export interface WorkflowEvidence {
+  id: string;
+  workflowItemId: string;
+  claimId: string | null;
+  evidenceType: string;
+  source: string;
+  locator: string;
+  capturedAt: number;
+  provenance: WorkflowJson;
+  payload: WorkflowJson;
+  createdAt: number;
+}
+
+export interface WorkflowEvent {
+  id: string;
+  workflowItemId: string;
+  eventType: string;
+  actorId: string | null;
+  correlationId: string | null;
+  payload: WorkflowJson;
+  createdAt: number;
+}
+
+export interface WorkflowLease {
+  id: string;
+  workflowItemId: string;
+  actorId: string;
+  actorKind: WorkflowActorKind;
+  leaseState: WorkflowLeaseState;
+  acquiredAt: number;
+  renewedAt: number | null;
+  expiresAt: number;
+  releasedAt: number | null;
+}
+
+export interface WorkflowIntervention {
+  id: string;
+  workflowItemId: string;
+  interventionType: string;
+  reason: string;
+  status: WorkflowInterventionStatus;
+  payload: WorkflowJson;
+  createdAt: number;
+  resolvedAt: number | null;
+}
+
+export interface WorkflowDecision {
+  decision: WorkflowDecisionState;
+  reasonCodes: string[];
+  missingEvidence: string[];
+  recommendedIntervention: string | null;
+}
+
+export interface WorkflowEvaluationSummary {
+  evaluatedItems: number;
+  interventionsRequested: number;
+}
+
+export const CreateWorkflowItemInputSchema = z.object({
+  id: z.string().min(1),
+  workflowType: z.string().min(1),
+  domain: z.string().min(1),
+  title: z.string().min(1),
+  goal: JsonRecordSchema,
+  ownerActorId: z.string().min(1).optional(),
+  sourceThreadId: z.string().min(1).optional(),
+  sourceMessageId: z.string().min(1).optional(),
+  sourceRunId: z.string().min(1).optional(),
+  priority: z.number().int().default(0),
+  rolloutMode: WorkflowRolloutModeSchema.optional(),
+  policyPack: z.string().min(1).optional(),
+  policyVersion: z.string().min(1).optional(),
+});
+
+export const SubmitWorkflowClaimInputSchema = z.object({
+  id: z.string().min(1),
+  workflowItemId: z.string().min(1),
+  claimType: z.string().min(1),
+  actorId: z.string().min(1),
+  actorKind: WorkflowActorKindSchema,
+  action: z.string().min(1),
+  target: z.string().min(1),
+  assertedOutcome: z.string().min(1),
+  summary: z.string().min(1),
+  payload: JsonRecordSchema.default({}),
+});
+
+export const AttachWorkflowEvidenceInputSchema = z.object({
+  id: z.string().min(1),
+  workflowItemId: z.string().min(1),
+  claimId: z.string().min(1).nullable().optional(),
+  evidenceType: z.string().min(1),
+  source: z.string().min(1),
+  locator: z.string().min(1),
+  capturedAt: z.number().int().nonnegative(),
+  provenance: JsonRecordSchema,
+  payload: JsonRecordSchema.default({}),
+});
+
+export type CreateWorkflowItemInput = z.infer<typeof CreateWorkflowItemInputSchema>;
+export type SubmitWorkflowClaimInput = z.infer<typeof SubmitWorkflowClaimInputSchema>;
+export type AttachWorkflowEvidenceInput = z.infer<typeof AttachWorkflowEvidenceInputSchema>;
+
+export interface RequestWorkflowTransitionInput {
+  workflowItemId: string;
+  requestedState: WorkflowState;
+  actorId: string;
+  reason: string;
+  correlationId?: string;
+}
+
+export interface AcquireWorkflowLeaseInput {
+  id: string;
+  workflowItemId: string;
+  actorId: string;
+  actorKind: WorkflowActorKind;
+  expiresAt: number;
+}
+
+export interface RenewWorkflowLeaseInput {
+  leaseId: string;
+  expiresAt: number;
+}
+
+export interface ReleaseWorkflowLeaseInput {
+  leaseId: string;
+}
+
+export class WorkflowError extends Error {
+  constructor(message: string, readonly cause?: Error) {
+    super(message);
+    this.name = 'WorkflowError';
+  }
+}

--- a/src/workflow/workflow-watchdog.ts
+++ b/src/workflow/workflow-watchdog.ts
@@ -1,0 +1,157 @@
+import { v4 as uuidv4 } from 'uuid';
+import { err, ok, type Result } from 'neverthrow';
+
+import type {
+  WorkflowClaimRepository,
+  WorkflowEventRepository,
+  WorkflowInterventionRepository,
+  WorkflowItemRepository,
+  WorkflowLeaseRepository,
+} from '../core/database/repositories/index.js';
+import type { WorkflowEvaluationSummary } from './workflow-types.js';
+import { WorkflowError } from './workflow-types.js';
+
+interface WorkflowWatchdogOptions {
+  itemRepository: WorkflowItemRepository;
+  claimRepository: WorkflowClaimRepository;
+  eventRepository: WorkflowEventRepository;
+  leaseRepository: WorkflowLeaseRepository;
+  interventionRepository: WorkflowInterventionRepository;
+  claimRejectionThreshold?: number;
+  now?: () => number;
+}
+
+export class WorkflowWatchdog {
+  private readonly itemRepository: WorkflowItemRepository;
+  private readonly claimRepository: WorkflowClaimRepository;
+  private readonly eventRepository: WorkflowEventRepository;
+  private readonly leaseRepository: WorkflowLeaseRepository;
+  private readonly interventionRepository: WorkflowInterventionRepository;
+  private readonly claimRejectionThreshold: number;
+  private readonly now: () => number;
+
+  constructor(options: WorkflowWatchdogOptions) {
+    this.itemRepository = options.itemRepository;
+    this.claimRepository = options.claimRepository;
+    this.eventRepository = options.eventRepository;
+    this.leaseRepository = options.leaseRepository;
+    this.interventionRepository = options.interventionRepository;
+    this.claimRejectionThreshold = options.claimRejectionThreshold ?? 2;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  evaluate(now = this.now()): Result<WorkflowEvaluationSummary, WorkflowError> {
+    try {
+      let interventionsRequested = 0;
+
+      this.itemRepository.transaction(() => {
+        const expiringLeases = this.leaseRepository.listActiveExpiringBefore(now);
+        if (expiringLeases.isErr()) {
+          throw expiringLeases.error;
+        }
+
+        for (const lease of expiringLeases.value) {
+          const updateLease = this.leaseRepository.updateState(lease.id, 'expired');
+          if (updateLease.isErr()) {
+            throw updateLease.error;
+          }
+
+          const insertEvent = this.eventRepository.insert({
+            id: uuidv4(),
+            workflowItemId: lease.workflowItemId,
+            eventType: 'workflow.lease_expired',
+            actorId: lease.actorId,
+            correlationId: lease.id,
+            payload: {
+              leaseId: lease.id,
+              expiresAt: lease.expiresAt,
+            },
+            createdAt: now,
+          });
+          if (insertEvent.isErr()) {
+            throw insertEvent.error;
+          }
+        }
+
+        const items = this.itemRepository.listAll();
+        if (items.isErr()) {
+          throw items.error;
+        }
+
+        for (const item of items.value) {
+          const claims = this.claimRepository.listByWorkflowItemId(item.id);
+          if (claims.isErr()) {
+            throw claims.error;
+          }
+
+          const rejectedClaims = claims.value.filter((claim) => claim.status === 'rejected');
+          if (rejectedClaims.length < this.claimRejectionThreshold) {
+            continue;
+          }
+
+          const interventions = this.interventionRepository.listByWorkflowItemId(item.id);
+          if (interventions.isErr()) {
+            throw interventions.error;
+          }
+
+          const alreadyPending = interventions.value.some(
+            (intervention) =>
+              intervention.reason === 'claim_rejection_threshold_exceeded' &&
+              intervention.status === 'pending',
+          );
+          if (alreadyPending) {
+            continue;
+          }
+
+          const interventionId = uuidv4();
+          const insertIntervention = this.interventionRepository.insert({
+            id: interventionId,
+            workflowItemId: item.id,
+            interventionType: 'request_status_audit',
+            reason: 'claim_rejection_threshold_exceeded',
+            status: 'pending',
+            payload: {
+              rejectedClaimCount: rejectedClaims.length,
+            },
+            createdAt: now,
+            resolvedAt: null,
+          });
+          if (insertIntervention.isErr()) {
+            throw insertIntervention.error;
+          }
+
+          const insertEvent = this.eventRepository.insert({
+            id: uuidv4(),
+            workflowItemId: item.id,
+            eventType: 'workflow.intervention_requested',
+            actorId: null,
+            correlationId: interventionId,
+            payload: {
+              interventionType: 'request_status_audit',
+              reason: 'claim_rejection_threshold_exceeded',
+              rejectedClaimCount: rejectedClaims.length,
+            },
+            createdAt: now,
+          });
+          if (insertEvent.isErr()) {
+            throw insertEvent.error;
+          }
+
+          interventionsRequested += 1;
+        }
+      });
+
+      return ok({
+        evaluatedItems: this.itemRepository.listAll().match((items) => items.length, () => 0),
+        interventionsRequested,
+      });
+    } catch (cause) {
+      return err(
+        new WorkflowError(
+          `Failed to evaluate workflow watchdog state: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+}

--- a/talond.yaml.example
+++ b/talond.yaml.example
@@ -167,6 +167,23 @@ backgroundAgent:
         defaultModel: gemini-2.5-pro
 
 # ---------------------------------------------------------------------------
+# Workflow kernel — durable workflow state, claims/evidence, and watchdogs
+# ---------------------------------------------------------------------------
+workflow:
+  enabled: false                     # sidecar is off by default
+  defaultRolloutMode: observe        # observe | guided | authoritative
+  defaultPolicyPack: observe-only
+  bindings:
+    - workflowType: orchestrator_task
+      policyPack: orchestrator-task
+      rolloutMode: authoritative
+  watchdog:
+    enabled: true
+    evaluationIntervalMs: 30000
+    freshnessThresholdMs: 900000
+    claimRejectionThreshold: 2
+
+# ---------------------------------------------------------------------------
 # Scheduler — cron/interval/one-shot task execution engine
 # ---------------------------------------------------------------------------
 scheduler:

--- a/tests/integration/a2a/a2a-task-flow.test.ts
+++ b/tests/integration/a2a/a2a-task-flow.test.ts
@@ -21,10 +21,17 @@ import { QueueRepository } from '../../../src/core/database/repositories/queue-r
 import { ThreadRepository } from '../../../src/core/database/repositories/thread-repository.js';
 import { ChannelRepository } from '../../../src/core/database/repositories/channel-repository.js';
 import { PersonaRepository } from '../../../src/core/database/repositories/persona-repository.js';
+import { WorkflowItemRepository } from '../../../src/core/database/repositories/workflow-item-repository.js';
+import { WorkflowClaimRepository } from '../../../src/core/database/repositories/workflow-claim-repository.js';
+import { WorkflowEvidenceRepository } from '../../../src/core/database/repositories/workflow-evidence-repository.js';
+import { WorkflowEventRepository } from '../../../src/core/database/repositories/workflow-event-repository.js';
+import { WorkflowLeaseRepository } from '../../../src/core/database/repositories/workflow-lease-repository.js';
+import { WorkflowInterventionRepository } from '../../../src/core/database/repositories/workflow-intervention-repository.js';
 import { A2ATaskMapper } from '../../../src/a2a/a2a-task-mapper.js';
 import { A2AServer } from '../../../src/a2a/a2a-server.js';
 import { buildAgentCardRegistry } from '../../../src/a2a/persona-agent-card.js';
 import type { LoadedPersona } from '../../../src/personas/persona-types.js';
+import { WorkflowKernelService } from '../../../src/workflow/workflow-service.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -276,5 +283,91 @@ describe('A2A Task Flow Integration', () => {
     const body = await res.json() as { error?: { message: string } };
     expect(body.error).toBeDefined();
     expect(body.error?.message).toMatch(/hop/i);
+  });
+
+  it('stores workflow linkage in the durable A2A task payload when provided', () => {
+    const workflowService = new WorkflowKernelService({
+      itemRepository: new WorkflowItemRepository(db),
+      claimRepository: new WorkflowClaimRepository(db),
+      evidenceRepository: new WorkflowEvidenceRepository(db),
+      eventRepository: new WorkflowEventRepository(db),
+      leaseRepository: new WorkflowLeaseRepository(db),
+      interventionRepository: new WorkflowInterventionRepository(db),
+    });
+    const workflowItem = workflowService.createItem({
+      id: uuidv4(),
+      workflowType: 'orchestrator_task',
+      domain: 'operations',
+      title: 'Coordinate delegated task',
+      goal: { deliverable: 'verified output' },
+      ownerActorId: 'assistant',
+      sourceThreadId: threadId,
+      rolloutMode: 'authoritative',
+      policyPack: 'orchestrator-task',
+      policyVersion: '1',
+    })._unsafeUnwrap();
+
+    const submitResult = mapper.submitTask({
+      sourcePersona: 'assistant',
+      targetPersona: 'software-engineer',
+      sourceThreadId: threadId,
+      content: 'Review PR #42',
+      hopCount: 0,
+      workflowItemId: workflowItem.id,
+    } as any);
+
+    expect(submitResult.isOk()).toBe(true);
+    expect((submitResult._unsafeUnwrap() as any).workflowItemId).toBe(workflowItem.id);
+
+    const taskRow = taskRepo.findById(submitResult._unsafeUnwrap().taskId)._unsafeUnwrap();
+    const requestPayload = JSON.parse(taskRow!.request_payload) as { workflowItemId?: string };
+    expect(requestPayload.workflowItemId).toBe(workflowItem.id);
+
+    const queueRow = queueRepo.findById(submitResult._unsafeUnwrap().queueItemId!)._unsafeUnwrap();
+    const payload = JSON.parse(queueRow!.payload as unknown as string) as { metadata?: { workflow?: { workflowItemId?: string } } };
+    expect(payload.metadata?.workflow?.workflowItemId).toBe(workflowItem.id);
+  });
+
+  it('rejects authoritative completion transitions without required evidence', () => {
+    const itemRepository = new WorkflowItemRepository(db);
+    const workflowService = new WorkflowKernelService({
+      itemRepository,
+      claimRepository: new WorkflowClaimRepository(db),
+      evidenceRepository: new WorkflowEvidenceRepository(db),
+      eventRepository: new WorkflowEventRepository(db),
+      leaseRepository: new WorkflowLeaseRepository(db),
+      interventionRepository: new WorkflowInterventionRepository(db),
+    });
+    const workflowItem = workflowService.createItem({
+      id: uuidv4(),
+      workflowType: 'orchestrator_task',
+      domain: 'operations',
+      title: 'Coordinate delegated task',
+      goal: { deliverable: 'verified output' },
+      ownerActorId: 'assistant',
+      sourceThreadId: threadId,
+      rolloutMode: 'authoritative',
+      policyPack: 'orchestrator-task',
+      policyVersion: '1',
+    })._unsafeUnwrap();
+
+    workflowService.requestTransition({
+      workflowItemId: workflowItem.id,
+      requestedState: 'ready',
+      actorId: 'assistant',
+      reason: 'a2a_submitted',
+      correlationId: 'task-123',
+    });
+    const completionResult = workflowService.requestTransition({
+      workflowItemId: workflowItem.id,
+      requestedState: 'done',
+      actorId: 'assistant',
+      reason: 'a2a_completed',
+      correlationId: 'task-123',
+    });
+
+    expect(completionResult.isOk()).toBe(true);
+    expect(completionResult._unsafeUnwrap().decision).toBe('rejected');
+    expect(itemRepository.findById(workflowItem.id)._unsafeUnwrap()?.state).toBe('ready');
   });
 });

--- a/tests/integration/workflow/workflow-kernel-sidecar.test.ts
+++ b/tests/integration/workflow/workflow-kernel-sidecar.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTestDb, uuid } from '../../unit/core/database/repositories/helpers.js';
+import {
+  WorkflowItemRepository,
+  WorkflowClaimRepository,
+  WorkflowEvidenceRepository,
+  WorkflowEventRepository,
+  WorkflowLeaseRepository,
+  WorkflowInterventionRepository,
+} from '../../../src/core/database/repositories/index.js';
+import { WorkflowKernelService } from '../../../src/workflow/workflow-service.js';
+
+function createWorkflowService() {
+  const db = createTestDb();
+  const itemRepository = new WorkflowItemRepository(db);
+  const workflowService = new WorkflowKernelService({
+    itemRepository,
+    claimRepository: new WorkflowClaimRepository(db),
+    evidenceRepository: new WorkflowEvidenceRepository(db),
+    eventRepository: new WorkflowEventRepository(db),
+    leaseRepository: new WorkflowLeaseRepository(db),
+    interventionRepository: new WorkflowInterventionRepository(db),
+  });
+
+  return { db, itemRepository, workflowService };
+}
+
+describe('Workflow kernel sidecar integration', () => {
+  it('observe mode records completion requests without blocking the runtime path', () => {
+    const { db, itemRepository, workflowService } = createWorkflowService();
+    const item = workflowService.createItem({
+      id: uuid(),
+      workflowType: 'orchestrator_task',
+      domain: 'operations',
+      title: 'Coordinate delegated task',
+      goal: { deliverable: 'verified output' },
+      ownerActorId: 'assistant',
+      sourceThreadId: 'thread-001',
+      rolloutMode: 'observe',
+      policyPack: 'orchestrator-task',
+      policyVersion: '1',
+    })._unsafeUnwrap();
+
+    const result = workflowService.requestTransition({
+      workflowItemId: item.id,
+      requestedState: 'done',
+      actorId: 'assistant',
+      reason: 'a2a_completed',
+      correlationId: 'task-123',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap().decision).toBe('accepted');
+    expect(itemRepository.findById(item.id)._unsafeUnwrap()?.state).toBe('intake');
+
+    db.close();
+  });
+
+  it('authoritative orchestrator mode rejects completion without the required evidence', () => {
+    const { db, itemRepository, workflowService } = createWorkflowService();
+    const item = workflowService.createItem({
+      id: uuid(),
+      workflowType: 'orchestrator_task',
+      domain: 'operations',
+      title: 'Coordinate delegated task',
+      goal: { deliverable: 'verified output' },
+      ownerActorId: 'assistant',
+      sourceThreadId: 'thread-001',
+      rolloutMode: 'authoritative',
+      policyPack: 'orchestrator-task',
+      policyVersion: '1',
+    })._unsafeUnwrap();
+
+    workflowService.requestTransition({
+      workflowItemId: item.id,
+      requestedState: 'ready',
+      actorId: 'assistant',
+      reason: 'a2a_submitted',
+      correlationId: 'task-123',
+    });
+    const result = workflowService.requestTransition({
+      workflowItemId: item.id,
+      requestedState: 'done',
+      actorId: 'assistant',
+      reason: 'a2a_completed',
+      correlationId: 'task-123',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap().decision).toBe('rejected');
+    expect(itemRepository.findById(item.id)._unsafeUnwrap()?.state).toBe('ready');
+
+    db.close();
+  });
+});

--- a/tests/unit/core/config/config-loader.test.ts
+++ b/tests/unit/core/config/config-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { writeFileSync, unlinkSync, mkdirSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadConfig, loadConfigFromString, validateConfig } from '../../../../src/core/config/config-loader.js';
@@ -256,6 +256,26 @@ agentRunner:
           summarizer: 'session-summarizer',
         },
       });
+    }
+  });
+
+  it('loads the root talond.yaml.example successfully', () => {
+    const example = readFileSync(join(process.cwd(), 'talond.yaml.example'), 'utf8');
+    const result = loadConfigFromString(example);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.workflow.defaultRolloutMode).toBe('observe');
+    }
+  });
+
+  it('loads config/talond.example.yaml successfully', () => {
+    const example = readFileSync(join(process.cwd(), 'config/talond.example.yaml'), 'utf8');
+    const result = loadConfigFromString(example);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.workflow.defaultRolloutMode).toBe('observe');
     }
   });
 

--- a/tests/unit/core/config/config-schema.test.ts
+++ b/tests/unit/core/config/config-schema.test.ts
@@ -4,6 +4,7 @@ import {
   LangfuseConfigSchema,
   StorageConfigSchema,
   SandboxConfigSchema,
+  WorkflowConfigSchema,
   ExecutionEnvResourceLimitsSchema,
   CapabilitiesSchema,
   MountConfigSchema,
@@ -75,6 +76,55 @@ describe('LangfuseConfigSchema', () => {
         secretKey: '',
       }).success,
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkflowConfigSchema
+// ---------------------------------------------------------------------------
+
+describe('WorkflowConfigSchema', () => {
+  it('defaults to disabled observational mode', () => {
+    const result = WorkflowConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.enabled).toBe(false);
+      expect(result.data.defaultRolloutMode).toBe('observe');
+      expect(result.data.defaultPolicyPack).toBe('observe-only');
+      expect(result.data.bindings).toEqual([]);
+      expect(result.data.watchdog).toEqual({
+        enabled: true,
+        evaluationIntervalMs: 30_000,
+        freshnessThresholdMs: 15 * 60 * 1000,
+        claimRejectionThreshold: 2,
+      });
+    }
+  });
+
+  it('accepts explicit authoritative bindings when enabled', () => {
+    const result = WorkflowConfigSchema.safeParse({
+      enabled: true,
+      defaultRolloutMode: 'guided',
+      bindings: [
+        {
+          workflowType: 'orchestrator_task',
+          policyPack: 'orchestrator-task',
+          rolloutMode: 'authoritative',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.enabled).toBe(true);
+      expect(result.data.defaultRolloutMode).toBe('guided');
+      expect(result.data.bindings).toEqual([
+        {
+          workflowType: 'orchestrator_task',
+          policyPack: 'orchestrator-task',
+          rolloutMode: 'authoritative',
+        },
+      ]);
+    }
   });
 });
 
@@ -869,6 +919,18 @@ describe('TalondConfigSchema', () => {
           },
         },
       });
+      expect(result.data.workflow).toEqual({
+        enabled: false,
+        defaultRolloutMode: 'observe',
+        defaultPolicyPack: 'observe-only',
+        bindings: [],
+        watchdog: {
+          enabled: true,
+          evaluationIntervalMs: 30_000,
+          freshnessThresholdMs: 15 * 60 * 1000,
+          claimRejectionThreshold: 2,
+        },
+      });
       expect(result.data.sprites).toEqual({
         enabled: false,
         token: '',
@@ -938,6 +1000,24 @@ describe('TalondConfigSchema', () => {
           },
         },
       },
+      workflow: {
+        enabled: true,
+        defaultRolloutMode: 'guided',
+        defaultPolicyPack: 'observe-only',
+        bindings: [
+          {
+            workflowType: 'orchestrator_task',
+            policyPack: 'orchestrator-task',
+            rolloutMode: 'authoritative',
+          },
+        ],
+        watchdog: {
+          enabled: true,
+          evaluationIntervalMs: 15_000,
+          freshnessThresholdMs: 120_000,
+          claimRejectionThreshold: 3,
+        },
+      },
       sprites: {
         enabled: true,
         token: 'sprites-token',
@@ -967,6 +1047,8 @@ describe('TalondConfigSchema', () => {
       expect(result.data.channels).toHaveLength(1);
       expect(result.data.personas).toHaveLength(1);
       expect(result.data.backgroundAgent.enabled).toBe(false);
+      expect(result.data.workflow.bindings).toHaveLength(1);
+      expect(result.data.workflow.bindings[0]?.rolloutMode).toBe('authoritative');
       expect(result.data.sprites.enabled).toBe(true);
       expect(result.data.sprites.resourceLimits.diskGb).toBe(40);
       expect(result.data.langfuse.release).toBe('abcdef1234');

--- a/tests/unit/daemon/agent-runner.test.ts
+++ b/tests/unit/daemon/agent-runner.test.ts
@@ -50,6 +50,16 @@ import type { DaemonContext } from '../../../src/daemon/daemon-context.js';
 import { type QueueItem, QueueItemStatus } from '../../../src/queue/queue-types.js';
 import { ProviderRegistry } from '../../../src/providers/provider-registry.js';
 import { ClaudeCodeProvider } from '../../../src/providers/claude-code-provider.js';
+import { createTestDb, uuid } from '../core/database/repositories/helpers.js';
+import {
+  WorkflowItemRepository,
+  WorkflowClaimRepository,
+  WorkflowEvidenceRepository,
+  WorkflowEventRepository,
+  WorkflowLeaseRepository,
+  WorkflowInterventionRepository,
+} from '../../../src/core/database/repositories/index.js';
+import { WorkflowKernelService } from '../../../src/workflow/workflow-service.js';
 import type {
   ObservationHandle,
   StartedObservationHandle,
@@ -154,6 +164,9 @@ function makeMockContext(): DaemonContext {
           name: 'TestBot',
         })),
       } as any,
+      backgroundTask: {} as any,
+      executionEnv: {} as any,
+      executionEnvCheckpoint: {} as any,
       schedule: {} as any,
       audit: {} as any,
       message: {
@@ -169,6 +182,13 @@ function makeMockContext(): DaemonContext {
       } as any,
       binding: {} as any,
       memory: {} as any,
+      a2aTask: {} as any,
+      workflowItem: {} as any,
+      workflowClaim: {} as any,
+      workflowEvidence: {} as any,
+      workflowEvent: {} as any,
+      workflowLease: {} as any,
+      workflowIntervention: {} as any,
     },
     channelRegistry: {
       get: vi.fn().mockReturnValue({
@@ -233,6 +253,16 @@ function makeMockContext(): DaemonContext {
         await fn(makeObservationHandle(null))),
       shutdown: vi.fn().mockResolvedValue(undefined),
     } as any,
+    workflowService: {
+      submitClaim: vi.fn().mockReturnValue(ok({})),
+      attachEvidence: vi.fn().mockReturnValue(ok({})),
+      requestTransition: vi.fn().mockReturnValue(ok({
+        decision: 'accepted',
+        reasonCodes: ['observed_request'],
+        missingEvidence: [],
+        recommendedIntervention: null,
+      })),
+    } as any,
     hostToolsBridge: {
       path: '/tmp/test-data/host-tools.sock',
     } as any,
@@ -244,8 +274,43 @@ function makeMockContext(): DaemonContext {
         'claude-code': (config) => new ClaudeCodeProvider(config),
       },
     ),
+    subAgentRunner: null,
     backgroundAgentManager: null,
+    executionEnvManager: null,
+    a2aServer: null,
+    a2aTaskMapper: null,
     logger: mockLogger as any,
+  };
+}
+
+function createWorkflowHarness() {
+  const db = createTestDb();
+  const itemRepository = new WorkflowItemRepository(db);
+  const claimRepository = new WorkflowClaimRepository(db);
+  const evidenceRepository = new WorkflowEvidenceRepository(db);
+  const eventRepository = new WorkflowEventRepository(db);
+  const leaseRepository = new WorkflowLeaseRepository(db);
+  const interventionRepository = new WorkflowInterventionRepository(db);
+  const workflowService = new WorkflowKernelService({
+    itemRepository,
+    claimRepository,
+    evidenceRepository,
+    eventRepository,
+    leaseRepository,
+    interventionRepository,
+  });
+
+  return {
+    db,
+    workflowService,
+    repositories: {
+      item: itemRepository,
+      claim: claimRepository,
+      evidence: evidenceRepository,
+      event: eventRepository,
+      lease: leaseRepository,
+      intervention: interventionRepository,
+    },
   };
 }
 
@@ -3536,6 +3601,133 @@ describe('AgentRunner', () => {
       // Internal tools should NOT produce a tool call description
       const toolDescriptions = sendBodies.filter((b) => b.startsWith('💾') || b.startsWith('🔧'));
       expect(toolDescriptions).toHaveLength(0);
+    });
+  });
+
+  describe('workflow runtime hooks', () => {
+    it('records progress claims for queue items that reference an existing workflow item', async () => {
+      const workflow = createWorkflowHarness();
+      const workflowItem = workflow.workflowService.createItem({
+        id: uuid(),
+        workflowType: 'orchestrator_task',
+        domain: 'operations',
+        title: 'Coordinate delegated task',
+        goal: { deliverable: 'verified output' },
+        ownerActorId: 'persona-001',
+        sourceThreadId: 'thread-001',
+      })._unsafeUnwrap();
+
+      const baseCtx = makeMockContext();
+      ctx = {
+        ...baseCtx,
+        repos: {
+          ...baseCtx.repos,
+          workflowItem: workflow.repositories.item,
+          workflowClaim: workflow.repositories.claim,
+          workflowEvidence: workflow.repositories.evidence,
+          workflowEvent: workflow.repositories.event,
+          workflowLease: workflow.repositories.lease,
+          workflowIntervention: workflow.repositories.intervention,
+        },
+        workflowService: workflow.workflowService,
+      };
+      runner = new AgentRunner(ctx);
+      mockQuery.mockReturnValue(makeAgentStream());
+
+      const result = await runner.run(
+        makeQueueItem({
+          payload: {
+            personaId: 'persona-001',
+            content: 'Continue the delegated work',
+            workflow: {
+              workflowItemId: workflowItem.id,
+              claim: {
+                claimType: 'progress',
+                action: 'report_progress',
+                target: 'delegated-task',
+                assertedOutcome: 'in_progress',
+                summary: 'Progress checkpoint recorded.',
+                payload: { percentComplete: 50 },
+              },
+            },
+          },
+        }),
+      );
+
+      expect(result.isOk()).toBe(true);
+      const claims = workflow.repositories.claim.listByWorkflowItemId(workflowItem.id)._unsafeUnwrap();
+      expect(claims).toHaveLength(1);
+      expect(claims[0]?.claimType).toBe('progress');
+      expect(claims[0]?.summary).toBe('Progress checkpoint recorded.');
+
+      workflow.db.close();
+    });
+
+    it('records blockage claims and transition requests as append-only workflow events', async () => {
+      const workflow = createWorkflowHarness();
+      const workflowItem = workflow.workflowService.createItem({
+        id: uuid(),
+        workflowType: 'orchestrator_task',
+        domain: 'operations',
+        title: 'Coordinate delegated task',
+        goal: { deliverable: 'verified output' },
+        ownerActorId: 'persona-001',
+        sourceThreadId: 'thread-001',
+      })._unsafeUnwrap();
+
+      const baseCtx = makeMockContext();
+      ctx = {
+        ...baseCtx,
+        repos: {
+          ...baseCtx.repos,
+          workflowItem: workflow.repositories.item,
+          workflowClaim: workflow.repositories.claim,
+          workflowEvidence: workflow.repositories.evidence,
+          workflowEvent: workflow.repositories.event,
+          workflowLease: workflow.repositories.lease,
+          workflowIntervention: workflow.repositories.intervention,
+        },
+        workflowService: workflow.workflowService,
+      };
+      runner = new AgentRunner(ctx);
+      mockQuery.mockReturnValue(makeAgentStream());
+
+      const result = await runner.run(
+        makeQueueItem({
+          payload: {
+            personaId: 'persona-001',
+            content: 'I am blocked waiting for credentials',
+            workflow: {
+              workflowItemId: workflowItem.id,
+              claim: {
+                claimType: 'blockage',
+                action: 'report_blocker',
+                target: 'delegated-task',
+                assertedOutcome: 'blocked',
+                summary: 'Blocked on missing credential.',
+                payload: { reason: 'missing_credential' },
+              },
+              transition: {
+                requestedState: 'blocked',
+                reason: 'missing_credential',
+                correlationId: 'claim-blocked-001',
+              },
+            },
+          },
+        }),
+      );
+
+      expect(result.isOk()).toBe(true);
+      const updatedItem = workflow.repositories.item.findById(workflowItem.id)._unsafeUnwrap();
+      const events = workflow.repositories.event.listByWorkflowItemId(workflowItem.id)._unsafeUnwrap();
+      expect(updatedItem?.state).toBe('intake');
+      expect(events.map((event) => event.eventType)).toEqual([
+        'workflow.created',
+        'workflow.claim_submitted',
+        'workflow.transition_requested',
+      ]);
+
+      workflow.db.close();
     });
   });
 

--- a/tests/unit/daemon/daemon-bootstrap.test.ts
+++ b/tests/unit/daemon/daemon-bootstrap.test.ts
@@ -42,6 +42,12 @@ vi.mock('../../../src/core/database/repositories/index.js', () => ({
   BindingRepository: vi.fn().mockImplementation(() => ({})),
   MemoryRepository: vi.fn().mockImplementation(() => ({})),
   A2ATaskRepository: vi.fn().mockImplementation(() => ({})),
+  WorkflowItemRepository: vi.fn().mockImplementation(() => ({})),
+  WorkflowClaimRepository: vi.fn().mockImplementation(() => ({})),
+  WorkflowEvidenceRepository: vi.fn().mockImplementation(() => ({})),
+  WorkflowEventRepository: vi.fn().mockImplementation(() => ({})),
+  WorkflowLeaseRepository: vi.fn().mockImplementation(() => ({})),
+  WorkflowInterventionRepository: vi.fn().mockImplementation(() => ({})),
 }));
 
 vi.mock('../../../src/core/database/repositories/audit-repository.js', () => ({
@@ -242,6 +248,18 @@ function makeConfig(overrides: Record<string, unknown> = {}): unknown {
       defaultProvider: 'claude-code',
       providers: {
         'claude-code': makeBackgroundProviderConfig(),
+      },
+    },
+    workflow: {
+      enabled: false,
+      defaultRolloutMode: 'observe',
+      defaultPolicyPack: 'observe-only',
+      bindings: [],
+      watchdog: {
+        enabled: true,
+        evaluationIntervalMs: 30000,
+        freshnessThresholdMs: 15 * 60 * 1000,
+        claimRejectionThreshold: 2,
       },
     },
     sprites: {
@@ -461,6 +479,12 @@ describe('bootstrap', () => {
       expect(ctx.repos.run).toBeDefined();
       expect(ctx.repos.binding).toBeDefined();
       expect(ctx.repos.memory).toBeDefined();
+      expect(ctx.repos.workflowItem).toBeDefined();
+      expect(ctx.repos.workflowClaim).toBeDefined();
+      expect(ctx.repos.workflowEvidence).toBeDefined();
+      expect(ctx.repos.workflowEvent).toBeDefined();
+      expect(ctx.repos.workflowLease).toBeDefined();
+      expect(ctx.repos.workflowIntervention).toBeDefined();
       expect(ctx.channelRegistry).toBeDefined();
       expect(ctx.queueManager).toBeDefined();
       expect(ctx.scheduler).toBeDefined();
@@ -474,6 +498,7 @@ describe('bootstrap', () => {
       expect(ctx.backgroundAgentManager).toBeDefined();
       expect(ctx.providerRegistry).toBeDefined();
       expect(ctx.observability).toBeDefined();
+      expect(ctx.workflowService).toBeDefined();
       expect(ctx.logger).toBeDefined();
     });
 

--- a/tests/unit/daemon/daemon.test.ts
+++ b/tests/unit/daemon/daemon.test.ts
@@ -94,6 +94,18 @@ function makeMockContext(overrides: Partial<DaemonContext> = {}): DaemonContext 
         resourceLimits: { memoryMb: 1024, cpus: 1, pidsLimit: 256 },
       },
       auth: { mode: 'subscription' },
+      workflow: {
+        enabled: false,
+        defaultRolloutMode: 'observe',
+        defaultPolicyPack: 'observe-only',
+        bindings: [],
+        watchdog: {
+          enabled: true,
+          evaluationIntervalMs: 30_000,
+          freshnessThresholdMs: 15 * 60 * 1000,
+          claimRejectionThreshold: 2,
+        },
+      },
     } as any,
     configPath: '/etc/talond/config.yaml',
     dataDir: '/tmp/test-data',
@@ -103,12 +115,21 @@ function makeMockContext(overrides: Partial<DaemonContext> = {}): DaemonContext 
       channel: {} as any,
       persona: {} as any,
       backgroundTask: {} as any,
+      executionEnv: {} as any,
+      executionEnvCheckpoint: {} as any,
       schedule: {} as any,
       audit: {} as any,
       message: {} as any,
       run: { aggregateByPeriod: vi.fn().mockReturnValue(ok({ total_input_tokens: 0, total_output_tokens: 0, total_cost_usd: 0 })) } as any,
       binding: {} as any,
       memory: {} as any,
+      a2aTask: {} as any,
+      workflowItem: {} as any,
+      workflowClaim: {} as any,
+      workflowEvidence: {} as any,
+      workflowEvent: {} as any,
+      workflowLease: {} as any,
+      workflowIntervention: {} as any,
     },
     channelRegistry: {
       startAll: vi.fn().mockResolvedValue(undefined),
@@ -149,8 +170,22 @@ function makeMockContext(overrides: Partial<DaemonContext> = {}): DaemonContext 
       observe: vi.fn(),
       observeWithTraceparent: vi.fn(),
     } as any,
+    workflowService: {
+      evaluateDueWork: vi.fn().mockReturnValue(ok({ evaluatedItems: 0, interventionsRequested: 0 })),
+    } as any,
+    workflowReadModel: {
+      summarizeOperationalView: vi.fn().mockReturnValue(ok({
+        totalItems: 0,
+        blockedItems: 0,
+        activeLeases: 0,
+      })),
+    } as any,
     hostToolsBridge: { path: '/tmp/host-tools.sock', start: vi.fn(), stop: vi.fn() } as any,
+    subAgentRunner: null,
     logger: mockLogger as any,
+    executionEnvManager: null,
+    a2aServer: null,
+    a2aTaskMapper: null,
     ...overrides,
   };
 }
@@ -266,6 +301,33 @@ describe('TalondDaemon', () => {
       await daemon.start('/config.yaml');
 
       expect(ctx.scheduler.start).toHaveBeenCalledOnce();
+    });
+
+    it('starts periodic workflow watchdog evaluation when workflow watchdog is enabled', async () => {
+      vi.useFakeTimers();
+      const ctx = setupSuccessfulBootstrap({
+        config: {
+          ...makeMockContext().config,
+          workflow: {
+            enabled: true,
+            defaultRolloutMode: 'observe',
+            defaultPolicyPack: 'observe-only',
+            bindings: [],
+            watchdog: {
+              enabled: true,
+              evaluationIntervalMs: 15_000,
+              freshnessThresholdMs: 15 * 60 * 1000,
+              claimRejectionThreshold: 2,
+            },
+          },
+        } as any,
+      });
+
+      await daemon.start('/config.yaml');
+      vi.advanceTimersByTime(15_000);
+
+      expect(ctx.workflowService.evaluateDueWork).toHaveBeenCalled();
+      vi.useRealTimers();
     });
 
     it('writes the PID file on successful start', async () => {

--- a/tests/unit/tools/background-agent.test.ts
+++ b/tests/unit/tools/background-agent.test.ts
@@ -216,6 +216,13 @@ describe('BackgroundAgentHandler', () => {
     expect(backgroundAgentManager.spawn.mock.calls[0][0].personaPrompt).not.toContain(
       'Skill instructions.',
     );
+    expect((result as any).workflowMetadata?.evidence).toEqual(
+      expect.objectContaining({
+        evidenceType: 'background_task_spawned',
+        source: 'background_task',
+        locator: 'task:task-1',
+      }),
+    );
   });
 
   it('uses lazy skill loading — system prompt contains skill index not full skill content', async () => {
@@ -460,6 +467,94 @@ describe('BackgroundAgentHandler', () => {
     expect(result.error).toContain('does not belong to the current thread');
     expect(backgroundAgentManager.getResult).not.toHaveBeenCalled();
   });
+
+  it('returns completed-task result metadata as workflow evidence', async () => {
+    const completedTask = makeTask({
+      status: 'completed',
+      completedAt: 2_000,
+      output: 'Done!',
+    });
+    const completedResult = makeResult({
+      status: 'completed',
+      output: 'Done!',
+    });
+    const completedManager = {
+      spawn: vi.fn().mockResolvedValue(ok('task-1')),
+      listTasksForThread: vi.fn().mockReturnValue(ok([completedTask])),
+      getTask: vi.fn().mockReturnValue(ok(completedTask)),
+      cancel: vi.fn().mockResolvedValue(ok(true)),
+      getResult: vi.fn().mockReturnValue(ok(completedResult)),
+    };
+    const { handler } = createHandler({
+      backgroundAgentManager: completedManager,
+    });
+
+    const result = await handler.execute(
+      { action: 'result', taskId: 'task-1' },
+      {
+        runId: 'run-1',
+        threadId: 'thread-1',
+        personaId: 'persona-1',
+        requestId: 'req-1',
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(result.result).toEqual(completedResult);
+    expect((result as any).workflowMetadata?.evidence).toEqual(
+      expect.objectContaining({
+        evidenceType: 'background_task_completed',
+        locator: 'task:task-1',
+      }),
+    );
+    expect(completedManager.getResult).toHaveBeenCalledWith('task-1');
+  });
+
+  it.each([
+    ['timed_out', 'background_task_timed_out'],
+    ['failed', 'background_task_failed'],
+  ] as const)(
+    'returns %s task metadata as %s workflow evidence',
+    async (status, evidenceType) => {
+      const task = makeTask({
+        status,
+        completedAt: 2_000,
+        error: status === 'failed' ? 'process crashed' : 'Process timed out',
+      });
+      const taskResult = makeResult({
+        status,
+        output: status === 'timed_out' ? 'Partial output' : null,
+        error: task.error,
+      });
+      const { handler } = createHandler({
+        backgroundAgentManager: {
+          spawn: vi.fn().mockResolvedValue(ok('task-1')),
+          listTasksForThread: vi.fn().mockReturnValue(ok([task])),
+          getTask: vi.fn().mockReturnValue(ok(task)),
+          cancel: vi.fn().mockResolvedValue(ok(true)),
+          getResult: vi.fn().mockReturnValue(ok(taskResult)),
+        },
+      });
+
+      const result = await handler.execute(
+        { action: 'result', taskId: 'task-1' },
+        {
+          runId: 'run-1',
+          threadId: 'thread-1',
+          personaId: 'persona-1',
+          requestId: 'req-1',
+        },
+      );
+
+      expect(result.status).toBe('success');
+      expect((result as any).workflowMetadata?.evidence).toEqual(
+        expect.objectContaining({
+          evidenceType,
+          locator: 'task:task-1',
+        }),
+      );
+    },
+  );
 
   describe('profile parameter', () => {
     it('spawns with profile persona when a valid profile name is given', async () => {

--- a/tests/unit/tools/host-tools/persona-send.test.ts
+++ b/tests/unit/tools/host-tools/persona-send.test.ts
@@ -118,6 +118,42 @@ function makePersonaRepo(): PersonaRepository {
   } as unknown as PersonaRepository;
 }
 
+function makeWorkflowService() {
+  return {
+    createItem: vi.fn().mockReturnValue(
+      ok({
+        id: 'workflow-123',
+        workflowType: 'orchestrator_task',
+        domain: 'operations',
+        title: 'Delegate to researcher',
+        goal: { targetPersona: 'researcher' },
+        state: 'intake',
+        statusReason: null,
+        rolloutMode: 'authoritative',
+        policyPack: 'orchestrator-task',
+        policyVersion: '1',
+        ownerActorId: 'persona-001',
+        sourceThreadId: 'thread-001',
+        sourceMessageId: null,
+        sourceRunId: 'run-001',
+        priority: 0,
+        createdAt: 1_000,
+        updatedAt: 1_000,
+        completedAt: null,
+      }),
+    ),
+    attachEvidence: vi.fn().mockReturnValue(ok({})),
+    requestTransition: vi.fn().mockReturnValue(
+      ok({
+        decision: 'accepted',
+        reasonCodes: ['transition_recorded'],
+        missingEvidence: [],
+        recommendedIntervention: null,
+      }),
+    ),
+  };
+}
+
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -228,6 +264,112 @@ describe('PersonaSendHandler — success', () => {
       error: 'Timed out waiting for delegated persona reply. The delegated task may still complete asynchronously. Use persona_task_status with this task_id to fetch the final result later.',
     });
   });
+
+  it('creates an authoritative orchestrator workflow item when workflow_type is requested', async () => {
+    const taskMapper = makeTaskMapper();
+    const taskRepo = makeTaskRepo();
+    const personaRepo = makePersonaRepo();
+    const workflowService = makeWorkflowService();
+    const handler = new PersonaSendHandler({
+      taskMapper,
+      taskRepo,
+      personaRepo,
+      workflowService,
+      logger: makeLogger(),
+    } as any);
+
+    const result = await handler.execute(
+      makeArgs({ workflow_type: 'orchestrator_task' } as Partial<PersonaSendArgs>),
+      makeContext(),
+    );
+
+    expect(result.status).toBe('success');
+    expect(result.result).toEqual({
+      task_id: 'task-123',
+      state: 'submitted',
+      workflow_item_id: 'workflow-123',
+    });
+    expect(workflowService.createItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowType: 'orchestrator_task',
+        sourceThreadId: 'thread-001',
+        sourceRunId: 'run-001',
+        ownerActorId: 'persona-001',
+      }),
+    );
+    expect(taskMapper.submitTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowItemId: 'workflow-123',
+      }),
+    );
+    expect(workflowService.attachEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowItemId: 'workflow-123',
+        evidenceType: 'a2a_task_submitted',
+      }),
+    );
+    expect(workflowService.requestTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowItemId: 'workflow-123',
+        requestedState: 'ready',
+      }),
+    );
+  });
+
+  it('maps polled A2A states into workflow transitions for orchestrator tasks', async () => {
+    vi.useFakeTimers();
+
+    const taskMapper = makeTaskMapper();
+    const taskRepo = makeTaskRepo();
+    const personaRepo = makePersonaRepo();
+    const workflowService = makeWorkflowService();
+    (taskRepo.findById as unknown as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(ok(makeTaskRow({ state: 'working' })))
+      .mockReturnValueOnce(
+        ok(
+          makeTaskRow({
+            state: 'completed',
+            result_payload: JSON.stringify({ text: 'Task complete' }),
+            completed_at: 1020,
+            updated_at: 1020,
+          }),
+        ),
+      );
+
+    const handler = new PersonaSendHandler({
+      taskMapper,
+      taskRepo,
+      personaRepo,
+      workflowService,
+      logger: makeLogger(),
+      maxWaitMs: 100,
+      pollIntervalMs: 10,
+    } as any);
+
+    const resultPromise = handler.execute(
+      makeArgs({ workflow_type: 'orchestrator_task', await_reply: true } as Partial<PersonaSendArgs>),
+      makeContext(),
+    );
+    await vi.advanceTimersByTimeAsync(20);
+    const result = await resultPromise;
+
+    expect(result.status).toBe('success');
+    expect(workflowService.requestTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowItemId: 'workflow-123', requestedState: 'in_progress' }),
+    );
+    expect(workflowService.attachEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowItemId: 'workflow-123', evidenceType: 'a2a_task_completed' }),
+    );
+    expect(workflowService.requestTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowItemId: 'workflow-123', requestedState: 'done' }),
+    );
+    expect(result.result).toEqual({
+      task_id: 'task-123',
+      state: 'completed',
+      result: 'Task complete',
+      workflow_item_id: 'workflow-123',
+    });
+  });
 });
 
 describe('PersonaSendHandler — hop count propagation', () => {
@@ -317,6 +459,43 @@ describe('PersonaSendHandler — timeout and errors', () => {
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/message is required/);
     expect(taskMapper.submitTask).not.toHaveBeenCalled();
+  });
+
+  it('maps input-required A2A state to a blocked workflow outcome', async () => {
+    vi.useFakeTimers();
+
+    const taskMapper = makeTaskMapper();
+    const taskRepo = makeTaskRepo();
+    const personaRepo = makePersonaRepo();
+    const workflowService = makeWorkflowService();
+    (taskRepo.findById as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      ok(makeTaskRow({ state: 'input-required' })),
+    );
+
+    const handler = new PersonaSendHandler({
+      taskMapper,
+      taskRepo,
+      personaRepo,
+      workflowService,
+      logger: makeLogger(),
+      maxWaitMs: 100,
+      pollIntervalMs: 10,
+    } as any);
+
+    const result = await handler.execute(
+      makeArgs({ workflow_type: 'orchestrator_task', await_reply: true } as Partial<PersonaSendArgs>),
+      makeContext(),
+    );
+
+    expect(result.status).toBe('success');
+    expect(workflowService.requestTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowItemId: 'workflow-123', requestedState: 'blocked' }),
+    );
+    expect(result.result).toEqual({
+      task_id: 'task-123',
+      state: 'input-required',
+      workflow_item_id: 'workflow-123',
+    });
   });
 
   it('rejects invalid timeout_ms values', async () => {

--- a/tests/unit/workflow/workflow-evidence-adapter.test.ts
+++ b/tests/unit/workflow/workflow-evidence-adapter.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import { WorkflowEvidenceAdapter } from '../../../src/workflow/workflow-evidence-adapter.js';
+import type { ToolCallResult } from '../../../src/tools/tool-types.js';
+import type { BackgroundTask, BackgroundTaskResult } from '../../../src/subagents/background/background-agent-types.js';
+
+function makeToolResult(): ToolCallResult {
+  return {
+    requestId: 'req-001',
+    tool: 'subagent.background',
+    status: 'success',
+    result: { taskId: 'task-123' },
+    workflowMetadata: {
+      evidence: {
+        evidenceType: 'background_task_spawned',
+        source: 'background_task',
+        locator: 'task:task-123',
+        capturedAt: 1_000,
+        provenance: {
+          tool: 'subagent.background',
+          runId: 'run-001',
+          threadId: 'thread-001',
+          requestId: 'req-001',
+        },
+        payload: {
+          status: 'running',
+        },
+      },
+    },
+  };
+}
+
+function makeBackgroundTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: 'task-123',
+    personaId: 'persona-001',
+    providerName: 'claude-code',
+    threadId: 'thread-001',
+    channelId: 'channel-001',
+    prompt: 'Investigate this issue',
+    workingDirectory: '/workspace/repo',
+    status: 'running',
+    output: null,
+    error: null,
+    pid: 4242,
+    createdAt: 1_000,
+    startedAt: 1_000,
+    completedAt: null,
+    timeoutMinutes: 30,
+    parentTraceparent: null,
+    sandboxEnabled: false,
+    primaryExecutionEnvId: null,
+    ...overrides,
+  };
+}
+
+function makeBackgroundResult(overrides: Partial<BackgroundTaskResult> = {}): BackgroundTaskResult {
+  return {
+    taskId: 'task-123',
+    providerName: 'claude-code',
+    status: 'completed',
+    output: 'Done',
+    error: null,
+    durationSeconds: 12,
+    ...overrides,
+  };
+}
+
+describe('WorkflowEvidenceAdapter', () => {
+  it('normalizes tool-call workflow metadata into workflow evidence input', () => {
+    const adapter = new WorkflowEvidenceAdapter();
+
+    const result = adapter.fromToolResult({
+      workflowItemId: 'workflow-123',
+      toolResult: makeToolResult(),
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toEqual(
+      expect.objectContaining({
+        workflowItemId: 'workflow-123',
+        evidenceType: 'background_task_spawned',
+        source: 'background_task',
+        locator: 'task:task-123',
+        capturedAt: 1_000,
+        provenance: expect.objectContaining({
+          tool: 'subagent.background',
+          runId: 'run-001',
+          requestId: 'req-001',
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    ['running', 'background_task_spawned'],
+    ['completed', 'background_task_completed'],
+    ['timed_out', 'background_task_timed_out'],
+    ['failed', 'background_task_failed'],
+  ] as const)(
+    'maps %s background task state into %s evidence',
+    (status, evidenceType) => {
+      const adapter = new WorkflowEvidenceAdapter();
+      const task = makeBackgroundTask({
+        status,
+        completedAt: status === 'running' ? null : 2_000,
+        output: status === 'completed' ? 'Done' : null,
+        error: status === 'failed' ? 'process crashed' : null,
+      });
+      const taskResult = makeBackgroundResult({
+        status,
+        output: status === 'completed' ? 'Done' : null,
+        error:
+          status === 'failed'
+            ? 'process crashed'
+            : status === 'timed_out'
+              ? 'Process timed out'
+              : null,
+      });
+
+      const result = adapter.fromBackgroundTask({
+        workflowItemId: 'workflow-123',
+        task,
+        taskResult,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap()).toEqual(
+        expect.objectContaining({
+          workflowItemId: 'workflow-123',
+          evidenceType,
+          source: 'background_task',
+          locator: 'task:task-123',
+        }),
+      );
+    },
+  );
+});

--- a/tests/unit/workflow/workflow-read-model.test.ts
+++ b/tests/unit/workflow/workflow-read-model.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { createTestDb, uuid } from '../core/database/repositories/helpers.js';
+import {
+  WorkflowItemRepository,
+  WorkflowClaimRepository,
+  WorkflowEvidenceRepository,
+  WorkflowEventRepository,
+  WorkflowLeaseRepository,
+  WorkflowInterventionRepository,
+} from '../../../src/core/database/repositories/index.js';
+import { WorkflowKernelService } from '../../../src/workflow/workflow-service.js';
+import { WorkflowReadModel } from '../../../src/workflow/workflow-read-model.js';
+
+describe('WorkflowReadModel', () => {
+  it('returns an operational view with current state, owner, blocker, and next expected transition', () => {
+    const db = createTestDb();
+    const workflowService = new WorkflowKernelService({
+      itemRepository: new WorkflowItemRepository(db),
+      claimRepository: new WorkflowClaimRepository(db),
+      evidenceRepository: new WorkflowEvidenceRepository(db),
+      eventRepository: new WorkflowEventRepository(db),
+      leaseRepository: new WorkflowLeaseRepository(db),
+      interventionRepository: new WorkflowInterventionRepository(db),
+    });
+    const readModel = new WorkflowReadModel(db);
+
+    const item = workflowService.createItem({
+      id: uuid(),
+      workflowType: 'orchestrator_task',
+      domain: 'operations',
+      title: 'Coordinate delegated task',
+      goal: { deliverable: 'verified output' },
+      ownerActorId: 'persona-001',
+      sourceThreadId: 'thread-001',
+    })._unsafeUnwrap();
+    workflowService.submitClaim({
+      id: uuid(),
+      workflowItemId: item.id,
+      claimType: 'blockage',
+      actorId: 'persona-001',
+      actorKind: 'persona',
+      action: 'report_blocker',
+      target: 'delegated-task',
+      assertedOutcome: 'blocked',
+      summary: 'Waiting for credential approval.',
+      payload: {},
+    });
+    workflowService.attachEvidence({
+      id: uuid(),
+      workflowItemId: item.id,
+      claimId: null,
+      evidenceType: 'tool_call_result',
+      source: 'tool_result',
+      locator: 'tool_result:req-001',
+      capturedAt: 1_500,
+      provenance: { tool: 'subagent.background' },
+      payload: {},
+    });
+    db.prepare(`
+      UPDATE workflow_items
+      SET state = 'blocked',
+          status_reason = 'waiting for credential approval',
+          updated_at = 2_000
+      WHERE id = ?
+    `).run(item.id);
+    db.prepare(`
+      INSERT INTO workflow_leases (
+        id, workflow_item_id, actor_id, actor_kind, lease_state, acquired_at, renewed_at, expires_at, released_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(uuid(), item.id, 'persona-001', 'persona', 'active', 1_000, null, 2_500, null);
+
+    const result = readModel.listOperationalView();
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toEqual([
+      expect.objectContaining({
+        workflowItemId: item.id,
+        state: 'blocked',
+        ownerActorId: 'persona-001',
+        blockedReason: 'waiting for credential approval',
+        latestClaimSummary: 'Waiting for credential approval.',
+        latestEvidenceLocator: 'tool_result:req-001',
+        leaseExpiresAt: 2_500,
+        nextExpectedTransition: 'resolve_blocker',
+      }),
+    ]);
+  });
+
+  it('returns append-only audit events in chronological order', () => {
+    const db = createTestDb();
+    const workflowService = new WorkflowKernelService({
+      itemRepository: new WorkflowItemRepository(db),
+      claimRepository: new WorkflowClaimRepository(db),
+      evidenceRepository: new WorkflowEvidenceRepository(db),
+      eventRepository: new WorkflowEventRepository(db),
+      leaseRepository: new WorkflowLeaseRepository(db),
+      interventionRepository: new WorkflowInterventionRepository(db),
+    });
+    const readModel = new WorkflowReadModel(db);
+    const item = workflowService.createItem({
+      id: uuid(),
+      workflowType: 'orchestrator_task',
+      domain: 'operations',
+      title: 'Coordinate delegated task',
+      goal: { deliverable: 'verified output' },
+      ownerActorId: 'persona-001',
+      sourceThreadId: 'thread-001',
+    })._unsafeUnwrap();
+
+    workflowService.submitClaim({
+      id: uuid(),
+      workflowItemId: item.id,
+      claimType: 'progress',
+      actorId: 'persona-001',
+      actorKind: 'persona',
+      action: 'report_progress',
+      target: 'delegated-task',
+      assertedOutcome: 'in_progress',
+      summary: 'Checkpoint reached.',
+      payload: {},
+    });
+    workflowService.requestTransition({
+      workflowItemId: item.id,
+      requestedState: 'awaiting_validation',
+      actorId: 'persona-001',
+      reason: 'work_submitted',
+      correlationId: 'transition-001',
+    });
+
+    const result = readModel.listAuditEvents(item.id);
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap().map((event) => event.eventType)).toEqual([
+      'workflow.created',
+      'workflow.claim_submitted',
+      'workflow.transition_requested',
+    ]);
+  });
+});

--- a/tests/unit/workflow/workflow-service.test.ts
+++ b/tests/unit/workflow/workflow-service.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type Database from 'better-sqlite3';
+
+import { createTestDb, uuid } from '../core/database/repositories/helpers.js';
+import {
+  WorkflowItemRepository,
+  WorkflowClaimRepository,
+  WorkflowEvidenceRepository,
+  WorkflowEventRepository,
+  WorkflowLeaseRepository,
+  WorkflowInterventionRepository,
+} from '../../../src/core/database/repositories/index.js';
+import { WorkflowKernelService } from '../../../src/workflow/workflow-service.js';
+
+describe('WorkflowKernelService', () => {
+  let db: Database.Database;
+  let itemRepo: WorkflowItemRepository;
+  let claimRepo: WorkflowClaimRepository;
+  let evidenceRepo: WorkflowEvidenceRepository;
+  let eventRepo: WorkflowEventRepository;
+  let leaseRepo: WorkflowLeaseRepository;
+  let interventionRepo: WorkflowInterventionRepository;
+  let service: WorkflowKernelService;
+
+  beforeEach(() => {
+    db = createTestDb();
+    itemRepo = new WorkflowItemRepository(db);
+    claimRepo = new WorkflowClaimRepository(db);
+    evidenceRepo = new WorkflowEvidenceRepository(db);
+    eventRepo = new WorkflowEventRepository(db);
+    leaseRepo = new WorkflowLeaseRepository(db);
+    interventionRepo = new WorkflowInterventionRepository(db);
+    service = new WorkflowKernelService({
+      itemRepository: itemRepo,
+      claimRepository: claimRepo,
+      evidenceRepository: evidenceRepo,
+      eventRepository: eventRepo,
+      leaseRepository: leaseRepo,
+      interventionRepository: interventionRepo,
+    });
+  });
+
+  function createItem() {
+    const result = service.createItem({
+      id: uuid(),
+      workflowType: 'orchestrator_task',
+      domain: 'operations',
+      title: 'Verify delegated task',
+      goal: {
+        deliverable: 'validated handoff',
+      },
+      ownerActorId: 'persona:orchestrator',
+      sourceThreadId: 'thread-001',
+    });
+
+    expect(result.isOk()).toBe(true);
+    return result._unsafeUnwrap();
+  }
+
+  it('initializes workflow repositories cleanly on a fresh database', () => {
+    expect(itemRepo.findById('missing-item')._unsafeUnwrap()).toBeNull();
+    expect(claimRepo.listByWorkflowItemId('missing-item')._unsafeUnwrap()).toEqual([]);
+    expect(evidenceRepo.listByWorkflowItemId('missing-item')._unsafeUnwrap()).toEqual([]);
+    expect(eventRepo.listByWorkflowItemId('missing-item')._unsafeUnwrap()).toEqual([]);
+    expect(leaseRepo.listByWorkflowItemId('missing-item')._unsafeUnwrap()).toEqual([]);
+    expect(interventionRepo.listByWorkflowItemId('missing-item')._unsafeUnwrap()).toEqual([]);
+  });
+
+  it('creates a workflow item and emits workflow.created', () => {
+    const item = createItem();
+
+    expect(item.state).toBe('intake');
+    expect(item.rolloutMode).toBe('observe');
+    expect(item.policyPack).toBe('observe-only');
+
+    const events = eventRepo.listByWorkflowItemId(item.id)._unsafeUnwrap();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.eventType).toBe('workflow.created');
+    expect(events[0]?.workflowItemId).toBe(item.id);
+  });
+
+  it('rejects claims that do not satisfy the core claim schema', () => {
+    const item = createItem();
+
+    const result = service.submitClaim({
+      id: uuid(),
+      workflowItemId: item.id,
+      claimType: 'progress',
+      actorId: 'persona:orchestrator',
+      actorKind: 'persona',
+      action: '',
+      target: 'delegated-task',
+      assertedOutcome: 'in_progress',
+      summary: 'The work is moving forward.',
+      payload: {
+        percentComplete: 50,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(claimRepo.listByWorkflowItemId(item.id)._unsafeUnwrap()).toEqual([]);
+  });
+
+  it('rejects evidence that does not satisfy the core evidence schema', () => {
+    const item = createItem();
+
+    const result = service.attachEvidence({
+      id: uuid(),
+      workflowItemId: item.id,
+      claimId: null,
+      evidenceType: 'tool_result',
+      source: '',
+      locator: 'tool_result:req-001',
+      capturedAt: Date.now(),
+      provenance: {
+        toolName: 'persona.send',
+      },
+      payload: {
+        requestId: 'req-001',
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(evidenceRepo.listByWorkflowItemId(item.id)._unsafeUnwrap()).toEqual([]);
+  });
+});

--- a/tests/unit/workflow/workflow-watchdog.test.ts
+++ b/tests/unit/workflow/workflow-watchdog.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type Database from 'better-sqlite3';
+
+import { createTestDb, uuid } from '../core/database/repositories/helpers.js';
+import {
+  WorkflowItemRepository,
+  WorkflowClaimRepository,
+  WorkflowEventRepository,
+  WorkflowLeaseRepository,
+  WorkflowInterventionRepository,
+} from '../../../src/core/database/repositories/index.js';
+import { WorkflowKernelService } from '../../../src/workflow/workflow-service.js';
+import { WorkflowWatchdog } from '../../../src/workflow/workflow-watchdog.js';
+
+describe('WorkflowWatchdog', () => {
+  let db: Database.Database;
+  let itemRepository: WorkflowItemRepository;
+  let claimRepository: WorkflowClaimRepository;
+  let eventRepository: WorkflowEventRepository;
+  let leaseRepository: WorkflowLeaseRepository;
+  let interventionRepository: WorkflowInterventionRepository;
+  let workflowService: WorkflowKernelService;
+  let watchdog: WorkflowWatchdog;
+
+  beforeEach(() => {
+    db = createTestDb();
+    itemRepository = new WorkflowItemRepository(db);
+    claimRepository = new WorkflowClaimRepository(db);
+    eventRepository = new WorkflowEventRepository(db);
+    leaseRepository = new WorkflowLeaseRepository(db);
+    interventionRepository = new WorkflowInterventionRepository(db);
+    workflowService = new WorkflowKernelService({
+      itemRepository,
+      claimRepository,
+      evidenceRepository: {} as any,
+      eventRepository,
+      leaseRepository,
+      interventionRepository,
+    });
+    watchdog = new WorkflowWatchdog({
+      itemRepository,
+      claimRepository,
+      eventRepository,
+      leaseRepository,
+      interventionRepository,
+      claimRejectionThreshold: 2,
+    });
+  });
+
+  it('expires active leases deterministically and emits workflow.lease_expired', () => {
+    const item = workflowService.createItem({
+      id: uuid(),
+      workflowType: 'orchestrator_task',
+      domain: 'operations',
+      title: 'Follow up on delegated work',
+      goal: { deliverable: 'validated result' },
+      ownerActorId: 'persona-001',
+      sourceThreadId: 'thread-001',
+    })._unsafeUnwrap();
+
+    leaseRepository.insert({
+      id: uuid(),
+      workflowItemId: item.id,
+      actorId: 'persona-001',
+      actorKind: 'persona',
+      leaseState: 'active',
+      acquiredAt: 1_000,
+      renewedAt: null,
+      expiresAt: 1_500,
+      releasedAt: null,
+    });
+
+    const result = watchdog.evaluate(2_000);
+
+    expect(result.isOk()).toBe(true);
+    expect(leaseRepository.listByWorkflowItemId(item.id)._unsafeUnwrap()[0]?.leaseState).toBe('expired');
+    expect(eventRepository.listByWorkflowItemId(item.id)._unsafeUnwrap().map((event) => event.eventType)).toContain(
+      'workflow.lease_expired',
+    );
+  });
+
+  it('creates an intervention request after repeated claim rejection', () => {
+    const item = workflowService.createItem({
+      id: uuid(),
+      workflowType: 'orchestrator_task',
+      domain: 'operations',
+      title: 'Follow up on delegated work',
+      goal: { deliverable: 'validated result' },
+      ownerActorId: 'persona-001',
+      sourceThreadId: 'thread-001',
+    })._unsafeUnwrap();
+
+    claimRepository.insert({
+      id: uuid(),
+      workflowItemId: item.id,
+      claimType: 'completion',
+      actorId: 'persona-001',
+      actorKind: 'persona',
+      action: 'report_completion',
+      target: 'delegated-task',
+      assertedOutcome: 'done',
+      summary: 'Marked complete without evidence.',
+      payload: {},
+      status: 'rejected',
+      policyDecision: { reason: 'missing_evidence' },
+      createdAt: 1_000,
+      resolvedAt: 1_100,
+    });
+    claimRepository.insert({
+      id: uuid(),
+      workflowItemId: item.id,
+      claimType: 'completion',
+      actorId: 'persona-001',
+      actorKind: 'persona',
+      action: 'report_completion',
+      target: 'delegated-task',
+      assertedOutcome: 'done',
+      summary: 'Marked complete without evidence again.',
+      payload: {},
+      status: 'rejected',
+      policyDecision: { reason: 'missing_evidence' },
+      createdAt: 1_200,
+      resolvedAt: 1_300,
+    });
+
+    const result = watchdog.evaluate(2_000);
+
+    expect(result.isOk()).toBe(true);
+    const interventions = interventionRepository.listByWorkflowItemId(item.id)._unsafeUnwrap();
+    expect(interventions).toHaveLength(1);
+    expect(interventions[0]?.reason).toBe('claim_rejection_threshold_exceeded');
+    expect(eventRepository.listByWorkflowItemId(item.id)._unsafeUnwrap().map((event) => event.eventType)).toContain(
+      'workflow.intervention_requested',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add the workflow kernel sidecar with durable workflow items, claims, evidence, events, leases, interventions, watchdog evaluation, and read models
- wire workflow capture into agent runner, background-agent results, persona delegation, A2A task linkage, and daemon watchdog scheduling
- document workflow rollout/configuration, add workflow inspection CLI support, and cover the new behavior with unit and integration tests

## Why
This implements the workflow-kernel plan on top of the spec branch without rewriting Talon's existing queue, persona, or A2A systems. The first authoritative rollout is constrained to orchestrator-style delegated work created explicitly through `persona.send`.

## Validation
- `npx vitest run tests/unit/workflow tests/unit/daemon tests/unit/tools tests/integration/a2a tests/integration/workflow`
- `npx vitest run tests/unit/core/config tests/unit/cli/status.test.ts tests/unit/cli/cli-registration.test.ts`
- `npm run build`
- `git diff --check`
