### PR TITLE
fix(context): guard auto-resume against looping when no open threads

### DIFF
--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -937,7 +937,7 @@ export class AgentRunner {
               } else {
                 try {
                   if (selectedMetricValue > 0) {
-                    const rotated = await this.ctx.contextRoller.checkAndRotate(
+                    const rotation = await this.ctx.contextRoller.checkAndRotate(
                       item.threadId,
                       personaId,
                       {
@@ -952,10 +952,16 @@ export class AgentRunner {
 
                     // For stateless providers (no session resumption), the agent
                     // loses its in-progress task state after context rotation.
-                    // Auto-enqueue a continuation message so the agent picks up
-                    // open threads from the summary without requiring a manual
-                    // "resume" nudge from the user.
-                    if (rotated && !strategy.supportsSessionResumption && !isA2ATask && item.type !== 'schedule') {
+                    // Only auto-enqueue a continuation when the summarizer found
+                    // open threads — otherwise the task was complete and a
+                    // "continue" would cause the agent to invent work.
+                    if (
+                      rotation.rotated
+                      && rotation.hasOpenThreads
+                      && !strategy.supportsSessionResumption
+                      && !isA2ATask
+                      && item.type !== 'schedule'
+                    ) {
                       const continueMessageId = uuidv4();
                       this.ctx.repos.message.insert({
                         id: continueMessageId,

--- a/src/daemon/context-roller.ts
+++ b/src/daemon/context-roller.ts
@@ -49,6 +49,14 @@ export type SummarizerRunFn = (
   input: { transcript: string },
 ) => Promise<Result<SubAgentResult, SubAgentError>>;
 
+/** Result of a successful context rotation. */
+export interface ContextRotationResult {
+  /** Whether the session was actually rotated. */
+  rotated: boolean;
+  /** Whether the summarizer found unfinished work (open threads). */
+  hasOpenThreads: boolean;
+}
+
 export interface ContextRollerDeps {
   messageRepo: Pick<MessageRepository, 'findLatestByThread'>;
   memoryRepo: Pick<MemoryRepository, 'insert' | 'findById' | 'upsertByKey' | 'delete' | 'runInTransaction'>;
@@ -85,10 +93,11 @@ export class ContextRoller {
     contextUsage: ResolvedContextUsage,
     overrideThreshold?: number,
     summarizerName: string = 'session-summarizer',
-  ): Promise<boolean> {
+  ): Promise<ContextRotationResult> {
+    const noRotation: ContextRotationResult = { rotated: false, hasOpenThreads: false };
     const threshold = overrideThreshold ?? this.deps.thresholdRatio ?? 0.4;
     if (contextUsage.ratio < threshold) {
-      return false;
+      return noRotation;
     }
 
     this.deps.logger.info(
@@ -103,13 +112,13 @@ export class ContextRoller {
         { threadId, error: messagesResult.error.message },
         'context-roller: failed to read messages, skipping rotation',
       );
-      return false;
+      return noRotation;
     }
 
     const messages = messagesResult.value;
     if (messages.length === 0) {
       this.deps.logger.warn({ threadId }, 'context-roller: no messages found, skipping rotation');
-      return false;
+      return noRotation;
     }
 
     const transcript = this.buildTranscript(messages, MAX_TRANSCRIPT_CHARS);
@@ -121,7 +130,7 @@ export class ContextRoller {
         { threadId, summarizer: summarizerName },
         'context-roller: summarizer not available, keeping current session',
       );
-      return false;
+      return noRotation;
     }
 
     // 2. Call pre-bound summarizer (model, prompt, and services captured at bootstrap).
@@ -136,7 +145,7 @@ export class ContextRoller {
         { threadId, error: summaryResult.error.message },
         'context-roller: summarization failed, keeping current session',
       );
-      return false;
+      return noRotation;
     }
 
     const summary = summaryResult.value;
@@ -191,7 +200,7 @@ export class ContextRoller {
     }
 
     if (preparationFailed) {
-      return false;
+      return noRotation;
     }
 
     // 4. Build summary content. Always include keyFacts as a safety net —
@@ -247,7 +256,7 @@ export class ContextRoller {
         { threadId, error: txResult.error.message },
         'context-roller: rotation transaction failed — all writes rolled back, keeping current session',
       );
-      return false;
+      return noRotation;
     }
 
     if (pendingUpdates.length > 0) {
@@ -265,7 +274,8 @@ export class ContextRoller {
       'context-roller: session rotated successfully',
     );
 
-    return true;
+    const hasOpenThreads = (data?.openThreads ?? []).length > 0;
+    return { rotated: true, hasOpenThreads };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Follows up on #186 which auto-enqueued a "continue" message after context rotation for stateless providers (Ollama, Gemini CLI)
- That approach could cause infinite looping when the agent had already finished its task — the "continue" would make it invent work
- `checkAndRotate()` now returns `{ rotated, hasOpenThreads }` instead of `boolean`
- Auto-continue only fires when the summarizer actually found unfinished work (`openThreads.length > 0`)

## Test plan
- [x] 27 context-roller unit tests pass
- [x] 85 agent-runner unit tests pass
- [x] 5 rolling-context-window integration tests pass
- [ ] Manual: verify completed Ollama task does NOT trigger a spurious continuation after rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)