### PR TITLE
fix(context): include tool activity in transcript for context rotation

### DIFF
--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -463,6 +463,7 @@ export class AgentRunner {
               fullOutputText: string;
               resultSessionId: string | undefined;
               usage: AgentUsage;
+              toolActivity: Array<{ tool: string; input?: unknown; output?: unknown; isError?: boolean }>;
             }> => {
               const toolInstructionsBlock = resolveToolInstructions(
                 this.ctx.toolInstructions,
@@ -603,6 +604,10 @@ export class AgentRunner {
                   const activeProviderToolObservations = new Map<string, StartedObservationHandle>();
                   const ignoredProviderToolUseIds = new Set<string>();
                   const pendingProviderToolTasks: Array<Promise<void>> = [];
+                  // Collect tool activity for persistence in the outbound message.
+                  // Used by the context-roller and context-assembler to reconstruct
+                  // what the agent did (tool calls, results) after context rotation.
+                  const toolActivity: Array<{ tool: string; input?: unknown; output?: unknown; isError?: boolean }> = [];
                   // FIFO queue for tool events that lack a toolUseId (e.g. claude-code tool_use/tool_result
                   // streaming events). Events are sequential so FIFO order correctly pairs starts with ends.
                   const pendingNoIdToolObservations: StartedObservationHandle[] = [];
@@ -709,6 +714,24 @@ export class AgentRunner {
                             pendingNoIdToolObservations,
                             event,
                           );
+                          // Capture tool activity for the outbound message so the
+                          // context-roller and context-assembler can reconstruct
+                          // what the agent did after context rotation.
+                          if (isToolUse) {
+                            toolActivity.push({
+                              tool: event.tool ?? 'unknown',
+                              input: event.input,
+                            });
+                          } else if (event.messageType === 'tool_result') {
+                            // Attach result to the last matching tool call.
+                            const pending = [...toolActivity].reverse().find(
+                              (t) => t.output === undefined && (event.tool === undefined || t.tool === event.tool),
+                            );
+                            if (pending) {
+                              pending.output = event.output;
+                              pending.isError = event.isError;
+                            }
+                          }
                           this.ctx.logger.debug(
                             {
                               runId,
@@ -794,6 +817,7 @@ export class AgentRunner {
                     fullOutputText: fullOutputText.replace(/\n\n$/, ''),
                     resultSessionId,
                     usage,
+                    toolActivity,
                   };
                 },
               );
@@ -806,6 +830,7 @@ export class AgentRunner {
               inputTokens: 0,
               outputTokens: 0,
             };
+            let toolActivity: Array<{ tool: string; input?: unknown; output?: unknown; isError?: boolean }> = [];
 
             try {
               ({
@@ -813,6 +838,7 @@ export class AgentRunner {
                 fullOutputText,
                 resultSessionId,
                 usage,
+                toolActivity,
               } = await executeAgentQuery(existingSessionId));
             } catch (cause) {
               if (strategy.type === 'sdk' && this.shouldRetryFreshSession(cause)) {
@@ -830,6 +856,7 @@ export class AgentRunner {
                   fullOutputText,
                   resultSessionId,
                   usage,
+                  toolActivity,
                 } = await executeAgentQuery(undefined));
               } else {
                 throw cause;
@@ -908,7 +935,10 @@ export class AgentRunner {
                 id: uuidv4(),
                 thread_id: item.threadId,
                 direction: 'outbound',
-                content: JSON.stringify({ body: fullOutputText }),
+                content: JSON.stringify({
+                  body: fullOutputText,
+                  ...(toolActivity.length > 0 ? { toolActivity } : {}),
+                }),
                 idempotency_key: `outbound:${runId}`,
                 provider_id: null,
                 run_id: runId,

--- a/src/daemon/context-assembler.ts
+++ b/src/daemon/context-assembler.ts
@@ -14,6 +14,7 @@
 
 import type { MessageRepository, MessageRow } from '../core/database/repositories/message-repository.js';
 import type { MemoryRepository } from '../core/database/repositories/memory-repository.js';
+import { formatMessageForTranscript } from './context-roller.js';
 
 export interface ContextAssemblerDeps {
   messageRepo: Pick<MessageRepository, 'findLatestByThread'>;
@@ -114,17 +115,7 @@ export class ContextAssembler {
 
   private formatMessages(messages: MessageRow[]): string {
     return messages
-      .map((msg) => {
-        const role = msg.direction === 'inbound' ? 'User' : 'Assistant';
-        let body: string;
-        try {
-          const parsed = JSON.parse(msg.content);
-          body = typeof parsed.body === 'string' ? parsed.body : msg.content;
-        } catch {
-          body = msg.content;
-        }
-        return `${role}: ${body}`;
-      })
+      .map((msg) => formatMessageForTranscript(msg))
       .join('\n');
   }
 }

--- a/src/daemon/context-roller.ts
+++ b/src/daemon/context-roller.ts
@@ -289,16 +289,7 @@ export class ContextRoller {
     let totalChars = 0;
 
     for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      const role = msg.direction === 'inbound' ? 'User' : 'Assistant';
-      let body: string;
-      try {
-        const parsed = JSON.parse(msg.content);
-        body = typeof parsed.body === 'string' ? parsed.body : msg.content;
-      } catch {
-        body = msg.content;
-      }
-      const line = `${role}: ${body}`;
+      const line = formatMessageForTranscript(messages[i]);
 
       if (totalChars + line.length > maxChars && lines.length > 0) {
         break;
@@ -310,4 +301,60 @@ export class ContextRoller {
     // Reverse back to chronological order.
     return lines.reverse().join('\n');
   }
+}
+
+// ---------------------------------------------------------------------------
+// Message formatting (shared with context-assembler)
+// ---------------------------------------------------------------------------
+
+interface ToolActivityEntry {
+  tool: string;
+  input?: unknown;
+  output?: unknown;
+  isError?: boolean;
+}
+
+/**
+ * Format a single message row into a human-readable transcript line.
+ *
+ * Includes tool activity (calls + results) when present so the summarizer
+ * and the fresh-session context both capture what the agent actually did,
+ * not just the text it produced.
+ */
+export function formatMessageForTranscript(msg: MessageRow): string {
+  const role = msg.direction === 'inbound' ? 'User' : 'Assistant';
+  let body: string;
+  let toolActivity: ToolActivityEntry[] | undefined;
+
+  try {
+    const parsed = JSON.parse(msg.content);
+    body = typeof parsed.body === 'string' ? parsed.body : msg.content;
+    if (Array.isArray(parsed.toolActivity)) {
+      toolActivity = parsed.toolActivity;
+    }
+  } catch {
+    body = msg.content;
+  }
+
+  if (!toolActivity || toolActivity.length === 0) {
+    return `${role}: ${body}`;
+  }
+
+  // Build a compact tool activity section.
+  const toolLines = toolActivity.map((t) => {
+    const inputStr = t.input !== undefined ? ` input=${summarizeValue(t.input)}` : '';
+    const outputStr = t.output !== undefined ? ` → ${summarizeValue(t.output)}` : '';
+    const errorStr = t.isError ? ' [ERROR]' : '';
+    return `  [tool] ${t.tool}${inputStr}${outputStr}${errorStr}`;
+  });
+
+  return `${role}: ${body}\n${toolLines.join('\n')}`;
+}
+
+/** Truncate a value to a compact string for transcript inclusion. */
+function summarizeValue(value: unknown, maxLen = 200): string {
+  if (value === null || value === undefined) return '';
+  const str = typeof value === 'string' ? value : JSON.stringify(value);
+  if (str.length <= maxLen) return str;
+  return `${str.slice(0, maxLen)}…`;
 }


### PR DESCRIPTION
## Summary
- After context rotation, stateless providers (Ollama/GLM) lost all knowledge of tool calls — only bare text output was persisted in messages
- The summarizer saw `User: X / Assistant: Y` but never the tool calls, results, or intermediate work the agent did
- Now the agent-runner captures `tool_use`/`tool_result` events during streaming and persists them as `toolActivity` in the outbound message JSON
- Both the summarizer transcript (context-roller) and recent messages (context-assembler) now include tool activity formatted as compact `[tool] name input=... → ...` lines
- Extracted shared `formatMessageForTranscript()` to eliminate duplication between context-roller and context-assembler

## Test plan
- [x] 27 context-roller unit tests pass
- [x] 85 agent-runner unit tests pass
- [x] 8 context-assembler unit tests pass
- [x] 5 rolling-context-window integration tests pass
- [ ] Manual: run GLM through a tool-heavy task, trigger context rotation, verify the summary captures tool activity and the agent can continue coherently

🤖 Generated with [Claude Code](https://claude.com/claude-code)