### PR TITLE
feat(context): observational memory for long-term context retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1266,13 +1266,26 @@ Each observation also carries `currentTask` and `suggestedContinuation` metadata
 **Priority levels:** 🔴 high (critical decisions, goals, deadlines) · 🟡 medium (questions, preferences, conditional info) · 🟢 low (ephemeral context, minor details)
 
 ```yaml
+# 1. Set the provider's summarizer to session-observer
 contextManagement:
   enabled: true
   triggerMetric: input_tokens
   thresholdRatio: 0.75
   recentMessageCount: 10
   summarizer: session-observer    # enables observational memory
+
+# 2. Add the observer and reflector to the persona's subagents list
+personas:
+  - name: assistant
+    subagents:
+      - session-observer           # required for observational memory
+      - session-reflector          # required for observation consolidation
+      - memory-groomer
+      - memory-retriever
+      - file-searcher
 ```
+
+**Important:** Personas only load sub-agents explicitly listed in their `subagents` config. Without `session-observer` and `session-reflector` in the list, the context-roller won't find them at runtime. You can remove `session-summarizer` from personas using OM since it won't be called.
 
 ### Provider Support
 

--- a/README.md
+++ b/README.md
@@ -1072,7 +1072,9 @@ The runner wraps `providerOptions` under the active model entry's provider name 
 | `file-searcher`       | `claude-haiku-4-5`    | Search files by content, return ranked results with snippets |
 | `memory-retriever`    | `claude-haiku-4-5`    | Find relevant memories via keyword pre-filter + LLM rerank  |
 | `memory-groomer`      | `claude-haiku-4-5`    | Prune stale, consolidate duplicate memory items              |
-| `session-summarizer`  | `claude-sonnet-4-6`   | Compress transcripts for rolling context window              |
+| `session-summarizer`  | `claude-sonnet-4-6`   | Compress transcripts for rolling context window (legacy)     |
+| `session-observer`    | `claude-sonnet-4-6`   | Generate dated, prioritized observations for long-term memory |
+| `session-reflector`   | `claude-sonnet-4-6`   | Consolidate observations when log grows too large            |
 | `spark-coder`         | `gpt-5.4-spark`       | Fast single-shot code generation (requires `OPENAI_API_KEY`) |
 
 Sub-agents are loaded from three locations at startup (later overrides earlier):
@@ -1238,6 +1240,39 @@ Agent run completes → selected trigger metric exceeds threshold?
 - **Prompt injection mitigation** — injected historical content is prefixed with a read-only disclaimer to prevent user messages from being treated as instructions.
 
 **Files:** `src/daemon/context-roller.ts`, `src/daemon/context-assembler.ts`
+
+#### Observational memory (long-term context)
+
+The default `session-summarizer` produces a single summary blob that gets overwritten on each rotation — history beyond the last rotation is lost. For long-running conversations (e.g. Telegram threads spanning days), switch to **observational memory** by setting `summarizer: session-observer`.
+
+Instead of overwriting, observations **append** over time as a dated, prioritized decision log:
+
+```
+Date: 2026-04-07
+- 🔴 14:10 User wants to replace openai-compatible provider with Mastra Harness
+- 🔴 14:12 Decision: keep existing provider, add new mastra-code provider alongside
+- 🟡 14:15 LibSQL storage uses separate mastra.db to avoid WAL contention
+- 🟢 14:20 Background invocations not supported yet
+
+Date: 2026-04-07
+- 🔴 16:30 Implemented observational memory for context roller
+- 🟡 16:45 Reflector threshold set at 40K chars
+```
+
+When the observation log exceeds 40K characters, the `session-reflector` sub-agent consolidates — merging related observations, dropping superseded context, and preserving important decisions. This gives the agent long-term memory that survives many rotations.
+
+Each observation also carries `currentTask` and `suggestedContinuation` metadata, so the agent resumes coherently after context rotation without requiring a manual nudge.
+
+**Priority levels:** 🔴 high (critical decisions, goals, deadlines) · 🟡 medium (questions, preferences, conditional info) · 🟢 low (ephemeral context, minor details)
+
+```yaml
+contextManagement:
+  enabled: true
+  triggerMetric: input_tokens
+  thresholdRatio: 0.75
+  recentMessageCount: 10
+  summarizer: session-observer    # enables observational memory
+```
 
 ### Provider Support
 
@@ -2391,7 +2426,9 @@ talon/
       subagent-runner.ts         # Execution engine with timeout
       index.ts                   # Barrel export
       default/                   # Built-in sub-agents
-        session-summarizer/      # Transcript compression
+        session-summarizer/      # Transcript compression (legacy)
+        session-observer/        # Observational memory — observation generation
+        session-reflector/       # Observational memory — observation consolidation
         memory-groomer/          # Memory consolidation
         memory-retriever/        # Memory search + LLM reranking
         file-searcher/           # File search (rg/grep/node cascade)

--- a/config/talond.example.yaml
+++ b/config/talond.example.yaml
@@ -132,7 +132,7 @@ agentRunner:
         triggerMetric: cache_read_input_tokens
         thresholdRatio: 0.5
         recentMessageCount: 10
-        summarizer: session-summarizer
+        summarizer: session-summarizer       # or session-observer for observational memory
     gemini-cli:
       enabled: false
       command: gemini

--- a/config/talond.example.yaml
+++ b/config/talond.example.yaml
@@ -88,7 +88,10 @@ personas:
     systemPromptFile: personas/assistant/system.md
     skills: []
     subagents:
-      - session-summarizer
+      - session-summarizer           # legacy single-summary context compression
+      # For observational memory (long-term context), replace session-summarizer with:
+      # - session-observer           # generates dated, prioritized observations
+      # - session-reflector          # consolidates observations when log grows large
       - memory-groomer
       - memory-retriever
       - file-searcher

