### PR TITLE
fix(context): auto-resume stateless providers after context rotation

### DIFF
--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -937,7 +937,7 @@ export class AgentRunner {
               } else {
                 try {
                   if (selectedMetricValue > 0) {
-                    await this.ctx.contextRoller.checkAndRotate(
+                    const rotated = await this.ctx.contextRoller.checkAndRotate(
                       item.threadId,
                       personaId,
                       {
@@ -949,6 +949,41 @@ export class AgentRunner {
                       enabledContextManagement.thresholdRatio,
                       enabledContextManagement.summarizer,
                     );
+
+                    // For stateless providers (no session resumption), the agent
+                    // loses its in-progress task state after context rotation.
+                    // Auto-enqueue a continuation message so the agent picks up
+                    // open threads from the summary without requiring a manual
+                    // "resume" nudge from the user.
+                    if (rotated && !strategy.supportsSessionResumption && !isA2ATask && item.type !== 'schedule') {
+                      const continueMessageId = uuidv4();
+                      this.ctx.repos.message.insert({
+                        id: continueMessageId,
+                        thread_id: item.threadId,
+                        direction: 'inbound',
+                        content: JSON.stringify({ body: 'continue' }),
+                        idempotency_key: `context-rotation-continue:${runId}`,
+                        provider_id: null,
+                        run_id: null,
+                      });
+                      const enqueueResult = this.ctx.queueManager.enqueue(
+                        item.threadId,
+                        'message',
+                        { personaId, content: 'continue' },
+                        continueMessageId,
+                      );
+                      if (enqueueResult.isOk()) {
+                        this.ctx.logger.info(
+                          { threadId: item.threadId, provider: providerEntry.provider.name },
+                          'agent-runner: auto-enqueued continuation after context rotation for stateless provider',
+                        );
+                      } else {
+                        this.ctx.logger.warn(
+                          { threadId: item.threadId, err: enqueueResult.error.message },
+                          'agent-runner: failed to auto-enqueue continuation after context rotation',
+                        );
+                      }
+                    }
                   }
                 } catch (e: unknown) {
                   this.ctx.logger.error(

--- a/src/daemon/context-roller.ts
+++ b/src/daemon/context-roller.ts
@@ -85,10 +85,10 @@ export class ContextRoller {
     contextUsage: ResolvedContextUsage,
     overrideThreshold?: number,
     summarizerName: string = 'session-summarizer',
-  ): Promise<void> {
+  ): Promise<boolean> {
     const threshold = overrideThreshold ?? this.deps.thresholdRatio ?? 0.4;
     if (contextUsage.ratio < threshold) {
-      return;
+      return false;
     }
 
     this.deps.logger.info(
@@ -103,13 +103,13 @@ export class ContextRoller {
         { threadId, error: messagesResult.error.message },
         'context-roller: failed to read messages, skipping rotation',
       );
-      return;
+      return false;
     }
 
     const messages = messagesResult.value;
     if (messages.length === 0) {
       this.deps.logger.warn({ threadId }, 'context-roller: no messages found, skipping rotation');
-      return;
+      return false;
     }
 
     const transcript = this.buildTranscript(messages, MAX_TRANSCRIPT_CHARS);
@@ -121,7 +121,7 @@ export class ContextRoller {
         { threadId, summarizer: summarizerName },
         'context-roller: summarizer not available, keeping current session',
       );
-      return;
+      return false;
     }
 
     // 2. Call pre-bound summarizer (model, prompt, and services captured at bootstrap).
@@ -136,7 +136,7 @@ export class ContextRoller {
         { threadId, error: summaryResult.error.message },
         'context-roller: summarization failed, keeping current session',
       );
-      return;
+      return false;
     }
 
     const summary = summaryResult.value;
@@ -191,7 +191,7 @@ export class ContextRoller {
     }
 
     if (preparationFailed) {
-      return;
+      return false;
     }
 
     // 4. Build summary content. Always include keyFacts as a safety net —
@@ -247,7 +247,7 @@ export class ContextRoller {
         { threadId, error: txResult.error.message },
         'context-roller: rotation transaction failed — all writes rolled back, keeping current session',
       );
-      return;
+      return false;
     }
 
     if (pendingUpdates.length > 0) {
@@ -264,6 +264,8 @@ export class ContextRoller {
       { threadId, messageCount: messages.length, summaryLength: summaryContent.length },
       'context-roller: session rotated successfully',
     );
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
## Summary
- After context-roller rotates the session for stateless providers (Ollama, Gemini CLI), the agent would stall mid-task because nothing triggered the next turn — users had to manually send "resume"
- `ContextRoller.checkAndRotate()` now returns `boolean` indicating whether rotation occurred
- When rotation completes for a provider without session resumption, a synthetic `"continue"` message is auto-enqueued so the agent picks up open threads from the summary automatically
- Skipped for A2A tasks and scheduled items (not interactive conversations)

## Test plan
- [x] All 27 context-roller unit tests pass
- [x] All 85 agent-runner unit tests pass
- [x] All 5 rolling-context-window integration tests pass
- [ ] Manual: run Ollama persona through a long multi-tool task that triggers context rotation — verify the agent continues without manual nudge

🤖 Generated with [Claude Code](https://claude.com/claude-code)