--- a/docs/superpowers/plans/2026-04-08-aisdk-http-channel-backend.md
+++ b/docs/superpowers/plans/2026-04-08-aisdk-http-channel-backend.md
@@ -1,0 +1,1112 @@
+# AI SDK HTTP Channel — Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new `aisdk-http` channel type to Talon that speaks the Vercel AI SDK v5 data-stream SSE protocol, so any `@ai-sdk/react` frontend can connect to a Talon persona via HTTP POST + SSE.
+
+**Architecture:** The connector runs its own lightweight HTTP server (Node `http`). Inbound POST requests are parsed as AI SDK message bodies and converted to `InboundEvent`s for the existing pipeline. The HTTP response is held open as an SSE stream; keep-alive ticks fire every 5 s while the agent runs. When `send()` is called by the daemon with the completed `AgentOutput`, the connector serialises it as AI SDK data-stream chunks and closes the stream. Tool results for configured tool names are additionally emitted as custom `data-` chunks.
+
+**Tech Stack:** Node 22 `http`, TypeScript strict, `neverthrow` Result, `zod`, `pino`, AI SDK v5 data-stream protocol (text/event-stream), `vitest` for tests.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `src/channels/connectors/aisdk-http/aisdk-http-types.ts` | Zod config schema + all TS types for this connector |
+| Create | `src/channels/connectors/aisdk-http/route-parser.ts` | Parse configurable route patterns, extract named path params |
+| Create | `src/channels/connectors/aisdk-http/stream-adapter.ts` | Convert `AgentOutput` → AI SDK data-stream SSE chunks |
+| Create | `src/channels/connectors/aisdk-http/artifact-mapper.ts` | Emit custom `2:[...]` data chunks for configured tool names |
+| Create | `src/channels/connectors/aisdk-http/aisdk-http-connector.ts` | Main `ChannelConnector` implementation — HTTP server, SSE, keep-alive |
+| Modify | `src/core/config/config-schema.ts` | Add `AisdkHttpChannelConfigSchema`, widen `ChannelConfigSchema.type` enum |
+| Modify | `src/daemon/channel-factory.ts` | Add `aisdk-http` case |
+| Create | `tests/unit/channels/aisdk-http/route-parser.test.ts` | Unit tests for route parsing |
+| Create | `tests/unit/channels/aisdk-http/stream-adapter.test.ts` | Unit tests for SSE serialisation |
+| Create | `tests/unit/channels/aisdk-http/artifact-mapper.test.ts` | Unit tests for artifact mapping |
+| Create | `tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts` | Integration tests for connector lifecycle + HTTP |
+
+---
+
+## Task 1: Types and Config Schema
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/aisdk-http-types.ts`
+- Modify: `src/core/config/config-schema.ts`
+
+- [ ] **Step 1: Write the types file**
+
+```typescript
+// src/channels/connectors/aisdk-http/aisdk-http-types.ts
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Config schema (registered in config-schema.ts)
+// ---------------------------------------------------------------------------
+
+export const ArtifactMappingSchema = z.object({
+  /** Tool name whose result should emit a custom data chunk. */
+  toolName: z.string(),
+  /** SSE data chunk type prefix, e.g. "data-exo-output-artifact". */
+  chunkType: z.string(),
+  /**
+   * Optional wrapper key. When set, result is emitted as { [wrapAs]: result }.
+   * When omitted, result is emitted as-is.
+   */
+  wrapAs: z.string().optional(),
+});
+
+export const AisdkHttpChannelConfigSchema = z.object({
+  /** TCP port to listen on. */
+  port: z.number().int().min(1).max(65535),
+  /**
+   * Express-style route pattern with named params (e.g. "/agents/:agentId/stream"
+   * or "/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream").
+   * The :agentId param maps to a persona name.
+   */
+  routePattern: z.string().default('/agents/:agentId/stream'),
+  /** CORS allowed origins. Glob patterns supported. */
+  cors: z.object({
+    allowOrigins: z.array(z.string()).default(['*']),
+  }).default({}),
+  /**
+   * Map specific tool result names to custom SSE data chunks.
+   * Each matched tool result also emits its normal tool-result chunk.
+   */
+  artifactMapping: z.array(ArtifactMappingSchema).default([]),
+  /**
+   * Override the SSE chunk type used for text output.
+   * null = use standard "0:" text-delta chunks (default, works with any useChat frontend).
+   * Set to e.g. "data-human-readable" for custom frontend handling.
+   */
+  textChunkType: z.string().nullable().default(null),
+  /**
+   * HTTP request headers to forward to MCP servers.
+   * E.g. ["Authorization"] passes the Bearer token through.
+   */
+  forwardHeaders: z.array(z.string()).default([]),
+  /**
+   * Map route path params to header names forwarded to MCP servers.
+   * E.g. { spaceId: "X-Space-Id" } extracts :spaceId from the URL and sends it as a header.
+   */
+  forwardPathParams: z.record(z.string()).default({}),
+  /**
+   * Explicit agentId → persona name mapping.
+   * If absent, agentId is used directly as the persona name.
+   */
+  agentMapping: z.record(z.string()).default({}),
+  /** Fallback persona when agentId doesn't match any mapping. */
+  defaultPersona: z.string().optional(),
+  /** Keep-alive SSE tick interval while agent is running (ms). Min 1000. */
+  keepAliveIntervalMs: z.number().int().min(1000).max(60000).default(5000),
+  /** Host to bind to. Defaults to 127.0.0.1. */
+  host: z.string().default('127.0.0.1'),
+});
+
+export type AisdkHttpChannelConfig = z.infer<typeof AisdkHttpChannelConfigSchema>;
+export type ArtifactMapping = z.infer<typeof ArtifactMappingSchema>;
+
+// ---------------------------------------------------------------------------
+// AI SDK v5 data-stream wire types
+// ---------------------------------------------------------------------------
+
+/** AI SDK data-stream protocol chunk types (numeric codes). */
+export const StreamPartType = {
+  TEXT_DELTA: '0',
+  DATA: '2',
+  ERROR: '3',
+  TOOL_CALL: '9',
+  TOOL_RESULT: 'a',
+  TOOL_CALL_STREAMING_START: 'b',
+  TOOL_CALL_DELTA: 'c',
+  FINISH_MESSAGE: 'd',
+  FINISH_STEP: 'e',
+  START_STEP: 'f',
+} as const;
+
+/** Represents one line in the AI SDK data-stream SSE body. */
+export interface StreamPart {
+  type: string;   // one of StreamPartType values
+  value: unknown; // serialised as JSON after the type prefix
+}
+
+// ---------------------------------------------------------------------------
+// AI SDK request body (what useChat POSTs)
+// ---------------------------------------------------------------------------
+
+export interface AisdkMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string;
+  id?: string;
+}
+
+export interface AisdkRequestBody {
+  /** Conversation messages. Last user message is the new input. */
+  messages: AisdkMessage[];
+  /** Client-generated thread ID. Used as Talon externalThreadId. */
+  id?: string;
+  /** Opaque metadata forwarded to the persona context. */
+  metadata?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: pending SSE stream entry
+// ---------------------------------------------------------------------------
+
+export interface PendingStream {
+  /** Node.js ServerResponse (kept open for SSE). */
+  res: import('node:http').ServerResponse;
+  /** Interval handle for keep-alive ticks. */
+  keepAliveInterval: ReturnType<typeof setInterval>;
+  /** Headers extracted from the original request (for MCP forwarding). */
+  forwardedHeaders: Record<string, string>;
+}
+```
+
+- [ ] **Step 2: Widen the ChannelConfigSchema type enum in config-schema.ts**
+
+Open `src/core/config/config-schema.ts`. Find the line:
+```typescript
+  type: z.enum(['telegram', 'whatsapp', 'whatsappBusiness', 'whatsappBaileys', 'slack', 'email', 'discord', 'terminal']),
+```
+Replace it with:
+```typescript
+  type: z.enum(['telegram', 'whatsapp', 'whatsappBusiness', 'whatsappBaileys', 'slack', 'email', 'discord', 'terminal', 'aisdk-http']),
+```
+
+- [ ] **Step 3: Build and typecheck**
+
+```bash
+cd /home/talon/talon && npm run build 2>&1 | tail -20
+```
+Expected: no errors related to config-schema.ts or aisdk-http-types.ts.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/aisdk-http-types.ts src/core/config/config-schema.ts
+git commit -m "feat(aisdk-http): add types, config schema, and enum registration"
+```
+
+---
+
+## Task 2: Route Parser
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/route-parser.ts`
+- Create: `tests/unit/channels/aisdk-http/route-parser.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// tests/unit/channels/aisdk-http/route-parser.test.ts
+import { describe, it, expect } from 'vitest';
+import { parseRoute, matchRoute } from '../../../src/channels/connectors/aisdk-http/route-parser.js';
+
+describe('parseRoute', () => {
+  it('converts pattern to regex and extracts param names', () => {
+    const result = parseRoute('/agents/:agentId/stream');
+    expect(result.paramNames).toEqual(['agentId']);
+    expect(result.regex.test('/agents/exo-agent/stream')).toBe(true);
+    expect(result.regex.test('/agents/exo-agent/other')).toBe(false);
+  });
+
+  it('handles multi-segment patterns with multiple params', () => {
+    const result = parseRoute('/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream');
+    expect(result.paramNames).toEqual(['spaceId', 'envId', 'agentId']);
+    expect(result.regex.test('/spaces/abc123/environments/master/ai/agents/exo-agent/stream')).toBe(true);
+  });
+
+  it('handles patterns with no params', () => {
+    const result = parseRoute('/chat/stream');
+    expect(result.paramNames).toEqual([]);
+    expect(result.regex.test('/chat/stream')).toBe(true);
+    expect(result.regex.test('/chat/stream/extra')).toBe(false);
+  });
+});
+
+describe('matchRoute', () => {
+  it('returns null when URL does not match pattern', () => {
+    const result = matchRoute('/agents/:agentId/stream', '/other/path');
+    expect(result).toBeNull();
+  });
+
+  it('extracts named params from matching URL', () => {
+    const result = matchRoute('/agents/:agentId/stream', '/agents/my-persona/stream');
+    expect(result).toEqual({ agentId: 'my-persona' });
+  });
+
+  it('extracts multiple named params', () => {
+    const result = matchRoute(
+      '/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream',
+      '/spaces/abc/environments/master/ai/agents/exo-agent/stream',
+    );
+    expect(result).toEqual({ spaceId: 'abc', envId: 'master', agentId: 'exo-agent' });
+  });
+
+  it('ignores query string when matching', () => {
+    const result = matchRoute('/agents/:agentId/stream', '/agents/foo/stream?bar=baz');
+    expect(result).toEqual({ agentId: 'foo' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/route-parser.test.ts 2>&1 | tail -10
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement route-parser.ts**
+
+```typescript
+// src/channels/connectors/aisdk-http/route-parser.ts
+
+interface ParsedRoute {
+  regex: RegExp;
+  paramNames: string[];
+}
+
+/**
+ * Pre-compile an Express-style route pattern to a regex + param name list.
+ * Segments like :paramName are captured as named groups.
+ */
+export function parseRoute(pattern: string): ParsedRoute {
+  const paramNames: string[] = [];
+  // Escape special regex chars except for our :param syntax
+  const regexStr = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')   // escape regex specials
+    .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, (_match, name: string) => {
+      paramNames.push(name);
+      return '([^/]+)';
+    });
+  const regex = new RegExp(`^${regexStr}$`);
+  return { regex, paramNames };
+}
+
+/**
+ * Match a URL pathname against a route pattern.
+ * Returns extracted param values, or null if no match.
+ */
+export function matchRoute(
+  pattern: string,
+  url: string,
+): Record<string, string> | null {
+  // Strip query string
+  const pathname = url.split('?')[0] ?? url;
+  const { regex, paramNames } = parseRoute(pattern);
+  const match = regex.exec(pathname);
+  if (!match) return null;
+  const params: Record<string, string> = {};
+  paramNames.forEach((name, i) => {
+    params[name] = match[i + 1] ?? '';
+  });
+  return params;
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/route-parser.test.ts 2>&1 | tail -10
+```
+Expected: PASS — all 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/route-parser.ts tests/unit/channels/aisdk-http/route-parser.test.ts
+git commit -m "feat(aisdk-http): route parser with named param extraction"
+```
+
+---
+
+## Task 3: Stream Adapter
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/stream-adapter.ts`
+- Create: `tests/unit/channels/aisdk-http/stream-adapter.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// tests/unit/channels/aisdk-http/stream-adapter.test.ts
+import { describe, it, expect } from 'vitest';
+import { encodeStreamPart, buildTextChunks, buildFinishChunks, buildKeepAlive } from '../../../src/channels/connectors/aisdk-http/stream-adapter.js';
+
+describe('encodeStreamPart', () => {
+  it('encodes a text-delta chunk', () => {
+    const line = encodeStreamPart('0', 'Hello world');
+    expect(line).toBe('0:"Hello world"\n');
+  });
+
+  it('encodes a data chunk (array)', () => {
+    const line = encodeStreamPart('2', [{ type: 'test' }]);
+    expect(line).toBe('2:[{"type":"test"}]\n');
+  });
+
+  it('encodes a finish-message chunk', () => {
+    const line = encodeStreamPart('d', { finishReason: 'stop', usage: { promptTokens: 10, completionTokens: 5 } });
+    expect(line).toBe('d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":5}}\n');
+  });
+});
+
+describe('buildTextChunks', () => {
+  it('returns array of encoded text-delta lines for word tokens', () => {
+    const chunks = buildTextChunks('Hello world', null);
+    // Each word (split by space) becomes a text-delta
+    expect(chunks.length).toBeGreaterThan(0);
+    chunks.forEach(c => expect(c).toMatch(/^0:".+"\n$/));
+  });
+
+  it('uses custom chunk type when textChunkType is set', () => {
+    const chunks = buildTextChunks('Hi', 'data-human-readable');
+    expect(chunks[0]).toMatch(/^data-human-readable:/);
+  });
+});
+
+describe('buildFinishChunks', () => {
+  it('returns finish-step and finish-message lines', () => {
+    const chunks = buildFinishChunks();
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toContain('"finishReason":"stop"');
+    expect(chunks[0]).toContain('"isContinued":false');
+    expect(chunks[1]).toContain('"finishReason":"stop"');
+  });
+});
+
+describe('buildKeepAlive', () => {
+  it('returns a comment line (SSE keep-alive)', () => {
+    const line = buildKeepAlive();
+    expect(line).toBe(': keep-alive\n\n');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/stream-adapter.test.ts 2>&1 | tail -10
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement stream-adapter.ts**
+
+```typescript
+// src/channels/connectors/aisdk-http/stream-adapter.ts
+
+/**
+ * Serialise one AI SDK v5 data-stream protocol part.
+ * Format: `TYPE_CODE:JSON_VALUE\n`
+ */
+export function encodeStreamPart(type: string, value: unknown): string {
+  return `${type}:${JSON.stringify(value)}\n`;
+}
+
+/**
+ * Split `AgentOutput.body` (Markdown string) into word-level text-delta chunks.
+ * Each chunk is one encoded SSE line.
+ *
+ * When textChunkType is null, uses standard "0:" prefix.
+ * When textChunkType is set, uses that string as the prefix instead.
+ */
+export function buildTextChunks(body: string, textChunkType: string | null): string[] {
+  // Split on whitespace boundaries, preserving the delimiter attached to each token
+  const tokens = body.match(/\S+\s*/g) ?? [body];
+  return tokens.map((token) =>
+    textChunkType
+      ? `${textChunkType}:${JSON.stringify(token)}\n`
+      : encodeStreamPart('0', token),
+  );
+}
+
+/**
+ * Build the two finish chunks that close an AI SDK stream:
+ * 1. finish-step (`e`) — marks the end of a reasoning step
+ * 2. finish-message (`d`) — marks the end of the assistant message
+ */
+export function buildFinishChunks(): string[] {
+  const finishStep = encodeStreamPart('e', {
+    finishReason: 'stop',
+    usage: { promptTokens: 0, completionTokens: 0 },
+    isContinued: false,
+  });
+  const finishMessage = encodeStreamPart('d', {
+    finishReason: 'stop',
+    usage: { promptTokens: 0, completionTokens: 0 },
+  });
+  return [finishStep, finishMessage];
+}
+
+/**
+ * SSE comment line used as a keep-alive tick.
+ * Browsers and proxies treat SSE comment lines as no-ops but they reset the
+ * connection timeout timer.
+ */
+export function buildKeepAlive(): string {
+  return ': keep-alive\n\n';
+}
+
+/**
+ * Build the start-step chunk (`f`) that opens the stream.
+ */
+export function buildStartStep(messageId: string): string {
+  return encodeStreamPart('f', { messageId });
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/stream-adapter.test.ts 2>&1 | tail -10
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/stream-adapter.ts tests/unit/channels/aisdk-http/stream-adapter.test.ts
+git commit -m "feat(aisdk-http): stream adapter — AI SDK v5 data-stream SSE encoding"
+```
+
+---
+
+## Task 4: Artifact Mapper
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/artifact-mapper.ts`
+- Create: `tests/unit/channels/aisdk-http/artifact-mapper.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// tests/unit/channels/aisdk-http/artifact-mapper.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildArtifactChunks } from '../../../src/channels/connectors/aisdk-http/artifact-mapper.js';
+import type { ArtifactMapping } from '../../../src/channels/connectors/aisdk-http/aisdk-http-types.js';
+
+const mapping: ArtifactMapping[] = [
+  { toolName: 'assemble_experience_tree', chunkType: 'data-exo-output-artifact', wrapAs: 'jsonContent' },
+  { toolName: 'search_results', chunkType: 'data-search-results' },
+];
+
+describe('buildArtifactChunks', () => {
+  it('returns empty array when tool name is not in mapping', () => {
+    const chunks = buildArtifactChunks('unknown_tool', { foo: 'bar' }, mapping);
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('wraps result when wrapAs is set', () => {
+    const chunks = buildArtifactChunks('assemble_experience_tree', { tree: [] }, mapping);
+    expect(chunks).toHaveLength(1);
+    // Should be a data chunk (type "2") with the custom wrapper
+    expect(chunks[0]).toContain('"data-exo-output-artifact"');
+    expect(chunks[0]).toContain('"jsonContent"');
+    expect(chunks[0]).toContain('"tree"');
+  });
+
+  it('emits result as-is when wrapAs is absent', () => {
+    const chunks = buildArtifactChunks('search_results', [{ id: '1' }], mapping);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain('"data-search-results"');
+    expect(chunks[0]).toContain('"id"');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/artifact-mapper.test.ts 2>&1 | tail -10
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement artifact-mapper.ts**
+
+```typescript
+// src/channels/connectors/aisdk-http/artifact-mapper.ts
+import { encodeStreamPart } from './stream-adapter.js';
+import type { ArtifactMapping } from './aisdk-http-types.js';
+
+/**
+ * Given a tool name and its result, emit zero or more custom SSE data chunks
+ * based on the configured artifact mapping.
+ *
+ * Custom chunks are emitted as `2:[{type, ...data}]` lines — the AI SDK
+ * data-stream "data" part type. Frontends can listen for these via
+ * `useChat`'s `onData` callback or by inspecting `data` from the hook.
+ */
+export function buildArtifactChunks(
+  toolName: string,
+  result: unknown,
+  mapping: ArtifactMapping[],
+): string[] {
+  const entry = mapping.find((m) => m.toolName === toolName);
+  if (!entry) return [];
+
+  const payload = entry.wrapAs
+    ? { type: entry.chunkType, [entry.wrapAs]: result }
+    : { type: entry.chunkType, ...( typeof result === 'object' && result !== null ? result : { result }) };
+
+  return [encodeStreamPart('2', [payload])];
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/artifact-mapper.test.ts 2>&1 | tail -10
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/artifact-mapper.ts tests/unit/channels/aisdk-http/artifact-mapper.test.ts
+git commit -m "feat(aisdk-http): artifact mapper — tool results to custom SSE data chunks"
+```
+
+---
+
+## Task 5: Main Connector
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/aisdk-http-connector.ts`
+
+- [ ] **Step 1: Write the connector**
+
+```typescript
+// src/channels/connectors/aisdk-http/aisdk-http-connector.ts
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import type pino from 'pino';
+import type { ChannelConnector, InboundEvent, AgentOutput } from '../../channel-types.js';
+import type { Result } from '../../../core/types/result.js';
+import { ok, err } from '../../../core/types/result.js';
+import { ChannelError } from '../../../core/errors/error-types.js';
+import { matchRoute } from './route-parser.js';
+import { buildTextChunks, buildFinishChunks, buildKeepAlive, buildStartStep } from './stream-adapter.js';
+import { buildArtifactChunks } from './artifact-mapper.js';
+import type { AisdkHttpChannelConfig, AisdkRequestBody, PendingStream } from './aisdk-http-types.js';
+import { AisdkHttpChannelConfigSchema } from './aisdk-http-types.js';
+
+// ---------------------------------------------------------------------------
+// AisdkHttpConnector
+// ---------------------------------------------------------------------------
+
+export class AisdkHttpConnector implements ChannelConnector {
+  readonly type = 'aisdk-http';
+  readonly name: string;
+
+  private config: AisdkHttpChannelConfig;
+  private handler?: (event: InboundEvent) => void | Promise<void>;
+  private running = false;
+  private httpServer?: ReturnType<typeof createServer>;
+  private idCounter = 0;
+
+  /**
+   * Map from externalThreadId to the open SSE response for that thread.
+   * Only one pending stream per thread is supported (last one wins).
+   */
+  private pendingStreams = new Map<string, PendingStream>();
+
+  constructor(
+    rawConfig: Record<string, unknown>,
+    channelName: string,
+    private readonly logger: pino.Logger,
+  ) {
+    this.name = channelName;
+    this.config = AisdkHttpChannelConfigSchema.parse(rawConfig);
+  }
+
+  // -------------------------------------------------------------------------
+  // ChannelConnector lifecycle
+  // -------------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    return new Promise((resolve, reject) => {
+      this.httpServer = createServer((req, res) => {
+        void this.handleRequest(req, res);
+      });
+
+      this.httpServer.on('error', (e) => {
+        this.running = false;
+        reject(e);
+      });
+
+      this.httpServer.listen(this.config.port, this.config.host, () => {
+        this.logger.info(
+          { channelName: this.name, port: this.config.port, host: this.config.host },
+          'aisdk-http: listening',
+        );
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return;
+    this.running = false;
+
+    // Close all open SSE streams
+    for (const [threadId, pending] of this.pendingStreams) {
+      clearInterval(pending.keepAliveInterval);
+      try { pending.res.end(); } catch { /* ignore */ }
+      this.pendingStreams.delete(threadId);
+    }
+
+    return new Promise((resolve) => {
+      if (this.httpServer) {
+        this.httpServer.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  onMessage(handler: (event: InboundEvent) => void | Promise<void>): void {
+    this.handler = handler;
+  }
+
+  /**
+   * Called by the daemon with the completed agent output.
+   * Flushes the response as AI SDK SSE chunks and closes the stream.
+   */
+  async send(externalThreadId: string, output: AgentOutput): Promise<Result<void, ChannelError>> {
+    const pending = this.pendingStreams.get(externalThreadId);
+    if (!pending) {
+      // Thread may have disconnected — not an error, just log and move on
+      this.logger.warn({ channelName: this.name, externalThreadId }, 'aisdk-http: no pending stream for thread');
+      return ok(undefined);
+    }
+
+    const { res } = pending;
+    clearInterval(pending.keepAliveInterval);
+    this.pendingStreams.delete(externalThreadId);
+
+    try {
+      // Start step
+      res.write(buildStartStep(randomUUID()));
+
+      // Text chunks (word-by-word streaming feel)
+      for (const chunk of buildTextChunks(output.body, this.config.textChunkType)) {
+        res.write(chunk);
+      }
+
+      // Finish
+      for (const chunk of buildFinishChunks()) {
+        res.write(chunk);
+      }
+
+      res.end();
+      return ok(undefined);
+    } catch (e) {
+      this.logger.error({ channelName: this.name, externalThreadId, err: e }, 'aisdk-http: send error');
+      return err(new ChannelError('send-failed', String(e)));
+    }
+  }
+
+  format(markdown: string): string {
+    return markdown; // No transformation needed — we emit raw Markdown
+  }
+
+  setSiblingBotIds(_ids: Set<string>): void {
+    // No bot-self-filtering concept for HTTP
+  }
+
+  // -------------------------------------------------------------------------
+  // HTTP request handling
+  // -------------------------------------------------------------------------
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // CORS preflight
+    this.setCorsHeaders(res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    // Only accept POST
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Method not allowed' }));
+      return;
+    }
+
+    // Match route
+    const url = req.url ?? '/';
+    const params = matchRoute(this.config.routePattern, url);
+    if (!params) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+      return;
+    }
+
+    // Resolve persona from agentId
+    const agentId = params['agentId'];
+    const personaName = agentId
+      ? (this.config.agentMapping[agentId] ?? agentId)
+      : this.config.defaultPersona ?? 'default';
+
+    // Parse request body
+    let body: AisdkRequestBody;
+    try {
+      body = await this.readBody(req);
+    } catch (e) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Invalid request body' }));
+      return;
+    }
+
+    // Determine thread ID (client-supplied or generate)
+    const externalThreadId = body.id ?? randomUUID();
+
+    // Extract headers to forward
+    const forwardedHeaders: Record<string, string> = {};
+    for (const header of this.config.forwardHeaders) {
+      const val = req.headers[header.toLowerCase()];
+      if (val) forwardedHeaders[header] = Array.isArray(val) ? val[0] ?? '' : val;
+    }
+    for (const [param, headerName] of Object.entries(this.config.forwardPathParams)) {
+      if (params[param]) forwardedHeaders[headerName] = params[param] ?? '';
+    }
+
+    // Build inbound event content from last user message
+    const lastUser = [...body.messages].reverse().find((m) => m.role === 'user');
+    const content = lastUser?.content ?? '';
+
+    // Open SSE stream immediately
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Thread-Id': externalThreadId,
+      'Access-Control-Expose-Headers': 'X-Thread-Id',
+    });
+
+    // Set up keep-alive
+    const keepAliveInterval = setInterval(() => {
+      try { res.write(buildKeepAlive()); } catch { /* client disconnected */ }
+    }, this.config.keepAliveIntervalMs);
+
+    // Store pending stream
+    const existing = this.pendingStreams.get(externalThreadId);
+    if (existing) {
+      clearInterval(existing.keepAliveInterval);
+      try { existing.res.end(); } catch { /* ignore */ }
+    }
+    this.pendingStreams.set(externalThreadId, { res, keepAliveInterval, forwardedHeaders });
+
+    // Handle client disconnect
+    req.on('close', () => {
+      const pending = this.pendingStreams.get(externalThreadId);
+      if (pending && pending.res === res) {
+        clearInterval(pending.keepAliveInterval);
+        this.pendingStreams.delete(externalThreadId);
+      }
+    });
+
+    // Fire inbound event
+    const idempotencyKey = `${externalThreadId}-${++this.idCounter}`;
+    const event: InboundEvent = {
+      channelType: this.type,
+      channelName: this.name,
+      externalThreadId,
+      senderId: externalThreadId, // No per-user identity in HTTP mode
+      idempotencyKey,
+      content,
+      timestamp: Date.now(),
+      raw: body,
+    };
+
+    if (this.handler) {
+      try {
+        await this.handler(event);
+      } catch (e) {
+        this.logger.error({ channelName: this.name, err: e }, 'aisdk-http: handler error');
+        clearInterval(keepAliveInterval);
+        this.pendingStreams.delete(externalThreadId);
+        try {
+          res.write(`:3:"Internal error"\n`);
+          res.end();
+        } catch { /* ignore */ }
+      }
+    }
+  }
+
+  private setCorsHeaders(res: ServerResponse): void {
+    // Allow configured origins (* by default)
+    const origins = this.config.cors.allowOrigins;
+    res.setHeader('Access-Control-Allow-Origin', origins.includes('*') ? '*' : origins[0] ?? '*');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  }
+
+  private readBody(req: IncomingMessage): Promise<AisdkRequestBody> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        try {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          resolve(JSON.parse(raw) as AisdkRequestBody);
+        } catch (e) {
+          reject(e);
+        }
+      });
+      req.on('error', reject);
+    });
+  }
+}
+```
+
+- [ ] **Step 2: Build and typecheck**
+
+```bash
+cd /home/talon/talon && npm run build 2>&1 | grep -E "error|Error" | head -20
+```
+Expected: 0 errors in the new files.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/aisdk-http-connector.ts
+git commit -m "feat(aisdk-http): main connector — HTTP server, SSE lifecycle, InboundEvent dispatch"
+```
+
+---
+
+## Task 6: Register in Channel Factory
+
+**Files:**
+- Modify: `src/daemon/channel-factory.ts`
+
+- [ ] **Step 1: Add the import and case**
+
+In `src/daemon/channel-factory.ts`, add the import after the existing terminal import:
+```typescript
+import { AisdkHttpConnector } from '../channels/connectors/aisdk-http/aisdk-http-connector.js';
+```
+
+In the `switch` block, add before `default`:
+```typescript
+    case 'aisdk-http':
+      return new AisdkHttpConnector(config, name, logger);
+```
+
+- [ ] **Step 2: Build — expect clean**
+
+```bash
+cd /home/talon/talon && npm run build 2>&1 | grep -E "^.*error" | head -10
+```
+Expected: 0 TypeScript errors.
+
+- [ ] **Step 3: Smoke test — start daemon with minimal aisdk-http config**
+
+Create a temporary test config at `/tmp/aisdk-test.yaml`:
+```yaml
+providers:
+  - type: claude
+    apiKey: "${ANTHROPIC_API_KEY}"
+
+personas:
+  - name: test-agent
+    provider: claude
+    model: claude-haiku-4-5
+    systemPrompt: "You are a test agent."
+
+channels:
+  - name: aisdk-test
+    type: aisdk-http
+    config:
+      port: 4199
+      routePattern: "/agents/:agentId/stream"
+
+bindings:
+  - channel: aisdk-test
+    persona: test-agent
+    isDefault: true
+```
+
+Start the daemon (ctrl-c after 5s to verify it starts without crashing):
+```bash
+cd /home/talon/talon && timeout 5 node dist/index.js --config /tmp/aisdk-test.yaml 2>&1 || true
+```
+Expected: logs show `aisdk-http: listening` on port 4199.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/daemon/channel-factory.ts
+git commit -m "feat(aisdk-http): register connector in channel factory"
+```
+
+---
+
+## Task 7: Update README and CLAUDE.md
+
+**Files:**
+- Modify: `README.md` (channel type list)
+- Modify: `CLAUDE.md` (source layout / architecture section)
+
+- [ ] **Step 1: Add aisdk-http to the channel list in README.md**
+
+Find the section in README.md that lists channel types (telegram, slack, discord, etc.) and add:
+```
+| `aisdk-http` | HTTP + SSE | Any Vercel AI SDK v5 frontend (`useChat`, `DefaultChatTransport`) |
+```
+
+- [ ] **Step 2: Add aisdk-http to CLAUDE.md architecture table**
+
+In CLAUDE.md, find the connectors line:
+```
+| Channels  | `src/channels/connectors/` | 7 adapters: telegram, slack, discord, whatsapp-business, whatsapp-baileys, email, terminal |
+```
+Update to:
+```
+| Channels  | `src/channels/connectors/` | 8 adapters: telegram, slack, discord, whatsapp-business, whatsapp-baileys, email, terminal, aisdk-http |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md CLAUDE.md
+git commit -m "docs: add aisdk-http channel to README and CLAUDE.md"
+```
+
+---
+
+## Task 8: Integration Test
+
+**Files:**
+- Create: `tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts`
+
+- [ ] **Step 1: Write integration tests**
+
+```typescript
+// tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AisdkHttpConnector } from '../../../../src/channels/connectors/aisdk-http/aisdk-http-connector.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+async function startConnector(config: Record<string, unknown>) {
+  const connector = new AisdkHttpConnector(config, 'test-aisdk', logger);
+  await connector.start();
+  return connector;
+}
+
+async function postMessage(port: number, body: object): Promise<Response> {
+  return fetch(`http://127.0.0.1:${port}/agents/test-agent/stream`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('AisdkHttpConnector', () => {
+  let connector: AisdkHttpConnector;
+
+  afterEach(async () => {
+    if (connector) await connector.stop();
+  });
+
+  it('starts and stops cleanly', async () => {
+    connector = await startConnector({ port: 4210 });
+    expect(connector.type).toBe('aisdk-http');
+    expect(connector.name).toBe('test-aisdk');
+  });
+
+  it('returns 404 for unknown routes', async () => {
+    connector = await startConnector({ port: 4211 });
+    const res = await fetch('http://127.0.0.1:4211/unknown/path', { method: 'POST', body: '{}', headers: { 'Content-Type': 'application/json' } });
+    expect(res.status).toBe(404);
+    await connector.stop();
+  });
+
+  it('returns 405 for non-POST requests', async () => {
+    connector = await startConnector({ port: 4212 });
+    const res = await fetch('http://127.0.0.1:4212/agents/test-agent/stream', { method: 'GET' });
+    expect(res.status).toBe(405);
+  });
+
+  it('fires onMessage handler with last user message content', async () => {
+    connector = await startConnector({ port: 4213 });
+    const received: string[] = [];
+    connector.onMessage((event) => { received.push(event.content); });
+
+    // Post but don't await the SSE stream — just trigger it
+    void postMessage(4213, {
+      messages: [{ role: 'user', content: 'Hello Talon' }],
+      id: 'thread-abc',
+    });
+
+    // Wait for handler to fire
+    await new Promise((r) => setTimeout(r, 100));
+    expect(received).toContain('Hello Talon');
+  });
+
+  it('send() writes text-delta chunks and closes stream', async () => {
+    connector = await startConnector({ port: 4214 });
+    connector.onMessage(() => {
+      // Simulate async agent response
+      setTimeout(() => {
+        void connector.send('thread-xyz', { body: 'Test response' });
+      }, 50);
+    });
+
+    const res = await postMessage(4214, {
+      messages: [{ role: 'user', content: 'ping' }],
+      id: 'thread-xyz',
+    });
+
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const body = await res.text();
+    expect(body).toContain('0:');          // text-delta chunks
+    expect(body).toContain('"stop"');      // finish
+    expect(res.headers.get('x-thread-id')).toBe('thread-xyz');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/ 2>&1 | tail -20
+```
+Expected: all tests pass (route-parser, stream-adapter, artifact-mapper, connector integration).
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts
+git commit -m "test(aisdk-http): integration tests for connector lifecycle and HTTP/SSE"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ HTTP server with configurable port and host
+- ✅ Configurable route pattern with named params
+- ✅ AI SDK v5 data-stream SSE protocol (text-delta, finish-step, finish-message)
+- ✅ Keep-alive ticks
+- ✅ CORS (configurable origins)
+- ✅ Header forwarding (forwardHeaders, forwardPathParams)
+- ✅ Artifact mapping (custom data-* chunks for configured tool names)
+- ✅ textChunkType override
+- ✅ agentId → persona mapping with fallback
+- ✅ Config schema (Zod, registered in ChannelConfigSchema enum)
+- ✅ Channel factory registration
+- ✅ README + CLAUDE.md docs
+- ⚠️ **Not implemented:** Tool-result artifact chunks (requires agent runner to call a streaming hook per tool result — deferred to V2). V1 only streams the final `AgentOutput.body`.
+- ⚠️ **Not implemented:** Per-request MCP header injection. The connector stores `forwardedHeaders` in `PendingStream` but the daemon pipeline doesn't yet have a mechanism to pass per-request headers to MCP servers. This is a known gap from design doc open question, deferred to a follow-up.
+
+**Type consistency:** All types defined in `aisdk-http-types.ts` are imported consistently. `PendingStream.res` correctly typed as `ServerResponse`.

--- a/docs/superpowers/plans/2026-04-08-aisdk-http-channel-frontend.md
+++ b/docs/superpowers/plans/2026-04-08-aisdk-http-channel-frontend.md
@@ -1,0 +1,1027 @@
+# AI SDK HTTP Channel — React Frontend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a clean, minimal React chat UI that connects to a Talon `aisdk-http` channel via the Vercel AI SDK, streaming responses in real-time, persisting thread ID across page reloads, and rendering custom `data-*` artifact chunks from tool results.
+
+**Architecture:** Vite + React 19 + TypeScript SPA. `@ai-sdk/react` `useChat` hook with `DefaultChatTransport` pointed at the Talon endpoint. Thread ID persisted in `localStorage`. Tailwind CSS v4 for styling. Artifact chunks surfaced via `useChat`'s `data` array. Deployable as a static site or served from `vite preview`. Configurable via `.env` file — no hardcoded URLs.
+
+**Tech Stack:** Vite 6, React 19, TypeScript 5, `@ai-sdk/react` ^4, `@ai-sdk/ui-utils`, Tailwind CSS v4, `lucide-react` (icons), `vitest` + `@testing-library/react` for component tests.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `tools/chat-ui/package.json` | Dependencies and scripts |
+| Create | `tools/chat-ui/vite.config.ts` | Vite config with proxy for dev |
+| Create | `tools/chat-ui/tsconfig.json` | TypeScript config |
+| Create | `tools/chat-ui/index.html` | HTML entry point |
+| Create | `tools/chat-ui/.env.example` | Documented env vars |
+| Create | `tools/chat-ui/src/main.tsx` | React root mount |
+| Create | `tools/chat-ui/src/App.tsx` | Root component — provides chat context, renders layout |
+| Create | `tools/chat-ui/src/config.ts` | Reads env vars, validates, exports typed config |
+| Create | `tools/chat-ui/src/hooks/useThreadId.ts` | Persist + retrieve thread ID from localStorage |
+| Create | `tools/chat-ui/src/hooks/useArtifacts.ts` | Extract artifact chunks from useChat `data` array |
+| Create | `tools/chat-ui/src/components/ChatWindow.tsx` | Scrollable message list |
+| Create | `tools/chat-ui/src/components/MessageBubble.tsx` | Single message (user / assistant), renders Markdown |
+| Create | `tools/chat-ui/src/components/InputBar.tsx` | Textarea input + send button |
+| Create | `tools/chat-ui/src/components/ArtifactPanel.tsx` | Renders custom artifact data-* chunks |
+| Create | `tools/chat-ui/src/components/StatusBar.tsx` | Connection status + thread ID display |
+| Create | `tools/chat-ui/src/components/Sidebar.tsx` | Thread controls (new thread button) |
+| Create | `tools/chat-ui/src/lib/markdown.ts` | Minimal Markdown → HTML (no heavy deps) |
+| Create | `tools/chat-ui/src/lib/format.ts` | Timestamp formatting helpers |
+| Create | `tools/chat-ui/tests/useThreadId.test.ts` | Hook unit test |
+| Create | `tools/chat-ui/tests/useArtifacts.test.ts` | Hook unit test |
+| Create | `tools/chat-ui/tests/MessageBubble.test.tsx` | Component test |
+
+---
+
+## Task 1: Project Scaffold
+
+**Files:**
+- Create: `tools/chat-ui/package.json`
+- Create: `tools/chat-ui/vite.config.ts`
+- Create: `tools/chat-ui/tsconfig.json`
+- Create: `tools/chat-ui/index.html`
+- Create: `tools/chat-ui/.env.example`
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "talon-chat-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/react": "^1.0.0",
+    "ai": "^4.0.0",
+    "lucide-react": "^0.511.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^26.1.0",
+    "tailwindcss": "^4.1.0",
+    "@tailwindcss/vite": "^4.1.0",
+    "typescript": "^5.7.2",
+    "vite": "^6.3.2",
+    "vitest": "^3.1.1"
+  }
+}
+```
+
+- [ ] **Step 2: Create vite.config.ts**
+
+```typescript
+// tools/chat-ui/vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    port: 5173,
+    proxy: {
+      // Proxy API calls to local Talon during development
+      '/api': {
+        target: process.env.VITE_TALON_URL ?? 'http://127.0.0.1:4100',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./tests/setup.ts'],
+    globals: true,
+  },
+});
+```
+
+- [ ] **Step 3: Create tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "tests"]
+}
+```
+
+- [ ] **Step 4: Create index.html**
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Talon Chat</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦅</text></svg>" />
+  </head>
+  <body class="bg-gray-950 text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 5: Create .env.example**
+
+```bash
+# URL of your Talon aisdk-http channel endpoint
+# e.g. http://localhost:4100 for local dev
+VITE_TALON_URL=http://localhost:4100
+
+# Persona/agent name to connect to (maps to :agentId in the route)
+VITE_AGENT_ID=exo-agent
+
+# Route pattern (must match talond.yaml routePattern for the channel)
+VITE_ROUTE_PATTERN=/agents/{agentId}/stream
+```
+
+- [ ] **Step 6: Create tests/setup.ts**
+
+```typescript
+// tools/chat-ui/tests/setup.ts
+import '@testing-library/jest-dom';
+```
+
+- [ ] **Step 7: Install dependencies**
+
+```bash
+cd /home/talon/talon/tools/chat-ui && npm install
+```
+Expected: node_modules installed, no peer dependency errors.
+
+- [ ] **Step 8: Commit scaffold**
+
+```bash
+cd /home/talon/talon && git add tools/chat-ui/
+git commit -m "feat(chat-ui): project scaffold — Vite, React 19, Tailwind v4, AI SDK"
+```
+
+---
+
+## Task 2: Config and Hooks
+
+**Files:**
+- Create: `tools/chat-ui/src/config.ts`
+- Create: `tools/chat-ui/src/hooks/useThreadId.ts`
+- Create: `tools/chat-ui/src/hooks/useArtifacts.ts`
+- Create: `tools/chat-ui/tests/useThreadId.test.ts`
+- Create: `tools/chat-ui/tests/useArtifacts.test.ts`
+
+- [ ] **Step 1: Create config.ts**
+
+```typescript
+// tools/chat-ui/src/config.ts
+
+function requireEnv(key: string): string {
+  const val = import.meta.env[key] as string | undefined;
+  if (!val) throw new Error(`Missing required env var: ${key}`);
+  return val;
+}
+
+function optionalEnv(key: string, fallback: string): string {
+  return (import.meta.env[key] as string | undefined) ?? fallback;
+}
+
+export const config = {
+  talonUrl: optionalEnv('VITE_TALON_URL', 'http://localhost:4100'),
+  agentId: optionalEnv('VITE_AGENT_ID', 'default'),
+  /**
+   * Full stream URL — constructed from talonUrl + agentId.
+   * Uses the default aisdk-http route pattern.
+   */
+  get streamUrl(): string {
+    return `${this.talonUrl}/agents/${this.agentId}/stream`;
+  },
+  /** localStorage key for thread ID persistence. */
+  threadStorageKey: `talon-thread-${optionalEnv('VITE_AGENT_ID', 'default')}`,
+} as const;
+```
+
+- [ ] **Step 2: Write useThreadId tests**
+
+```typescript
+// tools/chat-ui/tests/useThreadId.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useThreadId } from '../src/hooks/useThreadId';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useThreadId', () => {
+  it('generates a UUID on first render when no stored thread', () => {
+    const { result } = renderHook(() => useThreadId('test-key'));
+    expect(result.current.threadId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+
+  it('restores thread ID from localStorage', () => {
+    localStorage.setItem('test-key', 'stored-thread-id');
+    const { result } = renderHook(() => useThreadId('test-key'));
+    expect(result.current.threadId).toBe('stored-thread-id');
+  });
+
+  it('resetThread generates a new UUID and persists it', () => {
+    const { result } = renderHook(() => useThreadId('test-key'));
+    const original = result.current.threadId;
+    act(() => { result.current.resetThread(); });
+    expect(result.current.threadId).not.toBe(original);
+    expect(localStorage.getItem('test-key')).toBe(result.current.threadId);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — expect failure**
+
+```bash
+cd /home/talon/talon/tools/chat-ui && npm test -- --reporter=verbose 2>&1 | tail -15
+```
+Expected: FAIL — useThreadId not found.
+
+- [ ] **Step 4: Create useThreadId.ts**
+
+```typescript
+// tools/chat-ui/src/hooks/useThreadId.ts
+import { useState, useCallback } from 'react';
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+export interface UseThreadIdResult {
+  threadId: string;
+  resetThread: () => void;
+}
+
+export function useThreadId(storageKey: string): UseThreadIdResult {
+  const [threadId, setThreadId] = useState<string>(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) return stored;
+    const id = generateId();
+    localStorage.setItem(storageKey, id);
+    return id;
+  });
+
+  const resetThread = useCallback(() => {
+    const id = generateId();
+    localStorage.setItem(storageKey, id);
+    setThreadId(id);
+  }, [storageKey]);
+
+  return { threadId, resetThread };
+}
+```
+
+- [ ] **Step 5: Write useArtifacts tests**
+
+```typescript
+// tools/chat-ui/tests/useArtifacts.test.ts
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useArtifacts } from '../src/hooks/useArtifacts';
+
+describe('useArtifacts', () => {
+  it('returns empty array when data is empty', () => {
+    const { result } = renderHook(() => useArtifacts([]));
+    expect(result.current).toEqual([]);
+  });
+
+  it('filters data items by known artifact type prefixes', () => {
+    const data = [
+      { type: 'data-exo-output-artifact', jsonContent: { tree: [] } },
+      { type: 'data-search-results', items: [{ id: '1' }] },
+      { type: 'other-data' },
+    ];
+    const { result } = renderHook(() => useArtifacts(data as object[]));
+    // Should return all items that have a `type` starting with "data-"
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0]).toMatchObject({ type: 'data-exo-output-artifact' });
+  });
+});
+```
+
+- [ ] **Step 6: Create useArtifacts.ts**
+
+```typescript
+// tools/chat-ui/src/hooks/useArtifacts.ts
+import { useMemo } from 'react';
+
+export interface ArtifactChunk {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Extract custom artifact chunks from the useChat `data` array.
+ * Artifact chunks are identified by their `type` field starting with "data-".
+ */
+export function useArtifacts(data: object[]): ArtifactChunk[] {
+  return useMemo(
+    () =>
+      data.filter(
+        (item): item is ArtifactChunk =>
+          typeof item === 'object' &&
+          item !== null &&
+          'type' in item &&
+          typeof (item as { type: unknown }).type === 'string' &&
+          (item as { type: string }).type.startsWith('data-'),
+      ),
+    [data],
+  );
+}
+```
+
+- [ ] **Step 7: Run tests — expect pass**
+
+```bash
+cd /home/talon/talon/tools/chat-ui && npm test -- --reporter=verbose 2>&1 | tail -15
+```
+Expected: all hook tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/talon/talon && git add tools/chat-ui/src/ tools/chat-ui/tests/
+git commit -m "feat(chat-ui): config, useThreadId, useArtifacts hooks with tests"
+```
+
+---
+
+## Task 3: Utility Libraries
+
+**Files:**
+- Create: `tools/chat-ui/src/lib/markdown.ts`
+- Create: `tools/chat-ui/src/lib/format.ts`
+
+- [ ] **Step 1: Create markdown.ts**
+
+A minimal Markdown → safe HTML converter. No heavy dependencies — just enough for chat messages (bold, italic, code, links, line breaks).
+
+```typescript
+// tools/chat-ui/src/lib/markdown.ts
+
+/**
+ * Convert a small subset of Markdown to sanitised HTML.
+ * Handles: bold, italic, inline code, code blocks, links, line breaks.
+ * Does NOT handle: tables, images, headings (not expected in chat responses).
+ */
+export function markdownToHtml(md: string): string {
+  return md
+    // Code blocks (``` ... ```) — must come before inline code
+    .replace(/```[\w]*\n?([\s\S]*?)```/g, '<pre><code>$1</code></pre>')
+    // Inline code
+    .replace(/`([^`]+)`/g, '<code class="bg-gray-800 px-1 rounded text-sm font-mono">$1</code>')
+    // Bold
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    // Italic
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    // Links [text](url) — only allow http/https
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-blue-400 underline">$1</a>')
+    // Line breaks
+    .replace(/\n/g, '<br />');
+}
+```
+
+- [ ] **Step 2: Create format.ts**
+
+```typescript
+// tools/chat-ui/src/lib/format.ts
+
+/**
+ * Format a Unix timestamp (ms) as a short time string: "14:32".
+ */
+export function formatTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+/**
+ * Truncate a string to maxLen characters, appending "..." if truncated.
+ */
+export function truncate(str: string, maxLen: number): string {
+  return str.length > maxLen ? `${str.slice(0, maxLen)}…` : str;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/talon/talon && git add tools/chat-ui/src/lib/
+git commit -m "feat(chat-ui): markdown and format utilities"
+```
+
+---
+
+## Task 4: Components
+
+**Files:**
+- Create: `tools/chat-ui/src/components/MessageBubble.tsx`
+- Create: `tools/chat-ui/src/components/ChatWindow.tsx`
+- Create: `tools/chat-ui/src/components/InputBar.tsx`
+- Create: `tools/chat-ui/src/components/ArtifactPanel.tsx`
+- Create: `tools/chat-ui/src/components/StatusBar.tsx`
+- Create: `tools/chat-ui/src/components/Sidebar.tsx`
+- Create: `tools/chat-ui/tests/MessageBubble.test.tsx`
+
+- [ ] **Step 1: Write MessageBubble test**
+
+```typescript
+// tools/chat-ui/tests/MessageBubble.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MessageBubble } from '../src/components/MessageBubble';
+
+describe('MessageBubble', () => {
+  it('renders user message on the right', () => {
+    render(<MessageBubble role="user" content="Hello" createdAt={new Date()} />);
+    const bubble = screen.getByText('Hello').closest('div');
+    expect(bubble?.className).toContain('items-end');
+  });
+
+  it('renders assistant message on the left', () => {
+    render(<MessageBubble role="assistant" content="Hi there" createdAt={new Date()} />);
+    const bubble = screen.getByText('Hi there').closest('div');
+    expect(bubble?.className).toContain('items-start');
+  });
+
+  it('renders bold markdown in assistant messages', () => {
+    render(<MessageBubble role="assistant" content="This is **bold**" createdAt={new Date()} />);
+    const strong = document.querySelector('strong');
+    expect(strong?.textContent).toBe('bold');
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+```bash
+cd /home/talon/talon/tools/chat-ui && npm test -- tests/MessageBubble.test.tsx 2>&1 | tail -10
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create MessageBubble.tsx**
+
+```tsx
+// tools/chat-ui/src/components/MessageBubble.tsx
+import { markdownToHtml } from '../lib/markdown';
+import { formatTime } from '../lib/format';
+
+interface MessageBubbleProps {
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt: Date;
+}
+
+export function MessageBubble({ role, content, createdAt }: MessageBubbleProps) {
+  const isUser = role === 'user';
+
+  return (
+    <div className={`flex flex-col gap-1 ${isUser ? 'items-end' : 'items-start'}`}>
+      <div
+        className={`max-w-[75%] rounded-2xl px-4 py-3 text-sm leading-relaxed ${
+          isUser
+            ? 'bg-blue-600 text-white rounded-br-sm'
+            : 'bg-gray-800 text-gray-100 rounded-bl-sm'
+        }`}
+      >
+        {isUser ? (
+          <span>{content}</span>
+        ) : (
+          <span
+            dangerouslySetInnerHTML={{ __html: markdownToHtml(content) }}
+            className="prose-sm"
+          />
+        )}
+      </div>
+      <span className="text-xs text-gray-500 px-1">{formatTime(createdAt.getTime())}</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+```bash
+cd /home/talon/talon/tools/chat-ui && npm test -- tests/MessageBubble.test.tsx 2>&1 | tail -10
+```
+Expected: PASS.
+
+- [ ] **Step 5: Create ChatWindow.tsx**
+
+```tsx
+// tools/chat-ui/src/components/ChatWindow.tsx
+import { useEffect, useRef } from 'react';
+import type { Message } from '@ai-sdk/react';
+import { MessageBubble } from './MessageBubble';
+import { Bot } from 'lucide-react';
+
+interface ChatWindowProps {
+  messages: Message[];
+  isLoading: boolean;
+}
+
+export function ChatWindow({ messages, isLoading }: ChatWindowProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, isLoading]);
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-4 text-gray-500">
+        <Bot size={48} className="text-gray-700" />
+        <p className="text-sm">Start a conversation</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-6 flex flex-col gap-4">
+      {messages.map((msg) => (
+        <MessageBubble
+          key={msg.id}
+          role={msg.role as 'user' | 'assistant'}
+          content={msg.content}
+          createdAt={msg.createdAt ?? new Date()}
+        />
+      ))}
+      {isLoading && (
+        <div className="flex items-start gap-2">
+          <div className="bg-gray-800 rounded-2xl rounded-bl-sm px-4 py-3 flex gap-1">
+            {[0, 1, 2].map((i) => (
+              <span
+                key={i}
+                className="w-1.5 h-1.5 bg-gray-500 rounded-full animate-bounce"
+                style={{ animationDelay: `${i * 150}ms` }}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Create InputBar.tsx**
+
+```tsx
+// tools/chat-ui/src/components/InputBar.tsx
+import { type FormEvent, type KeyboardEvent, useRef } from 'react';
+import { Send } from 'lucide-react';
+
+interface InputBarProps {
+  input: string;
+  isLoading: boolean;
+  onChange: (value: string) => void;
+  onSubmit: (e: FormEvent) => void;
+}
+
+export function InputBar({ input, isLoading, onChange, onSubmit }: InputBarProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (input.trim() && !isLoading) {
+        onSubmit(e as unknown as FormEvent);
+      }
+    }
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="flex items-end gap-3 px-4 py-4 border-t border-gray-800 bg-gray-950"
+    >
+      <textarea
+        ref={textareaRef}
+        rows={1}
+        value={input}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Message Talon… (Enter to send, Shift+Enter for newline)"
+        disabled={isLoading}
+        className="flex-1 resize-none bg-gray-900 border border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-blue-500 disabled:opacity-50 max-h-40 overflow-y-auto"
+        style={{ fieldSizing: 'content' } as React.CSSProperties}
+      />
+      <button
+        type="submit"
+        disabled={isLoading || !input.trim()}
+        className="flex items-center justify-center w-10 h-10 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-800 disabled:text-gray-600 text-white rounded-xl transition-colors shrink-0"
+        aria-label="Send message"
+      >
+        <Send size={16} />
+      </button>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 7: Create ArtifactPanel.tsx**
+
+```tsx
+// tools/chat-ui/src/components/ArtifactPanel.tsx
+import type { ArtifactChunk } from '../hooks/useArtifacts';
+import { Package } from 'lucide-react';
+
+interface ArtifactPanelProps {
+  artifacts: ArtifactChunk[];
+}
+
+export function ArtifactPanel({ artifacts }: ArtifactPanelProps) {
+  if (artifacts.length === 0) return null;
+
+  return (
+    <aside className="w-80 border-l border-gray-800 bg-gray-900 flex flex-col overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-800">
+        <Package size={14} className="text-gray-400" />
+        <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+          Artifacts
+        </span>
+        <span className="ml-auto text-xs text-gray-600">{artifacts.length}</span>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+        {artifacts.map((artifact, idx) => (
+          <div key={idx} className="rounded-lg border border-gray-700 overflow-hidden">
+            <div className="flex items-center gap-2 px-3 py-2 bg-gray-800 border-b border-gray-700">
+              <span className="text-xs font-mono text-blue-400">{artifact.type}</span>
+            </div>
+            <pre className="text-xs text-gray-300 p-3 overflow-x-auto leading-relaxed">
+              {JSON.stringify(
+                Object.fromEntries(Object.entries(artifact).filter(([k]) => k !== 'type')),
+                null,
+                2,
+              )}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 8: Create StatusBar.tsx**
+
+```tsx
+// tools/chat-ui/src/components/StatusBar.tsx
+import { Wifi, WifiOff } from 'lucide-react';
+import { truncate } from '../lib/format';
+
+interface StatusBarProps {
+  threadId: string;
+  isConnected: boolean;
+  agentId: string;
+}
+
+export function StatusBar({ threadId, isConnected, agentId }: StatusBarProps) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 bg-gray-900 border-b border-gray-800 text-xs text-gray-500">
+      <span className="flex items-center gap-1">
+        {isConnected ? (
+          <Wifi size={12} className="text-green-500" />
+        ) : (
+          <WifiOff size={12} className="text-gray-600" />
+        )}
+        <span className={isConnected ? 'text-green-400' : 'text-gray-600'}>
+          {isConnected ? 'Connected' : 'Disconnected'}
+        </span>
+      </span>
+      <span className="text-gray-700">·</span>
+      <span>agent: <span className="text-blue-400 font-mono">{agentId}</span></span>
+      <span className="text-gray-700">·</span>
+      <span>thread: <span className="font-mono text-gray-400">{truncate(threadId, 8)}</span></span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 9: Create Sidebar.tsx**
+
+```tsx
+// tools/chat-ui/src/components/Sidebar.tsx
+import { PlusCircle, Bird } from 'lucide-react';
+
+interface SidebarProps {
+  agentId: string;
+  onNewThread: () => void;
+}
+
+export function Sidebar({ agentId, onNewThread }: SidebarProps) {
+  return (
+    <aside className="w-16 flex flex-col items-center py-4 gap-4 border-r border-gray-800 bg-gray-950 shrink-0">
+      <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-gray-800">
+        <Bird size={20} className="text-blue-400" />
+      </div>
+      <div className="flex-1" />
+      <button
+        onClick={onNewThread}
+        className="flex items-center justify-center w-10 h-10 rounded-xl hover:bg-gray-800 text-gray-500 hover:text-gray-300 transition-colors"
+        title="New thread"
+        aria-label="Start new thread"
+      >
+        <PlusCircle size={20} />
+      </button>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 10: Run all tests**
+
+```bash
+cd /home/talon/talon/tools/chat-ui && npm test 2>&1 | tail -20
+```
+Expected: all tests pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+cd /home/talon/talon && git add tools/chat-ui/src/components/ tools/chat-ui/tests/MessageBubble.test.tsx
+git commit -m "feat(chat-ui): all UI components — ChatWindow, MessageBubble, InputBar, ArtifactPanel, StatusBar, Sidebar"
+```
+
+---
+
+## Task 5: App Root and Main Entry
+
+**Files:**
+- Create: `tools/chat-ui/src/App.tsx`
+- Create: `tools/chat-ui/src/main.tsx`
+- Create: `tools/chat-ui/src/index.css`
+
+- [ ] **Step 1: Create index.css (Tailwind entry)**
+
+```css
+/* tools/chat-ui/src/index.css */
+@import "tailwindcss";
+```
+
+- [ ] **Step 2: Create App.tsx**
+
+```tsx
+// tools/chat-ui/src/App.tsx
+import { useChat } from '@ai-sdk/react';
+import { config } from './config';
+import { useThreadId } from './hooks/useThreadId';
+import { useArtifacts } from './hooks/useArtifacts';
+import { ChatWindow } from './components/ChatWindow';
+import { InputBar } from './components/InputBar';
+import { ArtifactPanel } from './components/ArtifactPanel';
+import { StatusBar } from './components/StatusBar';
+import { Sidebar } from './components/Sidebar';
+
+export function App() {
+  const { threadId, resetThread } = useThreadId(config.threadStorageKey);
+
+  const {
+    messages,
+    input,
+    handleInputChange,
+    handleSubmit,
+    isLoading,
+    data,
+    error,
+    setMessages,
+  } = useChat({
+    api: config.streamUrl,
+    id: threadId,
+    onError: (err) => {
+      console.error('Chat error:', err);
+    },
+  });
+
+  const artifacts = useArtifacts((data ?? []) as object[]);
+
+  function handleNewThread() {
+    setMessages([]);
+    resetThread();
+  }
+
+  function handleInputBarChange(value: string) {
+    // useChat handleInputChange expects a ChangeEvent — wrap it
+    handleInputChange({ target: { value } } as React.ChangeEvent<HTMLInputElement>);
+  }
+
+  return (
+    <div className="flex h-screen w-screen overflow-hidden bg-gray-950 text-gray-100">
+      <Sidebar agentId={config.agentId} onNewThread={handleNewThread} />
+
+      <div className="flex flex-col flex-1 min-w-0">
+        <StatusBar
+          threadId={threadId}
+          isConnected={!error}
+          agentId={config.agentId}
+        />
+
+        <div className="flex flex-1 min-h-0">
+          <div className="flex flex-col flex-1 min-w-0">
+            <ChatWindow messages={messages} isLoading={isLoading} />
+            {error && (
+              <div className="px-4 py-2 text-xs text-red-400 bg-red-950 border-t border-red-900">
+                Error: {error.message}
+              </div>
+            )}
+            <InputBar
+              input={input}
+              isLoading={isLoading}
+              onChange={handleInputBarChange}
+              onSubmit={handleSubmit}
+            />
+          </div>
+
+          <ArtifactPanel artifacts={artifacts} />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create main.tsx**
+
+```tsx
+// tools/chat-ui/src/main.tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import { App } from './App';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('#root element not found');
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
+```
+
+- [ ] **Step 4: Start dev server and verify it loads**
+
+```bash
+cd /home/talon/talon/tools/chat-ui && cp .env.example .env && npm run dev 2>&1 &
+sleep 3 && curl -s http://localhost:5173 | grep -c "Talon Chat"
+```
+Expected: output `1` (title found in HTML).
+
+- [ ] **Step 5: Build for production — verify no errors**
+
+```bash
+cd /home/talon/talon/tools/chat-ui && npm run build 2>&1 | tail -10
+```
+Expected: `dist/` directory created, 0 TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/talon/talon && git add tools/chat-ui/src/App.tsx tools/chat-ui/src/main.tsx tools/chat-ui/src/index.css
+git commit -m "feat(chat-ui): App root and main entry — fully wired useChat + layout"
+```
+
+---
+
+## Task 6: README for chat-ui
+
+**Files:**
+- Create: `tools/chat-ui/README.md`
+
+- [ ] **Step 1: Write README**
+
+```markdown
+# Talon Chat UI
+
+A minimal React frontend for any Talon `aisdk-http` channel.
+
+## Setup
+
+1. Copy env file and configure:
+   ```bash
+   cp .env.example .env
+   # Edit .env: set VITE_TALON_URL and VITE_AGENT_ID
+   ```
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Start Talon with an `aisdk-http` channel on the configured port.
+
+4. Start dev server:
+   ```bash
+   npm run dev
+   ```
+   Open http://localhost:5173.
+
+## Build
+
+```bash
+npm run build
+npm run preview   # preview the production build
+```
+
+## Features
+
+- Streams responses in real-time via AI SDK v5 data-stream protocol
+- Thread ID persisted across page reloads (localStorage)
+- Custom `data-*` artifact chunks rendered in the Artifact Panel
+- New Thread button to start fresh conversations
+- Shift+Enter for multi-line input, Enter to send
+
+## Connecting to Talon
+
+In `talond.yaml`:
+```yaml
+channels:
+  - name: my-chat
+    type: aisdk-http
+    config:
+      port: 4100
+      routePattern: "/agents/:agentId/stream"
+
+bindings:
+  - channel: my-chat
+    persona: my-persona
+    isDefault: true
+```
+
+Set `VITE_TALON_URL=http://localhost:4100` and `VITE_AGENT_ID=my-persona` in `.env`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/talon/talon && git add tools/chat-ui/README.md
+git commit -m "docs(chat-ui): setup and usage README"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ `@ai-sdk/react` `useChat` connected to Talon `aisdk-http` endpoint
+- ✅ Thread ID persisted in `localStorage`, resettable via "New Thread" button
+- ✅ Real-time streaming — text appears as chunks arrive via SSE
+- ✅ Custom `data-*` artifact chunks surfaced in `ArtifactPanel`
+- ✅ Clean, dark-mode design (Tailwind v4, `bg-gray-950` base)
+- ✅ Configurable via `.env` — no hardcoded URLs
+- ✅ Typing indicator (animated dots while `isLoading`)
+- ✅ Error display when connection fails
+- ✅ Markdown rendering (bold, italic, inline code, code blocks, links) in assistant messages
+- ✅ Enter to send, Shift+Enter for newlines
+- ✅ Auto-scroll to latest message
+- ✅ Status bar with connection state, agent ID, thread ID
+- ✅ Production build via `vite build`
+- ✅ Tests for hooks and key component
+
+**Not implemented (intentional):**
+- Message history persistence beyond `useChat` state (requires backend API, deferred)
+- Multi-conversation sidebar (V2 — single thread per tab for now)
+- File attachment upload (not in scope for V1)
+- Dark/light theme toggle (dark-only is fine for a dev tool)
+
+**Type consistency:** All component prop types match what `useChat` returns. `data` typed as `object[]` via `useArtifacts` guard. `Message` imported from `@ai-sdk/react`.

--- a/src/core/database/migrations/010-memory-observation-type.sql
+++ b/src/core/database/migrations/010-memory-observation-type.sql
@@ -1,0 +1,31 @@
+-- Migration 010: Add 'observation' to memory_items type CHECK constraint
+--
+-- The observational memory feature stores context observations as
+-- memory_items with type='observation'. The existing CHECK constraint
+-- only allows fact|summary|note|embedding_ref, so this migration
+-- recreates the table with the updated constraint.
+
+-- 1. Create the new table with updated CHECK constraint.
+CREATE TABLE memory_items_new (
+  thread_id     TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+  id            TEXT NOT NULL,
+  type          TEXT NOT NULL CHECK (type IN ('fact', 'summary', 'note', 'embedding_ref', 'observation')),
+  content       TEXT NOT NULL,
+  embedding_ref TEXT,
+  metadata      TEXT NOT NULL DEFAULT '{}',
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  PRIMARY KEY (thread_id, id)
+);
+
+-- 2. Copy existing data.
+INSERT INTO memory_items_new (thread_id, id, type, content, embedding_ref, metadata, created_at, updated_at)
+  SELECT thread_id, id, type, content, embedding_ref, metadata, created_at, updated_at
+  FROM memory_items;
+
+-- 3. Drop old table and rename.
+DROP TABLE memory_items;
+ALTER TABLE memory_items_new RENAME TO memory_items;
+
+-- 4. Recreate index.
+CREATE INDEX idx_memory_thread ON memory_items(thread_id, type);

--- a/src/core/database/repositories/memory-repository.ts
+++ b/src/core/database/repositories/memory-repository.ts
@@ -14,7 +14,7 @@ import { DbError } from '../../errors/index.js';
 import { BaseRepository } from './base-repository.js';
 
 /** Valid memory item type values. */
-export type MemoryType = 'fact' | 'summary' | 'note' | 'embedding_ref';
+export type MemoryType = 'fact' | 'summary' | 'note' | 'embedding_ref' | 'observation';
 
 /** Row shape matching the `memory_items` table exactly. */
 export interface MemoryItemRow {

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -937,18 +937,30 @@ export class AgentRunner {
               } else {
                 try {
                   if (selectedMetricValue > 0) {
-                    const rotation = await this.ctx.contextRoller.checkAndRotate(
-                      item.threadId,
-                      personaId,
-                      {
-                        ratio: selectedMetricValue / Math.max(1, providerEntry.config.contextWindowTokens),
-                        inputTokens: contextUsage.inputTokens,
-                        rawMetric: selectedMetricValue,
-                        rawMetricName: enabledContextManagement.triggerMetric,
-                      },
-                      enabledContextManagement.thresholdRatio,
-                      enabledContextManagement.summarizer,
-                    );
+                    const contextUsagePayload = {
+                      ratio: selectedMetricValue / Math.max(1, providerEntry.config.contextWindowTokens),
+                      inputTokens: contextUsage.inputTokens,
+                      rawMetric: selectedMetricValue,
+                      rawMetricName: enabledContextManagement.triggerMetric,
+                    };
+                    // Route to observational memory path when configured with
+                    // session-observer; otherwise use the legacy summarizer.
+                    const useOM = enabledContextManagement.summarizer === 'session-observer';
+                    const rotation = useOM
+                      ? await this.ctx.contextRoller.checkAndRotateOM(
+                          item.threadId,
+                          personaId,
+                          contextUsagePayload,
+                          enabledContextManagement.thresholdRatio,
+                          enabledContextManagement.summarizer,
+                        )
+                      : await this.ctx.contextRoller.checkAndRotate(
+                          item.threadId,
+                          personaId,
+                          contextUsagePayload,
+                          enabledContextManagement.thresholdRatio,
+                          enabledContextManagement.summarizer,
+                        );
 
                     // For stateless providers (no session resumption), the agent
                     // loses its in-progress task state after context rotation.

--- a/src/daemon/context-assembler.ts
+++ b/src/daemon/context-assembler.ts
@@ -53,13 +53,36 @@ export class ContextAssembler {
     let summaryFound = false;
     let recentMessageCount = 0;
 
-    // 1. Get latest session summary from memory.
-    const summaryResult = this.deps.memoryRepo.findByThread(threadId, 'summary');
-    if (summaryResult.isOk() && summaryResult.value.length > 0) {
-      // findByThread with type filter returns DESC by created_at, first is newest.
-      const latest = summaryResult.value[0];
-      sections.push(latest.content);
+    // 1. Check for observations (OM path) or legacy summary.
+    // Observations take priority — if any exist, use the observation log.
+    // Otherwise fall back to the legacy summary blob.
+    const observationsResult = this.deps.memoryRepo.findByThread(threadId, 'observation');
+    if (observationsResult.isOk() && observationsResult.value.length > 0) {
+      // Observations are ordered DESC by created_at; reverse to chronological.
+      const observations = [...observationsResult.value].reverse();
+      const observationLog = observations.map((o) => o.content).join('\n\n');
+
+      // Extract currentTask and suggestedContinuation from the newest observation.
+      const newest = observationsResult.value[0];
+      let continuationHint = '';
+      try {
+        const meta = JSON.parse(newest.metadata);
+        const parts: string[] = [];
+        if (meta.currentTask) parts.push(`**Current task:** ${meta.currentTask}`);
+        if (meta.suggestedContinuation) parts.push(`**Next step:** ${meta.suggestedContinuation}`);
+        if (parts.length > 0) continuationHint = `\n\n${parts.join('\n')}`;
+      } catch { /* ignore parse errors */ }
+
+      sections.push(`### Observation Log\n\n${observationLog}${continuationHint}`);
       summaryFound = true;
+    } else {
+      // Legacy path: single summary blob.
+      const summaryResult = this.deps.memoryRepo.findByThread(threadId, 'summary');
+      if (summaryResult.isOk() && summaryResult.value.length > 0) {
+        const latest = summaryResult.value[0];
+        sections.push(latest.content);
+        summaryFound = true;
+      }
     }
 
     // 2. Get recent messages for immediate conversational context.

--- a/src/daemon/context-roller.ts
+++ b/src/daemon/context-roller.ts
@@ -57,14 +57,32 @@ export interface ContextRotationResult {
   hasOpenThreads: boolean;
 }
 
+/** Reflector function signature — receives the accumulated observation log. */
+export type ReflectorRunFn = (
+  threadId: string,
+  personaId: string,
+  input: { observationLog: string },
+) => Promise<Result<SubAgentResult, SubAgentError>>;
+
+/**
+ * Maximum character budget for the accumulated observation log before
+ * the reflector is triggered to consolidate observations.
+ * ~40K chars ≈ ~10K tokens — keeps observations manageable.
+ */
+const MAX_OBSERVATION_CHARS = 40_000;
+
 export interface ContextRollerDeps {
   messageRepo: Pick<MessageRepository, 'findLatestByThread'>;
-  memoryRepo: Pick<MemoryRepository, 'insert' | 'findById' | 'upsertByKey' | 'delete' | 'runInTransaction'>;
+  memoryRepo: Pick<MemoryRepository, 'insert' | 'findById' | 'findByThread' | 'upsertByKey' | 'delete' | 'runInTransaction'>;
   sessionTracker: Pick<SessionTracker, 'rotateSession'>;
   /** Pre-bound summarizer function. Model, prompt, and services are captured at bootstrap. */
   summarizerRun: SummarizerRunFn;
   /** Optional resolver for provider-selected summarizer names. */
   resolveSummarizerRun?: (name: string) => SummarizerRunFn | null;
+  /** Optional pre-bound reflector function for observation consolidation. */
+  reflectorRun?: ReflectorRunFn;
+  /** Optional resolver for named reflector sub-agents. */
+  resolveReflectorRun?: (name: string) => ReflectorRunFn | null;
   logger: pino.Logger;
   /** Optional fallback context ratio threshold. */
   thresholdRatio?: number;
@@ -276,6 +294,284 @@ export class ContextRoller {
 
     const hasOpenThreads = (data?.openThreads ?? []).length > 0;
     return { rotated: true, hasOpenThreads };
+  }
+
+  /**
+   * Observational memory rotation — appends observations instead of
+   * overwriting summaries.
+   *
+   * Called when the configured summarizer is `session-observer`. Instead of
+   * producing a single summary blob, the observer generates dated, prioritized
+   * observations that are appended to an observation log in memory_items.
+   *
+   * When the accumulated observation log exceeds MAX_OBSERVATION_CHARS, the
+   * reflector is triggered to consolidate observations.
+   */
+  async checkAndRotateOM(
+    threadId: string,
+    personaId: string,
+    contextUsage: ResolvedContextUsage,
+    overrideThreshold?: number,
+    observerName: string = 'session-observer',
+    reflectorName: string = 'session-reflector',
+  ): Promise<ContextRotationResult> {
+    const noRotation: ContextRotationResult = { rotated: false, hasOpenThreads: false };
+    const threshold = overrideThreshold ?? this.deps.thresholdRatio ?? 0.4;
+    if (contextUsage.ratio < threshold) {
+      return noRotation;
+    }
+
+    this.deps.logger.info(
+      { threadId, contextUsage, thresholdRatio: threshold },
+      'context-roller-om: threshold exceeded, creating observations',
+    );
+
+    // 1. Reconstruct transcript.
+    const messagesResult = this.deps.messageRepo.findLatestByThread(threadId, 10_000);
+    if (messagesResult.isErr()) {
+      this.deps.logger.error(
+        { threadId, error: messagesResult.error.message },
+        'context-roller-om: failed to read messages, skipping rotation',
+      );
+      return noRotation;
+    }
+
+    const messages = messagesResult.value;
+    if (messages.length === 0) {
+      this.deps.logger.warn({ threadId }, 'context-roller-om: no messages found, skipping rotation');
+      return noRotation;
+    }
+
+    const transcript = this.buildTranscript(messages, MAX_TRANSCRIPT_CHARS);
+
+    // 2. Resolve and call the observer.
+    const observerRun = this.deps.resolveSummarizerRun
+      ? this.deps.resolveSummarizerRun(observerName)
+      : null;
+    if (!observerRun) {
+      this.deps.logger.error(
+        { threadId, observer: observerName },
+        'context-roller-om: observer not available, skipping rotation',
+      );
+      return noRotation;
+    }
+
+    const observerResult = await observerRun(threadId, personaId, { transcript });
+    if (observerResult.isErr()) {
+      this.deps.logger.error(
+        { threadId, error: observerResult.error.message },
+        'context-roller-om: observation failed, skipping rotation',
+      );
+      return noRotation;
+    }
+
+    const observerData = observerResult.value.data as {
+      observations?: Array<{ date: string; time: string; priority: string; text: string }>;
+      currentTask?: string;
+      suggestedContinuation?: string;
+      memoryUpdates?: Array<{ key: string; value: string; mode: 'append' | 'replace' }>;
+    } | undefined;
+
+    const observations = observerData?.observations ?? [];
+    if (observations.length === 0) {
+      this.deps.logger.warn({ threadId }, 'context-roller-om: observer produced no observations');
+      return noRotation;
+    }
+
+    // 3. Format observations into the observation log format.
+    const priorityEmoji: Record<string, string> = { high: '🔴', medium: '🟡', low: '🟢' };
+    const grouped = new Map<string, string[]>();
+    for (const obs of observations) {
+      const lines = grouped.get(obs.date) ?? [];
+      const emoji = priorityEmoji[obs.priority] ?? '🟢';
+      lines.push(`- ${emoji} ${obs.time} ${obs.text}`);
+      grouped.set(obs.date, lines);
+    }
+    const newObservationBlock = [...grouped.entries()]
+      .map(([date, lines]) => `Date: ${date}\n${lines.join('\n')}`)
+      .join('\n\n');
+
+    // 4. Build metadata with currentTask and suggestedContinuation.
+    const metadata: Record<string, unknown> = {
+      source: 'context-roller-om',
+      messageCount: messages.length,
+      contextUsage,
+      createdAt: new Date().toISOString(),
+    };
+    if (observerData?.currentTask) {
+      metadata.currentTask = observerData.currentTask;
+    }
+    if (observerData?.suggestedContinuation) {
+      metadata.suggestedContinuation = observerData.suggestedContinuation;
+    }
+
+    // 5. Persist: append new observations + process memory updates in a transaction.
+    const pendingUpdates: Array<{ key: string; content: string; type: 'note' }> = [];
+    if (observerData?.memoryUpdates) {
+      for (const update of observerData.memoryUpdates) {
+        if (!update.key || !update.value) continue;
+        if (update.mode === 'append') {
+          const existingResult = this.deps.memoryRepo.findById(threadId, update.key);
+          const existingContent = existingResult.isOk() ? (existingResult.value?.content ?? '') : '';
+          const newContent = existingContent ? `${existingContent}\n${update.value}` : update.value;
+          pendingUpdates.push({ key: update.key, content: newContent, type: 'note' });
+        } else {
+          pendingUpdates.push({ key: update.key, content: update.value, type: 'note' });
+        }
+      }
+    }
+
+    const observationId = randomUUID();
+    const txResult = this.deps.memoryRepo.runInTransaction(() => {
+      const insertResult = this.deps.memoryRepo.insert({
+        id: observationId,
+        thread_id: threadId,
+        type: 'observation',
+        content: newObservationBlock,
+        embedding_ref: null,
+        metadata: JSON.stringify(metadata),
+      });
+      if (insertResult.isErr()) {
+        throw new Error(`observation insert: ${insertResult.error.message}`);
+      }
+
+      for (const update of pendingUpdates) {
+        const upsertResult = this.deps.memoryRepo.upsertByKey(threadId, update.key, {
+          type: update.type,
+          content: update.content,
+        });
+        if (upsertResult.isErr()) {
+          throw new Error(`upsert ${update.key}: ${upsertResult.error.message}`);
+        }
+      }
+
+      return pendingUpdates.length;
+    });
+
+    if (txResult.isErr()) {
+      this.deps.logger.error(
+        { threadId, error: txResult.error.message },
+        'context-roller-om: observation transaction failed',
+      );
+      return noRotation;
+    }
+
+    // 6. Rotate session.
+    this.deps.sessionTracker.rotateSession(threadId);
+
+    this.deps.logger.info(
+      { threadId, observationCount: observations.length, blockLength: newObservationBlock.length },
+      'context-roller-om: observations appended, session rotated',
+    );
+
+    // 7. Check if accumulated observations need reflection (consolidation).
+    await this.maybeReflect(threadId, personaId, reflectorName);
+
+    const hasOpenThreads = !!(observerData?.currentTask || observerData?.suggestedContinuation);
+    return { rotated: true, hasOpenThreads };
+  }
+
+  /**
+   * Trigger the reflector if accumulated observations exceed the threshold.
+   */
+  private async maybeReflect(
+    threadId: string,
+    personaId: string,
+    reflectorName: string,
+  ): Promise<void> {
+    const observationsResult = this.deps.memoryRepo.findByThread(threadId, 'observation');
+    if (observationsResult.isErr() || observationsResult.value.length === 0) {
+      return;
+    }
+
+    const allObservations = observationsResult.value;
+    const fullLog = allObservations.map((o) => o.content).join('\n\n');
+
+    if (fullLog.length < MAX_OBSERVATION_CHARS) {
+      return;
+    }
+
+    this.deps.logger.info(
+      { threadId, observationChars: fullLog.length, threshold: MAX_OBSERVATION_CHARS },
+      'context-roller-om: observation log exceeds threshold, triggering reflector',
+    );
+
+    const reflectorRun = this.deps.resolveReflectorRun
+      ? this.deps.resolveReflectorRun(reflectorName)
+      : this.deps.reflectorRun;
+    if (!reflectorRun) {
+      this.deps.logger.warn(
+        { threadId, reflector: reflectorName },
+        'context-roller-om: reflector not available, skipping consolidation',
+      );
+      return;
+    }
+
+    const reflectorResult = await reflectorRun(threadId, personaId, { observationLog: fullLog });
+    if (reflectorResult.isErr()) {
+      this.deps.logger.error(
+        { threadId, error: reflectorResult.error.message },
+        'context-roller-om: reflection failed, keeping current observations',
+      );
+      return;
+    }
+
+    const consolidated = (reflectorResult.value.data as { consolidatedLog?: string })?.consolidatedLog;
+    if (!consolidated || consolidated.trim().length === 0) {
+      this.deps.logger.warn({ threadId }, 'context-roller-om: reflector returned empty output');
+      return;
+    }
+
+    // Replace all existing observations with a single consolidated entry.
+    const consolidatedId = randomUUID();
+    const txResult = this.deps.memoryRepo.runInTransaction(() => {
+      // Delete all existing observations.
+      for (const obs of allObservations) {
+        const delResult = this.deps.memoryRepo.delete(threadId, obs.id);
+        if (delResult.isErr()) {
+          throw new Error(`delete observation ${obs.id}: ${delResult.error.message}`);
+        }
+      }
+
+      // Insert consolidated observation.
+      const insertResult = this.deps.memoryRepo.insert({
+        id: consolidatedId,
+        thread_id: threadId,
+        type: 'observation',
+        content: consolidated,
+        embedding_ref: null,
+        metadata: JSON.stringify({
+          source: 'context-roller-om-reflector',
+          consolidatedFrom: allObservations.length,
+          originalChars: fullLog.length,
+          consolidatedChars: consolidated.length,
+          createdAt: new Date().toISOString(),
+        }),
+      });
+      if (insertResult.isErr()) {
+        throw new Error(`consolidated insert: ${insertResult.error.message}`);
+      }
+
+      return allObservations.length;
+    });
+
+    if (txResult.isErr()) {
+      this.deps.logger.error(
+        { threadId, error: txResult.error.message },
+        'context-roller-om: reflection transaction failed',
+      );
+      return;
+    }
+
+    this.deps.logger.info(
+      {
+        threadId,
+        consolidatedFrom: allObservations.length,
+        originalChars: fullLog.length,
+        consolidatedChars: consolidated.length,
+      },
+      'context-roller-om: observations consolidated by reflector',
+    );
   }
 
   /**

--- a/src/daemon/context-roller.ts
+++ b/src/daemon/context-roller.ts
@@ -378,6 +378,39 @@ export class ContextRoller {
       return noRotation;
     }
 
+    // Log compression metrics and priority breakdown.
+    const priorityCounts = { high: 0, medium: 0, low: 0 };
+    for (const obs of observations) {
+      if (obs.priority in priorityCounts) {
+        priorityCounts[obs.priority as keyof typeof priorityCounts]++;
+      }
+    }
+    const observerUsage = observerResult.value.usage;
+    this.deps.logger.info(
+      {
+        threadId,
+        transcriptChars: transcript.length,
+        messageCount: messages.length,
+        observationCount: observations.length,
+        priorities: priorityCounts,
+        currentTask: observerData?.currentTask ?? null,
+        suggestedContinuation: observerData?.suggestedContinuation ?? null,
+        memoryUpdateCount: observerData?.memoryUpdates?.length ?? 0,
+        observerTokens: observerUsage
+          ? { input: observerUsage.inputTokens, output: observerUsage.outputTokens }
+          : null,
+      },
+      'context-roller-om: observer completed',
+    );
+
+    // Log individual observations at debug level for operator inspection.
+    for (const obs of observations) {
+      this.deps.logger.debug(
+        { threadId, date: obs.date, time: obs.time, priority: obs.priority },
+        `context-roller-om: [${obs.priority}] ${obs.text}`,
+      );
+    }
+
     // 3. Format observations into the observation log format.
     const priorityEmoji: Record<string, string> = { high: '🔴', medium: '🟡', low: '🟢' };
     const grouped = new Map<string, string[]>();
@@ -472,8 +505,18 @@ export class ContextRoller {
     // 6. Rotate session.
     this.deps.sessionTracker.rotateSession(threadId);
 
+    const compressionRatio = transcript.length > 0
+      ? (transcript.length / newObservationBlock.length).toFixed(1)
+      : '0';
     this.deps.logger.info(
-      { threadId, observationCount: observations.length, blockLength: newObservationBlock.length },
+      {
+        threadId,
+        observationCount: observations.length,
+        transcriptChars: transcript.length,
+        observationChars: newObservationBlock.length,
+        compressionRatio: `${compressionRatio}x`,
+        memoryUpdatesApplied: pendingUpdates.length,
+      },
       'context-roller-om: observations appended, session rotated',
     );
 
@@ -584,12 +627,16 @@ export class ContextRoller {
       return;
     }
 
+    const reflectorReduction = fullLog.length > 0
+      ? `${((1 - consolidated.length / fullLog.length) * 100).toFixed(0)}%`
+      : '0%';
     this.deps.logger.info(
       {
         threadId,
         consolidatedFrom: allObservations.length,
         originalChars: fullLog.length,
         consolidatedChars: consolidated.length,
+        reduction: reflectorReduction,
       },
       'context-roller-om: observations consolidated by reflector',
     );

--- a/src/daemon/context-roller.ts
+++ b/src/daemon/context-roller.ts
@@ -46,7 +46,7 @@ const MAX_TRANSCRIPT_CHARS = 100_000;
 export type SummarizerRunFn = (
   threadId: string,
   personaId: string,
-  input: { transcript: string },
+  input: Record<string, unknown>,
 ) => Promise<Result<SubAgentResult, SubAgentError>>;
 
 /** Result of a successful context rotation. */
@@ -57,12 +57,12 @@ export interface ContextRotationResult {
   hasOpenThreads: boolean;
 }
 
-/** Reflector function signature — receives the accumulated observation log. */
-export type ReflectorRunFn = (
-  threadId: string,
-  personaId: string,
-  input: { observationLog: string },
-) => Promise<Result<SubAgentResult, SubAgentError>>;
+/**
+ * Reflector function signature — receives the accumulated observation log.
+ * Uses the same base signature as SummarizerRunFn since both are pre-bound
+ * sub-agent runners; the input shape differs but the runner passes it through.
+ */
+export type ReflectorRunFn = SummarizerRunFn;
 
 /**
  * Maximum character budget for the accumulated observation log before
@@ -406,16 +406,29 @@ export class ContextRoller {
     }
 
     // 5. Persist: append new observations + process memory updates in a transaction.
+    // Use an in-batch accumulator to handle duplicate keys correctly — multiple
+    // append entries for the same key in one run should accumulate, not overwrite.
     const pendingUpdates: Array<{ key: string; content: string; type: 'note' }> = [];
+    const accumulatedContent = new Map<string, string>();
     if (observerData?.memoryUpdates) {
       for (const update of observerData.memoryUpdates) {
         if (!update.key || !update.value) continue;
         if (update.mode === 'append') {
-          const existingResult = this.deps.memoryRepo.findById(threadId, update.key);
-          const existingContent = existingResult.isOk() ? (existingResult.value?.content ?? '') : '';
+          // Check in-batch accumulator first, then fall back to DB.
+          let existingContent = accumulatedContent.get(update.key);
+          if (existingContent === undefined) {
+            const existingResult = this.deps.memoryRepo.findById(threadId, update.key);
+            existingContent = existingResult.isOk() ? (existingResult.value?.content ?? '') : '';
+          }
           const newContent = existingContent ? `${existingContent}\n${update.value}` : update.value;
+          accumulatedContent.set(update.key, newContent);
+          const existingIdx = pendingUpdates.findIndex((p) => p.key === update.key);
+          if (existingIdx !== -1) pendingUpdates.splice(existingIdx, 1);
           pendingUpdates.push({ key: update.key, content: newContent, type: 'note' });
         } else {
+          accumulatedContent.set(update.key, update.value);
+          const existingIdx = pendingUpdates.findIndex((p) => p.key === update.key);
+          if (existingIdx !== -1) pendingUpdates.splice(existingIdx, 1);
           pendingUpdates.push({ key: update.key, content: update.value, type: 'note' });
         }
       }
@@ -496,9 +509,17 @@ export class ContextRoller {
       'context-roller-om: observation log exceeds threshold, triggering reflector',
     );
 
-    const reflectorRun = this.deps.resolveReflectorRun
+    // Resolve the reflector sub-agent. Try the dedicated reflector resolver
+    // first, then fall back to the shared summarizer resolver (all sub-agents
+    // are registered in the same resolver in bootstrap).
+    const reflectorRun = (this.deps.resolveReflectorRun
       ? this.deps.resolveReflectorRun(reflectorName)
-      : this.deps.reflectorRun;
+      : null)
+      ?? (this.deps.resolveSummarizerRun
+        ? this.deps.resolveSummarizerRun(reflectorName)
+        : null)
+      ?? this.deps.reflectorRun
+      ?? null;
     if (!reflectorRun) {
       this.deps.logger.warn(
         { threadId, reflector: reflectorName },

--- a/src/memory/memory-manager.ts
+++ b/src/memory/memory-manager.ts
@@ -61,7 +61,7 @@ export class MemoryManager {
 
     const repoResult = this.memoryRepo.findByThread(
       threadId,
-      type as 'fact' | 'summary' | 'note' | 'embedding_ref' | undefined,
+      type as 'fact' | 'summary' | 'note' | 'embedding_ref' | 'observation' | undefined,
     );
 
     if (repoResult.isErr()) {

--- a/src/memory/memory-types.ts
+++ b/src/memory/memory-types.ts
@@ -35,7 +35,7 @@ export interface MemoryItem {
   /** Thread this memory belongs to. */
   threadId: string;
   /** Semantic type of the memory entry. */
-  type: 'fact' | 'summary' | 'note' | 'embedding_ref';
+  type: 'fact' | 'summary' | 'note' | 'embedding_ref' | 'observation';
   /** Human-readable (or LLM-generated) content. */
   content: string;
   /** Arbitrary key/value metadata (e.g. source run ID, persona name). */

--- a/src/subagents/default/session-observer/index.ts
+++ b/src/subagents/default/session-observer/index.ts
@@ -1,29 +1,45 @@
-import { generateObject } from 'ai';
-import { z } from 'zod';
+import { generateText } from 'ai';
 import { ok, err } from 'neverthrow';
 import type { SubAgentContext, SubAgentInput, SubAgentResult } from '../../subagent-types.js';
 import { SubAgentError } from '../../../core/errors/index.js';
 import type { Result } from 'neverthrow';
 
-const ObservationSchema = z.object({
-  date: z.string().describe('ISO date YYYY-MM-DD'),
-  time: z.string().describe('HH:MM timestamp'),
-  priority: z.enum(['high', 'medium', 'low']).describe('Importance level'),
-  text: z.string().describe('One clear sentence'),
-});
+/**
+ * Expected shape of the observer's JSON output.
+ *
+ * Uses generateText + manual JSON parsing instead of generateObject
+ * because many Ollama/OpenAI-compatible models don't support the
+ * structured output / tool-use mode that generateObject requires.
+ */
+interface ObserverOutput {
+  observations: Array<{
+    date: string;
+    time: string;
+    priority: 'high' | 'medium' | 'low';
+    text: string;
+  }>;
+  currentTask: string;
+  suggestedContinuation: string;
+  memoryUpdates: Array<{
+    key: string;
+    value: string;
+    mode: 'append' | 'replace';
+  }>;
+}
 
-const MemoryUpdateSchema = z.object({
-  key: z.string().describe('Namespace:topic key (e.g., work:people, projects:talon)'),
-  value: z.string().describe('The fact to store, prefixed with date'),
-  mode: z.enum(['append', 'replace']).describe('Whether to append to or replace the existing entry'),
-});
+const JSON_FORMAT_INSTRUCTIONS = `
+Respond with a JSON object (no markdown fences, no extra text) matching this structure:
 
-const ObserverOutputSchema = z.object({
-  observations: z.array(ObservationSchema).describe('Dated, prioritized observations from the conversation'),
-  currentTask: z.string().describe('What the agent was actively working on (empty if nothing)'),
-  suggestedContinuation: z.string().describe('What the agent should do next to resume (empty if nothing)'),
-  memoryUpdates: z.array(MemoryUpdateSchema).describe('Facts to store in specific memory namespace:topic keys'),
-});
+{
+  "observations": [
+    { "date": "YYYY-MM-DD", "time": "HH:MM", "priority": "high|medium|low", "text": "one sentence" }
+  ],
+  "currentTask": "what was being worked on (empty string if nothing)",
+  "suggestedContinuation": "what to do next (empty string if nothing)",
+  "memoryUpdates": [
+    { "key": "namespace:topic", "value": "fact prefixed with date", "mode": "append|replace" }
+  ]
+}`;
 
 export async function run(
   ctx: SubAgentContext,
@@ -36,20 +52,40 @@ export async function run(
   }
 
   try {
-    const { object, usage } = await generateObject({
+    const { text, usage } = await generateText({
       model: ctx.model,
       system: ctx.systemPrompt,
-      prompt: `Create observations from this conversation transcript:\n\n${transcript}`,
-      schema: ObserverOutputSchema,
+      prompt: `Create observations from this conversation transcript.
+
+${JSON_FORMAT_INSTRUCTIONS}
+
+Transcript:
+
+${transcript}`,
       maxOutputTokens: ctx.maxOutputTokens,
       experimental_telemetry: ctx.telemetry,
       abortSignal: ctx.abortSignal,
       providerOptions: ctx.providerOptions,
     });
 
+    // Extract JSON from the response — handle models that wrap in markdown fences.
+    const jsonStr = extractJson(text);
+    if (!jsonStr) {
+      return err(new SubAgentError(
+        `Session observer returned non-JSON response (${text.length} chars). First 200 chars: ${text.slice(0, 200)}`,
+      ));
+    }
+
+    const parsed = JSON.parse(jsonStr) as ObserverOutput;
+
+    // Validate minimum structure.
+    if (!Array.isArray(parsed.observations)) {
+      return err(new SubAgentError('Session observer response missing observations array'));
+    }
+
     return ok({
-      summary: object.currentTask || 'Observations recorded',
-      data: object as unknown as Record<string, unknown>,
+      summary: parsed.currentTask || 'Observations recorded',
+      data: parsed as unknown as Record<string, unknown>,
       usage: {
         inputTokens: usage?.inputTokens ?? 0,
         outputTokens: usage?.outputTokens ?? 0,
@@ -57,8 +93,37 @@ export async function run(
       },
     });
   } catch (error) {
+    if (error instanceof SyntaxError) {
+      return err(new SubAgentError(`Session observer returned invalid JSON: ${error.message}`));
+    }
     return err(new SubAgentError(
       `Session observation failed: ${error instanceof Error ? error.message : String(error)}`,
     ));
   }
+}
+
+/**
+ * Extract a JSON object from text that may contain markdown fences,
+ * preamble, or trailing text around the JSON.
+ */
+function extractJson(text: string): string | null {
+  // Try the raw text first.
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{')) {
+    return trimmed;
+  }
+
+  // Try extracting from markdown code fences.
+  const fenceMatch = trimmed.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+  if (fenceMatch) {
+    return fenceMatch[1].trim();
+  }
+
+  // Try finding the first { ... } block.
+  const braceStart = trimmed.indexOf('{');
+  if (braceStart >= 0) {
+    return trimmed.slice(braceStart);
+  }
+
+  return null;
 }

--- a/src/subagents/default/session-observer/index.ts
+++ b/src/subagents/default/session-observer/index.ts
@@ -1,0 +1,64 @@
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { ok, err } from 'neverthrow';
+import type { SubAgentContext, SubAgentInput, SubAgentResult } from '../../subagent-types.js';
+import { SubAgentError } from '../../../core/errors/index.js';
+import type { Result } from 'neverthrow';
+
+const ObservationSchema = z.object({
+  date: z.string().describe('ISO date YYYY-MM-DD'),
+  time: z.string().describe('HH:MM timestamp'),
+  priority: z.enum(['high', 'medium', 'low']).describe('Importance level'),
+  text: z.string().describe('One clear sentence'),
+});
+
+const MemoryUpdateSchema = z.object({
+  key: z.string().describe('Namespace:topic key (e.g., work:people, projects:talon)'),
+  value: z.string().describe('The fact to store, prefixed with date'),
+  mode: z.enum(['append', 'replace']).describe('Whether to append to or replace the existing entry'),
+});
+
+const ObserverOutputSchema = z.object({
+  observations: z.array(ObservationSchema).describe('Dated, prioritized observations from the conversation'),
+  currentTask: z.string().describe('What the agent was actively working on (empty if nothing)'),
+  suggestedContinuation: z.string().describe('What the agent should do next to resume (empty if nothing)'),
+  memoryUpdates: z.array(MemoryUpdateSchema).describe('Facts to store in specific memory namespace:topic keys'),
+});
+
+export async function run(
+  ctx: SubAgentContext,
+  input: SubAgentInput,
+): Promise<Result<SubAgentResult, SubAgentError>> {
+  const transcript = typeof input.transcript === 'string' ? input.transcript : '';
+
+  if (!transcript.trim()) {
+    return err(new SubAgentError('Cannot observe empty transcript'));
+  }
+
+  try {
+    const { object, usage } = await generateObject({
+      model: ctx.model,
+      system: ctx.systemPrompt,
+      prompt: `Create observations from this conversation transcript:\n\n${transcript}`,
+      schema: ObserverOutputSchema,
+      maxOutputTokens: ctx.maxOutputTokens,
+      experimental_telemetry: ctx.telemetry,
+      abortSignal: ctx.abortSignal,
+      providerOptions: ctx.providerOptions,
+    });
+
+    return ok({
+      summary: object.currentTask || 'Observations recorded',
+      data: object as unknown as Record<string, unknown>,
+      usage: {
+        inputTokens: usage?.inputTokens ?? 0,
+        outputTokens: usage?.outputTokens ?? 0,
+        costUsd: 0,
+      },
+    });
+  } catch (error) {
+    return err(new SubAgentError(
+      `Session observation failed: ${error instanceof Error ? error.message : String(error)}`,
+    ));
+  }
+}

--- a/src/subagents/default/session-observer/prompts/01-system.md
+++ b/src/subagents/default/session-observer/prompts/01-system.md
@@ -1,0 +1,35 @@
+You are a session observer. Your job is to compress a conversation transcript into a structured observation log — a dated, prioritized record of what happened, what was decided, and what's still in progress.
+
+## Output structure
+
+### 1. Observations
+A list of observations, each with:
+- **date**: ISO date (YYYY-MM-DD) when the events occurred
+- **time**: HH:MM timestamp (24h format)
+- **priority**: One of `high`, `medium`, `low`
+  - `high` (🔴): Critical decisions, user goals, deadlines, blocking issues, key facts
+  - `medium` (🟡): Questions asked, clarifications, conditional decisions, notable context
+  - `low` (🟢): Ephemeral context, greetings, minor details unlikely to matter later
+- **text**: One clear sentence describing the observation
+
+### 2. Current task
+What the agent was actively working on when the conversation was interrupted. One sentence. If no task was in progress, leave empty.
+
+### 3. Suggested continuation
+What the agent should do next to resume work. One sentence. If there's nothing to continue, leave empty.
+
+### 4. Memory updates
+Facts that should be stored in the persistent memory system. Same format as the session-summarizer:
+- **key**: Namespace:topic key (e.g., `work:people`, `projects:talon`)
+- **value**: The fact to store, prefixed with today's date
+- **mode**: `append` or `replace`
+
+## Guidelines
+
+- Produce a **decision log**, not a narrative summary. Each observation should be one specific action, decision, or fact — not a paragraph.
+- Preserve the temporal sequence — observations should be in chronological order.
+- Be aggressive with priority assignment. Most tool calls and routine actions are `low`. Key decisions and user-stated goals are `high`.
+- Tool call results should be abstracted to outcomes, not raw output. E.g., "Ran tests — 3 failures in auth module" not the full test output.
+- Preserve emotional context and user preferences — these are `medium` priority.
+- Do not include pleasantries, meta-conversation, or filler.
+- The observation log should be 5-40x smaller than the original transcript.

--- a/src/subagents/default/session-observer/subagent.yaml
+++ b/src/subagents/default/session-observer/subagent.yaml
@@ -1,0 +1,14 @@
+name: session-observer
+version: "0.1.0"
+description: "Compresses conversation messages into dated, prioritized observations for long-term memory"
+
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  maxTokens: 16384
+
+requiredCapabilities: []
+
+rootPaths: []
+
+timeoutMs: 60000

--- a/src/subagents/default/session-reflector/index.ts
+++ b/src/subagents/default/session-reflector/index.ts
@@ -1,0 +1,42 @@
+import { generateText } from 'ai';
+import { ok, err } from 'neverthrow';
+import type { SubAgentContext, SubAgentInput, SubAgentResult } from '../../subagent-types.js';
+import { SubAgentError } from '../../../core/errors/index.js';
+import type { Result } from 'neverthrow';
+
+export async function run(
+  ctx: SubAgentContext,
+  input: SubAgentInput,
+): Promise<Result<SubAgentResult, SubAgentError>> {
+  const observationLog = typeof input.observationLog === 'string' ? input.observationLog : '';
+
+  if (!observationLog.trim()) {
+    return err(new SubAgentError('Cannot reflect on empty observation log'));
+  }
+
+  try {
+    const { text, usage } = await generateText({
+      model: ctx.model,
+      system: ctx.systemPrompt,
+      prompt: `Consolidate this observation log:\n\n${observationLog}`,
+      maxOutputTokens: ctx.maxOutputTokens,
+      experimental_telemetry: ctx.telemetry,
+      abortSignal: ctx.abortSignal,
+      providerOptions: ctx.providerOptions,
+    });
+
+    return ok({
+      summary: 'Observations consolidated',
+      data: { consolidatedLog: text } as unknown as Record<string, unknown>,
+      usage: {
+        inputTokens: usage?.inputTokens ?? 0,
+        outputTokens: usage?.outputTokens ?? 0,
+        costUsd: 0,
+      },
+    });
+  } catch (error) {
+    return err(new SubAgentError(
+      `Session reflection failed: ${error instanceof Error ? error.message : String(error)}`,
+    ));
+  }
+}

--- a/src/subagents/default/session-reflector/prompts/01-system.md
+++ b/src/subagents/default/session-reflector/prompts/01-system.md
@@ -1,0 +1,48 @@
+You are a session reflector. Your job is to consolidate an accumulated observation log — merging related observations, removing superseded information, and producing a denser, cleaner log.
+
+## Input
+
+You receive a full observation log in this format:
+
+```
+Date: YYYY-MM-DD
+- 🔴 HH:MM observation text
+- 🟡 HH:MM observation text
+- 🟢 HH:MM observation text
+
+Date: YYYY-MM-DD
+- ...
+```
+
+## Output structure
+
+Return a consolidated observation log in the exact same format. The output should be **significantly shorter** than the input while preserving all important information.
+
+## Consolidation rules
+
+1. **Merge related observations**: Multiple observations about the same topic should be combined into one.
+   - Before: "🔴 14:10 Started implementing auth module" + "🔴 14:30 Auth module tests passing" + "🔴 15:00 Auth module merged to main"
+   - After: "🔴 14:10-15:00 Implemented auth module: tests passing, merged to main"
+
+2. **Drop superseded information**: When a newer observation replaces an older one, keep only the newer.
+   - Before: "🟡 10:00 Considering Redis for caching" + "🔴 11:00 Decided on Memcached for caching"
+   - After: "🔴 11:00 Decided on Memcached for caching"
+
+3. **Downgrade resolved items**: If an issue was raised and resolved, compress it.
+   - Before: "🔴 09:00 Build failing — missing dependency" + "🟢 09:15 Fixed build by adding missing dep"
+   - After: "🟢 09:00-09:15 Fixed build failure (missing dependency)"
+
+4. **Preserve high-priority items**: Never drop 🔴 observations unless they are explicitly superseded.
+
+5. **Collapse dates**: If all observations from a date can be summarized in 1-2 lines, collapse them.
+
+6. **Keep temporal structure**: The output must remain chronologically ordered with date headers.
+
+7. **Preserve the current task and continuation hints**: If the last date section contains observations about in-progress work, keep them at full detail.
+
+## Guidelines
+
+- Target 30-60% reduction in length.
+- Never invent information that wasn't in the input.
+- When in doubt about importance, keep the observation.
+- Recent observations (last date section) should be preserved with more detail than older ones.

--- a/src/subagents/default/session-reflector/subagent.yaml
+++ b/src/subagents/default/session-reflector/subagent.yaml
@@ -1,0 +1,14 @@
+name: session-reflector
+version: "0.1.0"
+description: "Consolidates and garbage-collects accumulated observations, merging related items and dropping superseded context"
+
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  maxTokens: 16384
+
+requiredCapabilities: []
+
+rootPaths: []
+
+timeoutMs: 90000


### PR DESCRIPTION
## Summary
- Adds an observational memory pattern alongside the existing single-summary context compression
- New `session-observer` sub-agent produces dated, emoji-prioritized observations (🔴/🟡/🟢) that **append** over time instead of overwriting
- New `session-reflector` sub-agent consolidates observations when the log exceeds 40K chars — merges related items, drops superseded context
- Context assembler injects the full observation log + `currentTask`/`suggestedContinuation` metadata so the agent can resume coherently
- Fully backward compatible: `summarizer: session-summarizer` keeps the legacy path, `summarizer: session-observer` enables OM

## How it works
```
Turn 1-5: messages accumulate → context threshold hit
  → Observer compresses to dated observations → appended to observation log
Turn 6-10: more messages → threshold hit again
  → Observer generates new observations → appended (old ones preserved)
After many rotations: observation log exceeds 40K chars
  → Reflector consolidates: merges, deduplicates, drops superseded → denser log
```

## To enable
```yaml
agentRunner:
  providers:
    openai-compatible:
      contextManagement:
        summarizer: session-observer   # instead of session-summarizer
```

## Test plan
- [x] 27 context-roller unit tests pass (legacy path unchanged)
- [x] 85 agent-runner unit tests pass
- [x] 8 context-assembler unit tests pass
- [x] 5 rolling-context-window integration tests pass
- [ ] Manual: run long Telegram conversation, verify observations accumulate across rotations
- [ ] Manual: verify reflector triggers and consolidates after enough rotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)