### PR TITLE
feat: add aisdk-http channel connector (AI SDK v5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Channel Connector → MessagePipeline (normalize, dedup, route, persist)
 | Module    | Path                       | Purpose                                                             |
 | --------- | -------------------------- | ------------------------------------------------------------------- |
 | Daemon    | `src/daemon/`              | Lifecycle state machine, agent runner, bootstrap, watchdog          |
-| Channels  | `src/channels/connectors/` | 7 adapters: telegram, slack, discord, whatsapp-business, whatsapp-baileys, email, terminal |
+| Channels  | `src/channels/connectors/` | 8 adapters: telegram, slack, discord, whatsapp-business, whatsapp-baileys, email, terminal, aisdk-http |
 | Pipeline  | `src/pipeline/`            | Inbound normalization, dedup, routing, persistence                  |
 | Queue     | `src/queue/`               | Durable SQLite queue, retry with exponential backoff, dead-letter   |
 | Scheduler | `src/scheduler/`           | Cron/interval/one-shot task execution                               |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It is built for single-user or small-team deployments where you want persistent,
 - **Discord** — Gateway events with REST API, rate limit handling _(inbound not yet implemented)_
 - **WhatsApp** — WhatsApp Web bridge via Baileys, supports dedicated number or self-chat mode
 - **Email** — IMAP polling + SMTP send, thread tracking via In-Reply-To headers _(not yet tested)_
+- **AI SDK HTTP** — HTTP + SSE server for any Vercel AI SDK v5 frontend (`useChat`, `DefaultChatTransport`)
 
 ### Agent System
 
@@ -169,6 +170,7 @@ graph TB
         WA[WhatsApp]
         EM[Email]
         TM[Terminal]
+        AH[AI SDK HTTP]
     end
 
     subgraph "talond (Host Daemon)"
@@ -196,7 +198,7 @@ graph TB
 
     DB[(SQLite)]
 
-    TG & SL & DC & WA & EM & TM --> CR
+    TG & SL & DC & WA & EM & TM & AH --> CR
     CR --> NP --> RT --> Q
     Q --> AR
     AR --> PR
@@ -1366,7 +1368,7 @@ npx talonctl chat --token mytoken --persona assistant
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--name <name>` | Unique channel name (required) | — |
-| `--type <type>` | Connector type: telegram, slack, discord, whatsappBaileys, whatsappBusiness, email, terminal (required) | — |
+| `--type <type>` | Connector type: telegram, slack, discord, whatsappBaileys, whatsappBusiness, email, terminal, aisdk-http (required) | — |
 | `--config <path>` | Path to talond.yaml | `talond.yaml` |
 
 **`add-persona`** options:
@@ -2327,6 +2329,7 @@ talon/
         whatsapp-baileys/        # WhatsApp Web (Baileys) connector
         email/                   # IMAP + SMTP connector
         terminal/                # WebSocket terminal connector
+        aisdk-http/              # AI SDK v5 HTTP + SSE connector
       channel-registry.ts        # Connector lifecycle management
       channel-router.ts          # Thread -> persona routing
       channel-types.ts           # ChannelConnector interface

--- a/specs/aisdk-http/backend-plan.md
+++ b/specs/aisdk-http/backend-plan.md
@@ -1,0 +1,1112 @@
+# AI SDK HTTP Channel — Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new `aisdk-http` channel type to Talon that speaks the Vercel AI SDK v5 data-stream SSE protocol, so any `@ai-sdk/react` frontend can connect to a Talon persona via HTTP POST + SSE.
+
+**Architecture:** The connector runs its own lightweight HTTP server (Node `http`). Inbound POST requests are parsed as AI SDK message bodies and converted to `InboundEvent`s for the existing pipeline. The HTTP response is held open as an SSE stream; keep-alive ticks fire every 5 s while the agent runs. When `send()` is called by the daemon with the completed `AgentOutput`, the connector serialises it as AI SDK data-stream chunks and closes the stream. Tool results for configured tool names are additionally emitted as custom `data-` chunks.
+
+**Tech Stack:** Node 22 `http`, TypeScript strict, `neverthrow` Result, `zod`, `pino`, AI SDK v5 data-stream protocol (text/event-stream), `vitest` for tests.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `src/channels/connectors/aisdk-http/aisdk-http-types.ts` | Zod config schema + all TS types for this connector |
+| Create | `src/channels/connectors/aisdk-http/route-parser.ts` | Parse configurable route patterns, extract named path params |
+| Create | `src/channels/connectors/aisdk-http/stream-adapter.ts` | Convert `AgentOutput` → AI SDK data-stream SSE chunks |
+| Create | `src/channels/connectors/aisdk-http/artifact-mapper.ts` | Emit custom `2:[...]` data chunks for configured tool names |
+| Create | `src/channels/connectors/aisdk-http/aisdk-http-connector.ts` | Main `ChannelConnector` implementation — HTTP server, SSE, keep-alive |
+| Modify | `src/core/config/config-schema.ts` | Add `AisdkHttpChannelConfigSchema`, widen `ChannelConfigSchema.type` enum |
+| Modify | `src/daemon/channel-factory.ts` | Add `aisdk-http` case |
+| Create | `tests/unit/channels/aisdk-http/route-parser.test.ts` | Unit tests for route parsing |
+| Create | `tests/unit/channels/aisdk-http/stream-adapter.test.ts` | Unit tests for SSE serialisation |
+| Create | `tests/unit/channels/aisdk-http/artifact-mapper.test.ts` | Unit tests for artifact mapping |
+| Create | `tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts` | Integration tests for connector lifecycle + HTTP |
+
+---
+
+## Task 1: Types and Config Schema
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/aisdk-http-types.ts`
+- Modify: `src/core/config/config-schema.ts`
+
+- [ ] **Step 1: Write the types file**
+
+```typescript
+// src/channels/connectors/aisdk-http/aisdk-http-types.ts
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Config schema (registered in config-schema.ts)
+// ---------------------------------------------------------------------------
+
+export const ArtifactMappingSchema = z.object({
+  /** Tool name whose result should emit a custom data chunk. */
+  toolName: z.string(),
+  /** SSE data chunk type prefix, e.g. "data-exo-output-artifact". */
+  chunkType: z.string(),
+  /**
+   * Optional wrapper key. When set, result is emitted as { [wrapAs]: result }.
+   * When omitted, result is emitted as-is.
+   */
+  wrapAs: z.string().optional(),
+});
+
+export const AisdkHttpChannelConfigSchema = z.object({
+  /** TCP port to listen on. */
+  port: z.number().int().min(1).max(65535),
+  /**
+   * Express-style route pattern with named params (e.g. "/agents/:agentId/stream"
+   * or "/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream").
+   * The :agentId param maps to a persona name.
+   */
+  routePattern: z.string().default('/agents/:agentId/stream'),
+  /** CORS allowed origins. Glob patterns supported. */
+  cors: z.object({
+    allowOrigins: z.array(z.string()).default(['*']),
+  }).default({}),
+  /**
+   * Map specific tool result names to custom SSE data chunks.
+   * Each matched tool result also emits its normal tool-result chunk.
+   */
+  artifactMapping: z.array(ArtifactMappingSchema).default([]),
+  /**
+   * Override the SSE chunk type used for text output.
+   * null = use standard "0:" text-delta chunks (default, works with any useChat frontend).
+   * Set to e.g. "data-human-readable" for custom frontend handling.
+   */
+  textChunkType: z.string().nullable().default(null),
+  /**
+   * HTTP request headers to forward to MCP servers.
+   * E.g. ["Authorization"] passes the Bearer token through.
+   */
+  forwardHeaders: z.array(z.string()).default([]),
+  /**
+   * Map route path params to header names forwarded to MCP servers.
+   * E.g. { spaceId: "X-Space-Id" } extracts :spaceId from the URL and sends it as a header.
+   */
+  forwardPathParams: z.record(z.string()).default({}),
+  /**
+   * Explicit agentId → persona name mapping.
+   * If absent, agentId is used directly as the persona name.
+   */
+  agentMapping: z.record(z.string()).default({}),
+  /** Fallback persona when agentId doesn't match any mapping. */
+  defaultPersona: z.string().optional(),
+  /** Keep-alive SSE tick interval while agent is running (ms). Min 1000. */
+  keepAliveIntervalMs: z.number().int().min(1000).max(60000).default(5000),
+  /** Host to bind to. Defaults to 127.0.0.1. */
+  host: z.string().default('127.0.0.1'),
+});
+
+export type AisdkHttpChannelConfig = z.infer<typeof AisdkHttpChannelConfigSchema>;
+export type ArtifactMapping = z.infer<typeof ArtifactMappingSchema>;
+
+// ---------------------------------------------------------------------------
+// AI SDK v5 data-stream wire types
+// ---------------------------------------------------------------------------
+
+/** AI SDK data-stream protocol chunk types (numeric codes). */
+export const StreamPartType = {
+  TEXT_DELTA: '0',
+  DATA: '2',
+  ERROR: '3',
+  TOOL_CALL: '9',
+  TOOL_RESULT: 'a',
+  TOOL_CALL_STREAMING_START: 'b',
+  TOOL_CALL_DELTA: 'c',
+  FINISH_MESSAGE: 'd',
+  FINISH_STEP: 'e',
+  START_STEP: 'f',
+} as const;
+
+/** Represents one line in the AI SDK data-stream SSE body. */
+export interface StreamPart {
+  type: string;   // one of StreamPartType values
+  value: unknown; // serialised as JSON after the type prefix
+}
+
+// ---------------------------------------------------------------------------
+// AI SDK request body (what useChat POSTs)
+// ---------------------------------------------------------------------------
+
+export interface AisdkMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string;
+  id?: string;
+}
+
+export interface AisdkRequestBody {
+  /** Conversation messages. Last user message is the new input. */
+  messages: AisdkMessage[];
+  /** Client-generated thread ID. Used as Talon externalThreadId. */
+  id?: string;
+  /** Opaque metadata forwarded to the persona context. */
+  metadata?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: pending SSE stream entry
+// ---------------------------------------------------------------------------
+
+export interface PendingStream {
+  /** Node.js ServerResponse (kept open for SSE). */
+  res: import('node:http').ServerResponse;
+  /** Interval handle for keep-alive ticks. */
+  keepAliveInterval: ReturnType<typeof setInterval>;
+  /** Headers extracted from the original request (for MCP forwarding). */
+  forwardedHeaders: Record<string, string>;
+}
+```
+
+- [ ] **Step 2: Widen the ChannelConfigSchema type enum in config-schema.ts**
+
+Open `src/core/config/config-schema.ts`. Find the line:
+```typescript
+  type: z.enum(['telegram', 'whatsapp', 'whatsappBusiness', 'whatsappBaileys', 'slack', 'email', 'discord', 'terminal']),
+```
+Replace it with:
+```typescript
+  type: z.enum(['telegram', 'whatsapp', 'whatsappBusiness', 'whatsappBaileys', 'slack', 'email', 'discord', 'terminal', 'aisdk-http']),
+```
+
+- [ ] **Step 3: Build and typecheck**
+
+```bash
+cd /home/talon/talon && npm run build 2>&1 | tail -20
+```
+Expected: no errors related to config-schema.ts or aisdk-http-types.ts.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/aisdk-http-types.ts src/core/config/config-schema.ts
+git commit -m "feat(aisdk-http): add types, config schema, and enum registration"
+```
+
+---
+
+## Task 2: Route Parser
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/route-parser.ts`
+- Create: `tests/unit/channels/aisdk-http/route-parser.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// tests/unit/channels/aisdk-http/route-parser.test.ts
+import { describe, it, expect } from 'vitest';
+import { parseRoute, matchRoute } from '../../../src/channels/connectors/aisdk-http/route-parser.js';
+
+describe('parseRoute', () => {
+  it('converts pattern to regex and extracts param names', () => {
+    const result = parseRoute('/agents/:agentId/stream');
+    expect(result.paramNames).toEqual(['agentId']);
+    expect(result.regex.test('/agents/exo-agent/stream')).toBe(true);
+    expect(result.regex.test('/agents/exo-agent/other')).toBe(false);
+  });
+
+  it('handles multi-segment patterns with multiple params', () => {
+    const result = parseRoute('/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream');
+    expect(result.paramNames).toEqual(['spaceId', 'envId', 'agentId']);
+    expect(result.regex.test('/spaces/abc123/environments/master/ai/agents/exo-agent/stream')).toBe(true);
+  });
+
+  it('handles patterns with no params', () => {
+    const result = parseRoute('/chat/stream');
+    expect(result.paramNames).toEqual([]);
+    expect(result.regex.test('/chat/stream')).toBe(true);
+    expect(result.regex.test('/chat/stream/extra')).toBe(false);
+  });
+});
+
+describe('matchRoute', () => {
+  it('returns null when URL does not match pattern', () => {
+    const result = matchRoute('/agents/:agentId/stream', '/other/path');
+    expect(result).toBeNull();
+  });
+
+  it('extracts named params from matching URL', () => {
+    const result = matchRoute('/agents/:agentId/stream', '/agents/my-persona/stream');
+    expect(result).toEqual({ agentId: 'my-persona' });
+  });
+
+  it('extracts multiple named params', () => {
+    const result = matchRoute(
+      '/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream',
+      '/spaces/abc/environments/master/ai/agents/exo-agent/stream',
+    );
+    expect(result).toEqual({ spaceId: 'abc', envId: 'master', agentId: 'exo-agent' });
+  });
+
+  it('ignores query string when matching', () => {
+    const result = matchRoute('/agents/:agentId/stream', '/agents/foo/stream?bar=baz');
+    expect(result).toEqual({ agentId: 'foo' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/route-parser.test.ts 2>&1 | tail -10
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement route-parser.ts**
+
+```typescript
+// src/channels/connectors/aisdk-http/route-parser.ts
+
+interface ParsedRoute {
+  regex: RegExp;
+  paramNames: string[];
+}
+
+/**
+ * Pre-compile an Express-style route pattern to a regex + param name list.
+ * Segments like :paramName are captured as named groups.
+ */
+export function parseRoute(pattern: string): ParsedRoute {
+  const paramNames: string[] = [];
+  // Escape special regex chars except for our :param syntax
+  const regexStr = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')   // escape regex specials
+    .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, (_match, name: string) => {
+      paramNames.push(name);
+      return '([^/]+)';
+    });
+  const regex = new RegExp(`^${regexStr}$`);
+  return { regex, paramNames };
+}
+
+/**
+ * Match a URL pathname against a route pattern.
+ * Returns extracted param values, or null if no match.
+ */
+export function matchRoute(
+  pattern: string,
+  url: string,
+): Record<string, string> | null {
+  // Strip query string
+  const pathname = url.split('?')[0] ?? url;
+  const { regex, paramNames } = parseRoute(pattern);
+  const match = regex.exec(pathname);
+  if (!match) return null;
+  const params: Record<string, string> = {};
+  paramNames.forEach((name, i) => {
+    params[name] = match[i + 1] ?? '';
+  });
+  return params;
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/route-parser.test.ts 2>&1 | tail -10
+```
+Expected: PASS — all 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/route-parser.ts tests/unit/channels/aisdk-http/route-parser.test.ts
+git commit -m "feat(aisdk-http): route parser with named param extraction"
+```
+
+---
+
+## Task 3: Stream Adapter
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/stream-adapter.ts`
+- Create: `tests/unit/channels/aisdk-http/stream-adapter.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// tests/unit/channels/aisdk-http/stream-adapter.test.ts
+import { describe, it, expect } from 'vitest';
+import { encodeStreamPart, buildTextChunks, buildFinishChunks, buildKeepAlive } from '../../../src/channels/connectors/aisdk-http/stream-adapter.js';
+
+describe('encodeStreamPart', () => {
+  it('encodes a text-delta chunk', () => {
+    const line = encodeStreamPart('0', 'Hello world');
+    expect(line).toBe('0:"Hello world"\n');
+  });
+
+  it('encodes a data chunk (array)', () => {
+    const line = encodeStreamPart('2', [{ type: 'test' }]);
+    expect(line).toBe('2:[{"type":"test"}]\n');
+  });
+
+  it('encodes a finish-message chunk', () => {
+    const line = encodeStreamPart('d', { finishReason: 'stop', usage: { promptTokens: 10, completionTokens: 5 } });
+    expect(line).toBe('d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":5}}\n');
+  });
+});
+
+describe('buildTextChunks', () => {
+  it('returns array of encoded text-delta lines for word tokens', () => {
+    const chunks = buildTextChunks('Hello world', null);
+    // Each word (split by space) becomes a text-delta
+    expect(chunks.length).toBeGreaterThan(0);
+    chunks.forEach(c => expect(c).toMatch(/^0:".+"\n$/));
+  });
+
+  it('uses custom chunk type when textChunkType is set', () => {
+    const chunks = buildTextChunks('Hi', 'data-human-readable');
+    expect(chunks[0]).toMatch(/^data-human-readable:/);
+  });
+});
+
+describe('buildFinishChunks', () => {
+  it('returns finish-step and finish-message lines', () => {
+    const chunks = buildFinishChunks();
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toContain('"finishReason":"stop"');
+    expect(chunks[0]).toContain('"isContinued":false');
+    expect(chunks[1]).toContain('"finishReason":"stop"');
+  });
+});
+
+describe('buildKeepAlive', () => {
+  it('returns a comment line (SSE keep-alive)', () => {
+    const line = buildKeepAlive();
+    expect(line).toBe(': keep-alive\n\n');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/stream-adapter.test.ts 2>&1 | tail -10
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement stream-adapter.ts**
+
+```typescript
+// src/channels/connectors/aisdk-http/stream-adapter.ts
+
+/**
+ * Serialise one AI SDK v5 data-stream protocol part.
+ * Format: `TYPE_CODE:JSON_VALUE\n`
+ */
+export function encodeStreamPart(type: string, value: unknown): string {
+  return `${type}:${JSON.stringify(value)}\n`;
+}
+
+/**
+ * Split `AgentOutput.body` (Markdown string) into word-level text-delta chunks.
+ * Each chunk is one encoded SSE line.
+ *
+ * When textChunkType is null, uses standard "0:" prefix.
+ * When textChunkType is set, uses that string as the prefix instead.
+ */
+export function buildTextChunks(body: string, textChunkType: string | null): string[] {
+  // Split on whitespace boundaries, preserving the delimiter attached to each token
+  const tokens = body.match(/\S+\s*/g) ?? [body];
+  return tokens.map((token) =>
+    textChunkType
+      ? `${textChunkType}:${JSON.stringify(token)}\n`
+      : encodeStreamPart('0', token),
+  );
+}
+
+/**
+ * Build the two finish chunks that close an AI SDK stream:
+ * 1. finish-step (`e`) — marks the end of a reasoning step
+ * 2. finish-message (`d`) — marks the end of the assistant message
+ */
+export function buildFinishChunks(): string[] {
+  const finishStep = encodeStreamPart('e', {
+    finishReason: 'stop',
+    usage: { promptTokens: 0, completionTokens: 0 },
+    isContinued: false,
+  });
+  const finishMessage = encodeStreamPart('d', {
+    finishReason: 'stop',
+    usage: { promptTokens: 0, completionTokens: 0 },
+  });
+  return [finishStep, finishMessage];
+}
+
+/**
+ * SSE comment line used as a keep-alive tick.
+ * Browsers and proxies treat SSE comment lines as no-ops but they reset the
+ * connection timeout timer.
+ */
+export function buildKeepAlive(): string {
+  return ': keep-alive\n\n';
+}
+
+/**
+ * Build the start-step chunk (`f`) that opens the stream.
+ */
+export function buildStartStep(messageId: string): string {
+  return encodeStreamPart('f', { messageId });
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/stream-adapter.test.ts 2>&1 | tail -10
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/stream-adapter.ts tests/unit/channels/aisdk-http/stream-adapter.test.ts
+git commit -m "feat(aisdk-http): stream adapter — AI SDK v5 data-stream SSE encoding"
+```
+
+---
+
+## Task 4: Artifact Mapper
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/artifact-mapper.ts`
+- Create: `tests/unit/channels/aisdk-http/artifact-mapper.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// tests/unit/channels/aisdk-http/artifact-mapper.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildArtifactChunks } from '../../../src/channels/connectors/aisdk-http/artifact-mapper.js';
+import type { ArtifactMapping } from '../../../src/channels/connectors/aisdk-http/aisdk-http-types.js';
+
+const mapping: ArtifactMapping[] = [
+  { toolName: 'assemble_experience_tree', chunkType: 'data-exo-output-artifact', wrapAs: 'jsonContent' },
+  { toolName: 'search_results', chunkType: 'data-search-results' },
+];
+
+describe('buildArtifactChunks', () => {
+  it('returns empty array when tool name is not in mapping', () => {
+    const chunks = buildArtifactChunks('unknown_tool', { foo: 'bar' }, mapping);
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('wraps result when wrapAs is set', () => {
+    const chunks = buildArtifactChunks('assemble_experience_tree', { tree: [] }, mapping);
+    expect(chunks).toHaveLength(1);
+    // Should be a data chunk (type "2") with the custom wrapper
+    expect(chunks[0]).toContain('"data-exo-output-artifact"');
+    expect(chunks[0]).toContain('"jsonContent"');
+    expect(chunks[0]).toContain('"tree"');
+  });
+
+  it('emits result as-is when wrapAs is absent', () => {
+    const chunks = buildArtifactChunks('search_results', [{ id: '1' }], mapping);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain('"data-search-results"');
+    expect(chunks[0]).toContain('"id"');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/artifact-mapper.test.ts 2>&1 | tail -10
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement artifact-mapper.ts**
+
+```typescript
+// src/channels/connectors/aisdk-http/artifact-mapper.ts
+import { encodeStreamPart } from './stream-adapter.js';
+import type { ArtifactMapping } from './aisdk-http-types.js';
+
+/**
+ * Given a tool name and its result, emit zero or more custom SSE data chunks
+ * based on the configured artifact mapping.
+ *
+ * Custom chunks are emitted as `2:[{type, ...data}]` lines — the AI SDK
+ * data-stream "data" part type. Frontends can listen for these via
+ * `useChat`'s `onData` callback or by inspecting `data` from the hook.
+ */
+export function buildArtifactChunks(
+  toolName: string,
+  result: unknown,
+  mapping: ArtifactMapping[],
+): string[] {
+  const entry = mapping.find((m) => m.toolName === toolName);
+  if (!entry) return [];
+
+  const payload = entry.wrapAs
+    ? { type: entry.chunkType, [entry.wrapAs]: result }
+    : { type: entry.chunkType, ...( typeof result === 'object' && result !== null ? result : { result }) };
+
+  return [encodeStreamPart('2', [payload])];
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/artifact-mapper.test.ts 2>&1 | tail -10
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/artifact-mapper.ts tests/unit/channels/aisdk-http/artifact-mapper.test.ts
+git commit -m "feat(aisdk-http): artifact mapper — tool results to custom SSE data chunks"
+```
+
+---
+
+## Task 5: Main Connector
+
+**Files:**
+- Create: `src/channels/connectors/aisdk-http/aisdk-http-connector.ts`
+
+- [ ] **Step 1: Write the connector**
+
+```typescript
+// src/channels/connectors/aisdk-http/aisdk-http-connector.ts
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import type pino from 'pino';
+import type { ChannelConnector, InboundEvent, AgentOutput } from '../../channel-types.js';
+import type { Result } from '../../../core/types/result.js';
+import { ok, err } from '../../../core/types/result.js';
+import { ChannelError } from '../../../core/errors/error-types.js';
+import { matchRoute } from './route-parser.js';
+import { buildTextChunks, buildFinishChunks, buildKeepAlive, buildStartStep } from './stream-adapter.js';
+import { buildArtifactChunks } from './artifact-mapper.js';
+import type { AisdkHttpChannelConfig, AisdkRequestBody, PendingStream } from './aisdk-http-types.js';
+import { AisdkHttpChannelConfigSchema } from './aisdk-http-types.js';
+
+// ---------------------------------------------------------------------------
+// AisdkHttpConnector
+// ---------------------------------------------------------------------------
+
+export class AisdkHttpConnector implements ChannelConnector {
+  readonly type = 'aisdk-http';
+  readonly name: string;
+
+  private config: AisdkHttpChannelConfig;
+  private handler?: (event: InboundEvent) => void | Promise<void>;
+  private running = false;
+  private httpServer?: ReturnType<typeof createServer>;
+  private idCounter = 0;
+
+  /**
+   * Map from externalThreadId to the open SSE response for that thread.
+   * Only one pending stream per thread is supported (last one wins).
+   */
+  private pendingStreams = new Map<string, PendingStream>();
+
+  constructor(
+    rawConfig: Record<string, unknown>,
+    channelName: string,
+    private readonly logger: pino.Logger,
+  ) {
+    this.name = channelName;
+    this.config = AisdkHttpChannelConfigSchema.parse(rawConfig);
+  }
+
+  // -------------------------------------------------------------------------
+  // ChannelConnector lifecycle
+  // -------------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    return new Promise((resolve, reject) => {
+      this.httpServer = createServer((req, res) => {
+        void this.handleRequest(req, res);
+      });
+
+      this.httpServer.on('error', (e) => {
+        this.running = false;
+        reject(e);
+      });
+
+      this.httpServer.listen(this.config.port, this.config.host, () => {
+        this.logger.info(
+          { channelName: this.name, port: this.config.port, host: this.config.host },
+          'aisdk-http: listening',
+        );
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return;
+    this.running = false;
+
+    // Close all open SSE streams
+    for (const [threadId, pending] of this.pendingStreams) {
+      clearInterval(pending.keepAliveInterval);
+      try { pending.res.end(); } catch { /* ignore */ }
+      this.pendingStreams.delete(threadId);
+    }
+
+    return new Promise((resolve) => {
+      if (this.httpServer) {
+        this.httpServer.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  onMessage(handler: (event: InboundEvent) => void | Promise<void>): void {
+    this.handler = handler;
+  }
+
+  /**
+   * Called by the daemon with the completed agent output.
+   * Flushes the response as AI SDK SSE chunks and closes the stream.
+   */
+  async send(externalThreadId: string, output: AgentOutput): Promise<Result<void, ChannelError>> {
+    const pending = this.pendingStreams.get(externalThreadId);
+    if (!pending) {
+      // Thread may have disconnected — not an error, just log and move on
+      this.logger.warn({ channelName: this.name, externalThreadId }, 'aisdk-http: no pending stream for thread');
+      return ok(undefined);
+    }
+
+    const { res } = pending;
+    clearInterval(pending.keepAliveInterval);
+    this.pendingStreams.delete(externalThreadId);
+
+    try {
+      // Start step
+      res.write(buildStartStep(randomUUID()));
+
+      // Text chunks (word-by-word streaming feel)
+      for (const chunk of buildTextChunks(output.body, this.config.textChunkType)) {
+        res.write(chunk);
+      }
+
+      // Finish
+      for (const chunk of buildFinishChunks()) {
+        res.write(chunk);
+      }
+
+      res.end();
+      return ok(undefined);
+    } catch (e) {
+      this.logger.error({ channelName: this.name, externalThreadId, err: e }, 'aisdk-http: send error');
+      return err(new ChannelError('send-failed', String(e)));
+    }
+  }
+
+  format(markdown: string): string {
+    return markdown; // No transformation needed — we emit raw Markdown
+  }
+
+  setSiblingBotIds(_ids: Set<string>): void {
+    // No bot-self-filtering concept for HTTP
+  }
+
+  // -------------------------------------------------------------------------
+  // HTTP request handling
+  // -------------------------------------------------------------------------
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // CORS preflight
+    this.setCorsHeaders(res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    // Only accept POST
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Method not allowed' }));
+      return;
+    }
+
+    // Match route
+    const url = req.url ?? '/';
+    const params = matchRoute(this.config.routePattern, url);
+    if (!params) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+      return;
+    }
+
+    // Resolve persona from agentId
+    const agentId = params['agentId'];
+    const personaName = agentId
+      ? (this.config.agentMapping[agentId] ?? agentId)
+      : this.config.defaultPersona ?? 'default';
+
+    // Parse request body
+    let body: AisdkRequestBody;
+    try {
+      body = await this.readBody(req);
+    } catch (e) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Invalid request body' }));
+      return;
+    }
+
+    // Determine thread ID (client-supplied or generate)
+    const externalThreadId = body.id ?? randomUUID();
+
+    // Extract headers to forward
+    const forwardedHeaders: Record<string, string> = {};
+    for (const header of this.config.forwardHeaders) {
+      const val = req.headers[header.toLowerCase()];
+      if (val) forwardedHeaders[header] = Array.isArray(val) ? val[0] ?? '' : val;
+    }
+    for (const [param, headerName] of Object.entries(this.config.forwardPathParams)) {
+      if (params[param]) forwardedHeaders[headerName] = params[param] ?? '';
+    }
+
+    // Build inbound event content from last user message
+    const lastUser = [...body.messages].reverse().find((m) => m.role === 'user');
+    const content = lastUser?.content ?? '';
+
+    // Open SSE stream immediately
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Thread-Id': externalThreadId,
+      'Access-Control-Expose-Headers': 'X-Thread-Id',
+    });
+
+    // Set up keep-alive
+    const keepAliveInterval = setInterval(() => {
+      try { res.write(buildKeepAlive()); } catch { /* client disconnected */ }
+    }, this.config.keepAliveIntervalMs);
+
+    // Store pending stream
+    const existing = this.pendingStreams.get(externalThreadId);
+    if (existing) {
+      clearInterval(existing.keepAliveInterval);
+      try { existing.res.end(); } catch { /* ignore */ }
+    }
+    this.pendingStreams.set(externalThreadId, { res, keepAliveInterval, forwardedHeaders });
+
+    // Handle client disconnect
+    req.on('close', () => {
+      const pending = this.pendingStreams.get(externalThreadId);
+      if (pending && pending.res === res) {
+        clearInterval(pending.keepAliveInterval);
+        this.pendingStreams.delete(externalThreadId);
+      }
+    });
+
+    // Fire inbound event
+    const idempotencyKey = `${externalThreadId}-${++this.idCounter}`;
+    const event: InboundEvent = {
+      channelType: this.type,
+      channelName: this.name,
+      externalThreadId,
+      senderId: externalThreadId, // No per-user identity in HTTP mode
+      idempotencyKey,
+      content,
+      timestamp: Date.now(),
+      raw: body,
+    };
+
+    if (this.handler) {
+      try {
+        await this.handler(event);
+      } catch (e) {
+        this.logger.error({ channelName: this.name, err: e }, 'aisdk-http: handler error');
+        clearInterval(keepAliveInterval);
+        this.pendingStreams.delete(externalThreadId);
+        try {
+          res.write(`:3:"Internal error"\n`);
+          res.end();
+        } catch { /* ignore */ }
+      }
+    }
+  }
+
+  private setCorsHeaders(res: ServerResponse): void {
+    // Allow configured origins (* by default)
+    const origins = this.config.cors.allowOrigins;
+    res.setHeader('Access-Control-Allow-Origin', origins.includes('*') ? '*' : origins[0] ?? '*');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  }
+
+  private readBody(req: IncomingMessage): Promise<AisdkRequestBody> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        try {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          resolve(JSON.parse(raw) as AisdkRequestBody);
+        } catch (e) {
+          reject(e);
+        }
+      });
+      req.on('error', reject);
+    });
+  }
+}
+```
+
+- [ ] **Step 2: Build and typecheck**
+
+```bash
+cd /home/talon/talon && npm run build 2>&1 | grep -E "error|Error" | head -20
+```
+Expected: 0 errors in the new files.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/channels/connectors/aisdk-http/aisdk-http-connector.ts
+git commit -m "feat(aisdk-http): main connector — HTTP server, SSE lifecycle, InboundEvent dispatch"
+```
+
+---
+
+## Task 6: Register in Channel Factory
+
+**Files:**
+- Modify: `src/daemon/channel-factory.ts`
+
+- [ ] **Step 1: Add the import and case**
+
+In `src/daemon/channel-factory.ts`, add the import after the existing terminal import:
+```typescript
+import { AisdkHttpConnector } from '../channels/connectors/aisdk-http/aisdk-http-connector.js';
+```
+
+In the `switch` block, add before `default`:
+```typescript
+    case 'aisdk-http':
+      return new AisdkHttpConnector(config, name, logger);
+```
+
+- [ ] **Step 2: Build — expect clean**
+
+```bash
+cd /home/talon/talon && npm run build 2>&1 | grep -E "^.*error" | head -10
+```
+Expected: 0 TypeScript errors.
+
+- [ ] **Step 3: Smoke test — start daemon with minimal aisdk-http config**
+
+Create a temporary test config at `/tmp/aisdk-test.yaml`:
+```yaml
+providers:
+  - type: claude
+    apiKey: "${ANTHROPIC_API_KEY}"
+
+personas:
+  - name: test-agent
+    provider: claude
+    model: claude-haiku-4-5
+    systemPrompt: "You are a test agent."
+
+channels:
+  - name: aisdk-test
+    type: aisdk-http
+    config:
+      port: 4199
+      routePattern: "/agents/:agentId/stream"
+
+bindings:
+  - channel: aisdk-test
+    persona: test-agent
+    isDefault: true
+```
+
+Start the daemon (ctrl-c after 5s to verify it starts without crashing):
+```bash
+cd /home/talon/talon && timeout 5 node dist/index.js --config /tmp/aisdk-test.yaml 2>&1 || true
+```
+Expected: logs show `aisdk-http: listening` on port 4199.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/daemon/channel-factory.ts
+git commit -m "feat(aisdk-http): register connector in channel factory"
+```
+
+---
+
+## Task 7: Update README and CLAUDE.md
+
+**Files:**
+- Modify: `README.md` (channel type list)
+- Modify: `CLAUDE.md` (source layout / architecture section)
+
+- [ ] **Step 1: Add aisdk-http to the channel list in README.md**
+
+Find the section in README.md that lists channel types (telegram, slack, discord, etc.) and add:
+```
+| `aisdk-http` | HTTP + SSE | Any Vercel AI SDK v5 frontend (`useChat`, `DefaultChatTransport`) |
+```
+
+- [ ] **Step 2: Add aisdk-http to CLAUDE.md architecture table**
+
+In CLAUDE.md, find the connectors line:
+```
+| Channels  | `src/channels/connectors/` | 7 adapters: telegram, slack, discord, whatsapp-business, whatsapp-baileys, email, terminal |
+```
+Update to:
+```
+| Channels  | `src/channels/connectors/` | 8 adapters: telegram, slack, discord, whatsapp-business, whatsapp-baileys, email, terminal, aisdk-http |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md CLAUDE.md
+git commit -m "docs: add aisdk-http channel to README and CLAUDE.md"
+```
+
+---
+
+## Task 8: Integration Test
+
+**Files:**
+- Create: `tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts`
+
+- [ ] **Step 1: Write integration tests**
+
+```typescript
+// tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AisdkHttpConnector } from '../../../../src/channels/connectors/aisdk-http/aisdk-http-connector.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+async function startConnector(config: Record<string, unknown>) {
+  const connector = new AisdkHttpConnector(config, 'test-aisdk', logger);
+  await connector.start();
+  return connector;
+}
+
+async function postMessage(port: number, body: object): Promise<Response> {
+  return fetch(`http://127.0.0.1:${port}/agents/test-agent/stream`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('AisdkHttpConnector', () => {
+  let connector: AisdkHttpConnector;
+
+  afterEach(async () => {
+    if (connector) await connector.stop();
+  });
+
+  it('starts and stops cleanly', async () => {
+    connector = await startConnector({ port: 4210 });
+    expect(connector.type).toBe('aisdk-http');
+    expect(connector.name).toBe('test-aisdk');
+  });
+
+  it('returns 404 for unknown routes', async () => {
+    connector = await startConnector({ port: 4211 });
+    const res = await fetch('http://127.0.0.1:4211/unknown/path', { method: 'POST', body: '{}', headers: { 'Content-Type': 'application/json' } });
+    expect(res.status).toBe(404);
+    await connector.stop();
+  });
+
+  it('returns 405 for non-POST requests', async () => {
+    connector = await startConnector({ port: 4212 });
+    const res = await fetch('http://127.0.0.1:4212/agents/test-agent/stream', { method: 'GET' });
+    expect(res.status).toBe(405);
+  });
+
+  it('fires onMessage handler with last user message content', async () => {
+    connector = await startConnector({ port: 4213 });
+    const received: string[] = [];
+    connector.onMessage((event) => { received.push(event.content); });
+
+    // Post but don't await the SSE stream — just trigger it
+    void postMessage(4213, {
+      messages: [{ role: 'user', content: 'Hello Talon' }],
+      id: 'thread-abc',
+    });
+
+    // Wait for handler to fire
+    await new Promise((r) => setTimeout(r, 100));
+    expect(received).toContain('Hello Talon');
+  });
+
+  it('send() writes text-delta chunks and closes stream', async () => {
+    connector = await startConnector({ port: 4214 });
+    connector.onMessage(() => {
+      // Simulate async agent response
+      setTimeout(() => {
+        void connector.send('thread-xyz', { body: 'Test response' });
+      }, 50);
+    });
+
+    const res = await postMessage(4214, {
+      messages: [{ role: 'user', content: 'ping' }],
+      id: 'thread-xyz',
+    });
+
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const body = await res.text();
+    expect(body).toContain('0:');          // text-delta chunks
+    expect(body).toContain('"stop"');      // finish
+    expect(res.headers.get('x-thread-id')).toBe('thread-xyz');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd /home/talon/talon && npx vitest run tests/unit/channels/aisdk-http/ 2>&1 | tail -20
+```
+Expected: all tests pass (route-parser, stream-adapter, artifact-mapper, connector integration).
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts
+git commit -m "test(aisdk-http): integration tests for connector lifecycle and HTTP/SSE"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ HTTP server with configurable port and host
+- ✅ Configurable route pattern with named params
+- ✅ AI SDK v5 data-stream SSE protocol (text-delta, finish-step, finish-message)
+- ✅ Keep-alive ticks
+- ✅ CORS (configurable origins)
+- ✅ Header forwarding (forwardHeaders, forwardPathParams)
+- ✅ Artifact mapping (custom data-* chunks for configured tool names)
+- ✅ textChunkType override
+- ✅ agentId → persona mapping with fallback
+- ✅ Config schema (Zod, registered in ChannelConfigSchema enum)
+- ✅ Channel factory registration
+- ✅ README + CLAUDE.md docs
+- ⚠️ **Not implemented:** Tool-result artifact chunks (requires agent runner to call a streaming hook per tool result — deferred to V2). V1 only streams the final `AgentOutput.body`.
+- ⚠️ **Not implemented:** Per-request MCP header injection. The connector stores `forwardedHeaders` in `PendingStream` but the daemon pipeline doesn't yet have a mechanism to pass per-request headers to MCP servers. This is a known gap from design doc open question, deferred to a follow-up.
+
+**Type consistency:** All types defined in `aisdk-http-types.ts` are imported consistently. `PendingStream.res` correctly typed as `ServerResponse`.

--- a/src/channels/connectors/aisdk-http/aisdk-http-connector.ts
+++ b/src/channels/connectors/aisdk-http/aisdk-http-connector.ts
@@ -2,8 +2,11 @@
  * AI SDK HTTP channel connector.
  *
  * Runs a lightweight HTTP server that speaks the Vercel AI SDK v5
- * data-stream SSE protocol. Any @ai-sdk/react frontend (useChat,
- * DefaultChatTransport) can connect to a Talon persona via this channel.
+ * UI Message Stream protocol (SSE). Any @ai-sdk/react frontend
+ * (useChat, DefaultChatTransport) can connect to a Talon persona
+ * via this channel.
+ *
+ * Protocol: https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol
  */
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
@@ -14,9 +17,12 @@ import type { Result } from '../../../core/types/result.js';
 import { ok, err } from '../../../core/types/result.js';
 import { ChannelError } from '../../../core/errors/error-types.js';
 import { matchRoute } from './route-parser.js';
-import { buildTextChunks, buildFinishChunks, buildKeepAlive, buildStartStep } from './stream-adapter.js';
+import { buildStart, buildStartStep, buildTextChunks, buildFinishChunks, buildDone, buildKeepAlive, encodeSSE } from './stream-adapter.js';
 import type { AisdkHttpChannelConfig, AisdkRequestBody, PendingStream } from './aisdk-http-types.js';
 import { AisdkHttpChannelConfigSchema } from './aisdk-http-types.js';
+
+/** Maximum request body size (1 MB). */
+const MAX_BODY_BYTES = 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // AisdkHttpConnector
@@ -100,7 +106,7 @@ export class AisdkHttpConnector implements ChannelConnector {
 
   /**
    * Called by the daemon with the completed agent output.
-   * Flushes the response as AI SDK SSE chunks and closes the stream.
+   * Flushes the response as AI SDK v5 SSE chunks and closes the stream.
    */
   async send(externalThreadId: string, output: AgentOutput): Promise<Result<void, ChannelError>> {
     const pending = this.pendingStreams.get(externalThreadId);
@@ -109,23 +115,27 @@ export class AisdkHttpConnector implements ChannelConnector {
       return ok(undefined);
     }
 
-    const { res } = pending;
+    const { res, messageId } = pending;
     clearInterval(pending.keepAliveInterval);
     this.pendingStreams.delete(externalThreadId);
 
     try {
-      // Start step
-      res.write(buildStartStep(randomUUID()));
+      // Stream start + step start
+      res.write(buildStart(messageId));
+      res.write(buildStartStep());
 
       // Text chunks (word-by-word streaming feel)
-      for (const chunk of buildTextChunks(output.body, this.config.textChunkType)) {
+      for (const chunk of buildTextChunks(output.body, this.config.textChunkType, messageId)) {
         res.write(chunk);
       }
 
-      // Finish
+      // Finish step + message
       for (const chunk of buildFinishChunks()) {
         res.write(chunk);
       }
+
+      // Required v5 stream terminator
+      res.write(buildDone());
 
       res.end();
       return ok(undefined);
@@ -171,25 +181,21 @@ export class AisdkHttpConnector implements ChannelConnector {
       return;
     }
 
-    // Resolve persona from agentId
-    const agentId = params['agentId'];
-    // TODO: forward to pipeline once persona routing from channel is supported
-    const _personaName = agentId
-      ? (this.config.agentMapping[agentId] ?? agentId)
-      : this.config.defaultPersona ?? 'default';
-
     // Parse request body
     let body: AisdkRequestBody;
     try {
       body = await this.readBody(req);
-    } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid request body' }));
+    } catch (e) {
+      const status = e instanceof BodyTooLargeError ? 413 : 400;
+      const message = e instanceof BodyTooLargeError ? 'Request body too large' : 'Invalid request body';
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: message }));
       return;
     }
 
     // Determine thread ID (client-supplied or generate)
     const externalThreadId = body.id ?? randomUUID();
+    const messageId = randomUUID();
 
     // Extract headers to forward
     const forwardedHeaders: Record<string, string> = {};
@@ -201,9 +207,8 @@ export class AisdkHttpConnector implements ChannelConnector {
       if (params[param]) forwardedHeaders[headerName] = params[param] ?? '';
     }
 
-    // Build inbound event content from last user message
-    const lastUser = [...body.messages].reverse().find((m) => m.role === 'user');
-    const content = lastUser?.content ?? '';
+    // Extract text content from last user message (supports both v4 and v5 formats)
+    const content = this.extractUserContent(body);
 
     // Open SSE stream immediately
     res.writeHead(200, {
@@ -211,7 +216,8 @@ export class AisdkHttpConnector implements ChannelConnector {
       'Cache-Control': 'no-cache',
       'Connection': 'keep-alive',
       'X-Thread-Id': externalThreadId,
-      'Access-Control-Expose-Headers': 'X-Thread-Id',
+      'X-Vercel-AI-UI-Message-Stream': 'v1',
+      'Access-Control-Expose-Headers': 'X-Thread-Id, X-Vercel-AI-UI-Message-Stream',
     });
 
     // Set up keep-alive
@@ -225,7 +231,7 @@ export class AisdkHttpConnector implements ChannelConnector {
       clearInterval(existing.keepAliveInterval);
       try { existing.res.end(); } catch { /* ignore */ }
     }
-    this.pendingStreams.set(externalThreadId, { res, keepAliveInterval, forwardedHeaders });
+    this.pendingStreams.set(externalThreadId, { res, keepAliveInterval, forwardedHeaders, messageId });
 
     // Handle client disconnect
     req.on('close', () => {
@@ -257,11 +263,35 @@ export class AisdkHttpConnector implements ChannelConnector {
         clearInterval(keepAliveInterval);
         this.pendingStreams.delete(externalThreadId);
         try {
-          res.write(`3:"Internal error"\n`);
+          res.write(encodeSSE({ type: 'error', errorText: 'Internal error' }));
+          res.write(buildDone());
           res.end();
         } catch { /* ignore */ }
       }
     }
+  }
+
+  /**
+   * Extract plain text content from the last user message.
+   * Supports both v4 format ({ role, content: string }) and v5 format
+   * ({ role, parts: [{ type: 'text', text: '...' }, ...] }).
+   */
+  private extractUserContent(body: AisdkRequestBody): string {
+    const lastUser = [...body.messages].reverse().find((m) => m.role === 'user');
+    if (!lastUser) return '';
+
+    // V4: content is a plain string
+    if (typeof lastUser.content === 'string') return lastUser.content;
+
+    // V5: parts array with typed content blocks
+    if ('parts' in lastUser && Array.isArray(lastUser.parts)) {
+      return lastUser.parts
+        .filter((p) => p.type === 'text')
+        .map((p) => p.text ?? '')
+        .join('');
+    }
+
+    return '';
   }
 
   /**
@@ -288,7 +318,16 @@ export class AisdkHttpConnector implements ChannelConnector {
   private readBody(req: IncomingMessage): Promise<AisdkRequestBody> {
     return new Promise((resolve, reject) => {
       const chunks: Buffer[] = [];
-      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      let totalBytes = 0;
+      req.on('data', (chunk: Buffer) => {
+        totalBytes += chunk.length;
+        if (totalBytes > MAX_BODY_BYTES) {
+          req.destroy();
+          reject(new BodyTooLargeError());
+          return;
+        }
+        chunks.push(chunk);
+      });
       req.on('end', () => {
         try {
           const raw = Buffer.concat(chunks).toString('utf8');
@@ -299,5 +338,12 @@ export class AisdkHttpConnector implements ChannelConnector {
       });
       req.on('error', reject);
     });
+  }
+}
+
+class BodyTooLargeError extends Error {
+  constructor() {
+    super('Request body exceeds maximum size');
+    this.name = 'BodyTooLargeError';
   }
 }

--- a/src/channels/connectors/aisdk-http/aisdk-http-connector.ts
+++ b/src/channels/connectors/aisdk-http/aisdk-http-connector.ts
@@ -1,0 +1,303 @@
+/**
+ * AI SDK HTTP channel connector.
+ *
+ * Runs a lightweight HTTP server that speaks the Vercel AI SDK v5
+ * data-stream SSE protocol. Any @ai-sdk/react frontend (useChat,
+ * DefaultChatTransport) can connect to a Talon persona via this channel.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import type pino from 'pino';
+import type { ChannelConnector, InboundEvent, AgentOutput } from '../../channel-types.js';
+import type { Result } from '../../../core/types/result.js';
+import { ok, err } from '../../../core/types/result.js';
+import { ChannelError } from '../../../core/errors/error-types.js';
+import { matchRoute } from './route-parser.js';
+import { buildTextChunks, buildFinishChunks, buildKeepAlive, buildStartStep } from './stream-adapter.js';
+import type { AisdkHttpChannelConfig, AisdkRequestBody, PendingStream } from './aisdk-http-types.js';
+import { AisdkHttpChannelConfigSchema } from './aisdk-http-types.js';
+
+// ---------------------------------------------------------------------------
+// AisdkHttpConnector
+// ---------------------------------------------------------------------------
+
+export class AisdkHttpConnector implements ChannelConnector {
+  readonly type = 'aisdk-http';
+  readonly name: string;
+
+  private config: AisdkHttpChannelConfig;
+  private handler?: (event: InboundEvent) => void | Promise<void>;
+  private running = false;
+  private httpServer?: ReturnType<typeof createServer>;
+  private idCounter = 0;
+
+  /**
+   * Map from externalThreadId to the open SSE response for that thread.
+   * Only one pending stream per thread is supported (last one wins).
+   */
+  private pendingStreams = new Map<string, PendingStream>();
+
+  constructor(
+    rawConfig: Record<string, unknown>,
+    channelName: string,
+    private readonly logger: pino.Logger,
+  ) {
+    this.name = channelName;
+    this.config = AisdkHttpChannelConfigSchema.parse(rawConfig);
+  }
+
+  // -------------------------------------------------------------------------
+  // ChannelConnector lifecycle
+  // -------------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    return new Promise((resolve, reject) => {
+      this.httpServer = createServer((req, res) => {
+        void this.handleRequest(req, res);
+      });
+
+      this.httpServer.on('error', (e) => {
+        this.running = false;
+        reject(e);
+      });
+
+      this.httpServer.listen(this.config.port, this.config.host, () => {
+        this.logger.info(
+          { channelName: this.name, port: this.config.port, host: this.config.host },
+          'aisdk-http: listening',
+        );
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return;
+    this.running = false;
+
+    for (const [threadId, pending] of this.pendingStreams) {
+      clearInterval(pending.keepAliveInterval);
+      try { pending.res.end(); } catch { /* client already disconnected */ }
+      this.pendingStreams.delete(threadId);
+    }
+
+    return new Promise((resolve) => {
+      if (this.httpServer) {
+        this.httpServer.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  onMessage(handler: (event: InboundEvent) => void | Promise<void>): void {
+    this.handler = handler;
+  }
+
+  /**
+   * Called by the daemon with the completed agent output.
+   * Flushes the response as AI SDK SSE chunks and closes the stream.
+   */
+  async send(externalThreadId: string, output: AgentOutput): Promise<Result<void, ChannelError>> {
+    const pending = this.pendingStreams.get(externalThreadId);
+    if (!pending) {
+      this.logger.warn({ channelName: this.name, externalThreadId }, 'aisdk-http: no pending stream for thread');
+      return ok(undefined);
+    }
+
+    const { res } = pending;
+    clearInterval(pending.keepAliveInterval);
+    this.pendingStreams.delete(externalThreadId);
+
+    try {
+      // Start step
+      res.write(buildStartStep(randomUUID()));
+
+      // Text chunks (word-by-word streaming feel)
+      for (const chunk of buildTextChunks(output.body, this.config.textChunkType)) {
+        res.write(chunk);
+      }
+
+      // Finish
+      for (const chunk of buildFinishChunks()) {
+        res.write(chunk);
+      }
+
+      res.end();
+      return ok(undefined);
+    } catch (e) {
+      this.logger.error({ channelName: this.name, externalThreadId, err: e }, 'aisdk-http: send error');
+      return err(new ChannelError(`aisdk-http send failed: ${String(e)}`));
+    }
+  }
+
+  format(markdown: string): string {
+    return markdown;
+  }
+
+  setSiblingBotIds(_ids: Set<string>): void {
+    // No bot-self-filtering concept for HTTP
+  }
+
+  // -------------------------------------------------------------------------
+  // HTTP request handling
+  // -------------------------------------------------------------------------
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // CORS preflight
+    this.setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Method not allowed' }));
+      return;
+    }
+
+    // Match route
+    const url = req.url ?? '/';
+    const params = matchRoute(this.config.routePattern, url);
+    if (!params) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+      return;
+    }
+
+    // Resolve persona from agentId
+    const agentId = params['agentId'];
+    // TODO: forward to pipeline once persona routing from channel is supported
+    const _personaName = agentId
+      ? (this.config.agentMapping[agentId] ?? agentId)
+      : this.config.defaultPersona ?? 'default';
+
+    // Parse request body
+    let body: AisdkRequestBody;
+    try {
+      body = await this.readBody(req);
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Invalid request body' }));
+      return;
+    }
+
+    // Determine thread ID (client-supplied or generate)
+    const externalThreadId = body.id ?? randomUUID();
+
+    // Extract headers to forward
+    const forwardedHeaders: Record<string, string> = {};
+    for (const header of this.config.forwardHeaders) {
+      const val = req.headers[header.toLowerCase()];
+      if (val) forwardedHeaders[header] = Array.isArray(val) ? val[0] ?? '' : val;
+    }
+    for (const [param, headerName] of Object.entries(this.config.forwardPathParams)) {
+      if (params[param]) forwardedHeaders[headerName] = params[param] ?? '';
+    }
+
+    // Build inbound event content from last user message
+    const lastUser = [...body.messages].reverse().find((m) => m.role === 'user');
+    const content = lastUser?.content ?? '';
+
+    // Open SSE stream immediately
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Thread-Id': externalThreadId,
+      'Access-Control-Expose-Headers': 'X-Thread-Id',
+    });
+
+    // Set up keep-alive
+    const keepAliveInterval = setInterval(() => {
+      try { res.write(buildKeepAlive()); } catch { /* client disconnected */ }
+    }, this.config.keepAliveIntervalMs);
+
+    // Store pending stream (last one wins if duplicate threadId)
+    const existing = this.pendingStreams.get(externalThreadId);
+    if (existing) {
+      clearInterval(existing.keepAliveInterval);
+      try { existing.res.end(); } catch { /* ignore */ }
+    }
+    this.pendingStreams.set(externalThreadId, { res, keepAliveInterval, forwardedHeaders });
+
+    // Handle client disconnect
+    req.on('close', () => {
+      const pending = this.pendingStreams.get(externalThreadId);
+      if (pending && pending.res === res) {
+        clearInterval(pending.keepAliveInterval);
+        this.pendingStreams.delete(externalThreadId);
+      }
+    });
+
+    // Fire inbound event
+    const idempotencyKey = `${externalThreadId}-${++this.idCounter}`;
+    const event: InboundEvent = {
+      channelType: this.type,
+      channelName: this.name,
+      externalThreadId,
+      senderId: externalThreadId,
+      idempotencyKey,
+      content,
+      timestamp: Date.now(),
+      raw: body,
+    };
+
+    if (this.handler) {
+      try {
+        await this.handler(event);
+      } catch (e) {
+        this.logger.error({ channelName: this.name, err: e }, 'aisdk-http: handler error');
+        clearInterval(keepAliveInterval);
+        this.pendingStreams.delete(externalThreadId);
+        try {
+          res.write(`3:"Internal error"\n`);
+          res.end();
+        } catch { /* ignore */ }
+      }
+    }
+  }
+
+  /**
+   * Set CORS headers, checking the request origin against allowed origins.
+   * Supports wildcard ('*') and exact-match origins.
+   */
+  private setCorsHeaders(req: IncomingMessage, res: ServerResponse): void {
+    const origins = this.config.cors.allowOrigins;
+
+    if (origins.includes('*')) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+    } else {
+      const requestOrigin = req.headers.origin;
+      if (requestOrigin && origins.includes(requestOrigin)) {
+        res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+        res.setHeader('Vary', 'Origin');
+      }
+    }
+
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  }
+
+  private readBody(req: IncomingMessage): Promise<AisdkRequestBody> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        try {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          resolve(JSON.parse(raw) as AisdkRequestBody);
+        } catch (e) {
+          reject(e);
+        }
+      });
+      req.on('error', reject);
+    });
+  }
+}

--- a/src/channels/connectors/aisdk-http/aisdk-http-types.ts
+++ b/src/channels/connectors/aisdk-http/aisdk-http-types.ts
@@ -1,7 +1,7 @@
 /**
  * Types and Zod schemas for the aisdk-http channel connector.
  *
- * Defines the config shape, AI SDK v5 data-stream wire types, and internal
+ * Defines the config shape, AI SDK v5 UI Message Stream types, and internal
  * structures for managing pending SSE streams.
  */
 
@@ -14,7 +14,7 @@ import { z } from 'zod';
 export const ArtifactMappingSchema = z.object({
   /** Tool name whose result should emit a custom data chunk. */
   toolName: z.string(),
-  /** SSE data chunk type prefix, e.g. "data-exo-output-artifact". */
+  /** SSE data chunk type, e.g. "data-exo-output-artifact". */
   chunkType: z.string(),
   /**
    * Optional wrapper key. When set, result is emitted as { [wrapAs]: result }.
@@ -29,7 +29,6 @@ export const AisdkHttpChannelConfigSchema = z.object({
   /**
    * Express-style route pattern with named params (e.g. "/agents/:agentId/stream"
    * or "/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream").
-   * The :agentId param maps to a persona name.
    */
   routePattern: z.string().default('/agents/:agentId/stream'),
   /** CORS allowed origins. Glob patterns supported. */
@@ -43,7 +42,7 @@ export const AisdkHttpChannelConfigSchema = z.object({
   artifactMapping: z.array(ArtifactMappingSchema).default([]),
   /**
    * Override the SSE chunk type used for text output.
-   * null = use standard "0:" text-delta chunks (default, works with any useChat frontend).
+   * null = use standard text-start/text-delta/text-end (default).
    * Set to e.g. "data-human-readable" for custom frontend handling.
    */
   textChunkType: z.string().nullable().default(null),
@@ -57,13 +56,6 @@ export const AisdkHttpChannelConfigSchema = z.object({
    * E.g. { spaceId: "X-Space-Id" } extracts :spaceId from the URL and sends it as a header.
    */
   forwardPathParams: z.record(z.string(), z.string()).default({}),
-  /**
-   * Explicit agentId -> persona name mapping.
-   * If absent, agentId is used directly as the persona name.
-   */
-  agentMapping: z.record(z.string(), z.string()).default({}),
-  /** Fallback persona when agentId doesn't match any mapping. */
-  defaultPersona: z.string().optional(),
   /** Keep-alive SSE tick interval while agent is running (ms). Min 1000. */
   keepAliveIntervalMs: z.number().int().min(1000).max(60000).default(5000),
   /** Host to bind to. Defaults to 127.0.0.1. */
@@ -74,38 +66,33 @@ export type AisdkHttpChannelConfig = z.infer<typeof AisdkHttpChannelConfigSchema
 export type ArtifactMapping = z.infer<typeof ArtifactMappingSchema>;
 
 // ---------------------------------------------------------------------------
-// AI SDK v5 data-stream wire types
-// ---------------------------------------------------------------------------
-
-/** AI SDK data-stream protocol chunk types (numeric codes). */
-export const StreamPartType = {
-  TEXT_DELTA: '0',
-  DATA: '2',
-  ERROR: '3',
-  TOOL_CALL: '9',
-  TOOL_RESULT: 'a',
-  TOOL_CALL_STREAMING_START: 'b',
-  TOOL_CALL_DELTA: 'c',
-  FINISH_MESSAGE: 'd',
-  FINISH_STEP: 'e',
-  START_STEP: 'f',
-} as const;
-
-/** Represents one line in the AI SDK data-stream SSE body. */
-export interface StreamPart {
-  type: string;   // one of StreamPartType values
-  value: unknown; // serialised as JSON after the type prefix
-}
-
-// ---------------------------------------------------------------------------
 // AI SDK request body (what useChat POSTs)
 // ---------------------------------------------------------------------------
 
-export interface AisdkMessage {
+/** V4 message format: content is a plain string. */
+interface AisdkMessageV4 {
   role: 'user' | 'assistant' | 'system' | 'tool';
   content: string;
   id?: string;
 }
+
+/** A single part within a v5 UIMessage. */
+export interface AisdkMessagePart {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+/** V5 UIMessage format: content may be parts array. */
+interface AisdkMessageV5 {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content?: string;
+  parts?: AisdkMessagePart[];
+  id?: string;
+}
+
+/** Union of v4 and v5 message formats. */
+export type AisdkMessage = AisdkMessageV4 | AisdkMessageV5;
 
 export interface AisdkRequestBody {
   /** Conversation messages. Last user message is the new input. */
@@ -127,4 +114,6 @@ export interface PendingStream {
   keepAliveInterval: ReturnType<typeof setInterval>;
   /** Headers extracted from the original request (for MCP forwarding). */
   forwardedHeaders: Record<string, string>;
+  /** Generated message ID for this stream (used in v5 text chunks). */
+  messageId: string;
 }

--- a/src/channels/connectors/aisdk-http/aisdk-http-types.ts
+++ b/src/channels/connectors/aisdk-http/aisdk-http-types.ts
@@ -1,0 +1,130 @@
+/**
+ * Types and Zod schemas for the aisdk-http channel connector.
+ *
+ * Defines the config shape, AI SDK v5 data-stream wire types, and internal
+ * structures for managing pending SSE streams.
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Config schema (registered in config-schema.ts)
+// ---------------------------------------------------------------------------
+
+export const ArtifactMappingSchema = z.object({
+  /** Tool name whose result should emit a custom data chunk. */
+  toolName: z.string(),
+  /** SSE data chunk type prefix, e.g. "data-exo-output-artifact". */
+  chunkType: z.string(),
+  /**
+   * Optional wrapper key. When set, result is emitted as { [wrapAs]: result }.
+   * When omitted, result is emitted as-is.
+   */
+  wrapAs: z.string().optional(),
+});
+
+export const AisdkHttpChannelConfigSchema = z.object({
+  /** TCP port to listen on. */
+  port: z.number().int().min(1).max(65535),
+  /**
+   * Express-style route pattern with named params (e.g. "/agents/:agentId/stream"
+   * or "/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream").
+   * The :agentId param maps to a persona name.
+   */
+  routePattern: z.string().default('/agents/:agentId/stream'),
+  /** CORS allowed origins. Glob patterns supported. */
+  cors: z.object({
+    allowOrigins: z.array(z.string()).default(['*']),
+  }).default(() => ({ allowOrigins: ['*'] })),
+  /**
+   * Map specific tool result names to custom SSE data chunks.
+   * Each matched tool result also emits its normal tool-result chunk.
+   */
+  artifactMapping: z.array(ArtifactMappingSchema).default([]),
+  /**
+   * Override the SSE chunk type used for text output.
+   * null = use standard "0:" text-delta chunks (default, works with any useChat frontend).
+   * Set to e.g. "data-human-readable" for custom frontend handling.
+   */
+  textChunkType: z.string().nullable().default(null),
+  /**
+   * HTTP request headers to forward to MCP servers.
+   * E.g. ["Authorization"] passes the Bearer token through.
+   */
+  forwardHeaders: z.array(z.string()).default([]),
+  /**
+   * Map route path params to header names forwarded to MCP servers.
+   * E.g. { spaceId: "X-Space-Id" } extracts :spaceId from the URL and sends it as a header.
+   */
+  forwardPathParams: z.record(z.string(), z.string()).default({}),
+  /**
+   * Explicit agentId -> persona name mapping.
+   * If absent, agentId is used directly as the persona name.
+   */
+  agentMapping: z.record(z.string(), z.string()).default({}),
+  /** Fallback persona when agentId doesn't match any mapping. */
+  defaultPersona: z.string().optional(),
+  /** Keep-alive SSE tick interval while agent is running (ms). Min 1000. */
+  keepAliveIntervalMs: z.number().int().min(1000).max(60000).default(5000),
+  /** Host to bind to. Defaults to 127.0.0.1. */
+  host: z.string().default('127.0.0.1'),
+});
+
+export type AisdkHttpChannelConfig = z.infer<typeof AisdkHttpChannelConfigSchema>;
+export type ArtifactMapping = z.infer<typeof ArtifactMappingSchema>;
+
+// ---------------------------------------------------------------------------
+// AI SDK v5 data-stream wire types
+// ---------------------------------------------------------------------------
+
+/** AI SDK data-stream protocol chunk types (numeric codes). */
+export const StreamPartType = {
+  TEXT_DELTA: '0',
+  DATA: '2',
+  ERROR: '3',
+  TOOL_CALL: '9',
+  TOOL_RESULT: 'a',
+  TOOL_CALL_STREAMING_START: 'b',
+  TOOL_CALL_DELTA: 'c',
+  FINISH_MESSAGE: 'd',
+  FINISH_STEP: 'e',
+  START_STEP: 'f',
+} as const;
+
+/** Represents one line in the AI SDK data-stream SSE body. */
+export interface StreamPart {
+  type: string;   // one of StreamPartType values
+  value: unknown; // serialised as JSON after the type prefix
+}
+
+// ---------------------------------------------------------------------------
+// AI SDK request body (what useChat POSTs)
+// ---------------------------------------------------------------------------
+
+export interface AisdkMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string;
+  id?: string;
+}
+
+export interface AisdkRequestBody {
+  /** Conversation messages. Last user message is the new input. */
+  messages: AisdkMessage[];
+  /** Client-generated thread ID. Used as Talon externalThreadId. */
+  id?: string;
+  /** Opaque metadata forwarded to the persona context. */
+  metadata?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: pending SSE stream entry
+// ---------------------------------------------------------------------------
+
+export interface PendingStream {
+  /** Node.js ServerResponse (kept open for SSE). */
+  res: import('node:http').ServerResponse;
+  /** Interval handle for keep-alive ticks. */
+  keepAliveInterval: ReturnType<typeof setInterval>;
+  /** Headers extracted from the original request (for MCP forwarding). */
+  forwardedHeaders: Record<string, string>;
+}

--- a/src/channels/connectors/aisdk-http/artifact-mapper.ts
+++ b/src/channels/connectors/aisdk-http/artifact-mapper.ts
@@ -1,0 +1,32 @@
+/**
+ * Artifact mapper for the aisdk-http channel.
+ *
+ * Maps tool results to custom AI SDK data-stream chunks based on
+ * the configured artifact mapping. Frontends can listen for these
+ * via `useChat`'s `onData` callback.
+ */
+
+import { encodeStreamPart } from './stream-adapter.js';
+import type { ArtifactMapping } from './aisdk-http-types.js';
+
+/**
+ * Given a tool name and its result, emit zero or more custom SSE data chunks
+ * based on the configured artifact mapping.
+ *
+ * Custom chunks are emitted as `2:[{type, ...data}]` lines — the AI SDK
+ * data-stream "data" part type.
+ */
+export function buildArtifactChunks(
+  toolName: string,
+  result: unknown,
+  mapping: ArtifactMapping[],
+): string[] {
+  const entry = mapping.find((m) => m.toolName === toolName);
+  if (!entry) return [];
+
+  const payload = entry.wrapAs
+    ? { type: entry.chunkType, [entry.wrapAs]: result }
+    : { type: entry.chunkType, ...(typeof result === 'object' && result !== null ? result : { result }) };
+
+  return [encodeStreamPart('2', [payload])];
+}

--- a/src/channels/connectors/aisdk-http/artifact-mapper.ts
+++ b/src/channels/connectors/aisdk-http/artifact-mapper.ts
@@ -1,20 +1,17 @@
 /**
  * Artifact mapper for the aisdk-http channel.
  *
- * Maps tool results to custom AI SDK data-stream chunks based on
- * the configured artifact mapping. Frontends can listen for these
- * via `useChat`'s `onData` callback.
+ * Maps tool results to custom AI SDK v5 data chunks based on
+ * the configured artifact mapping. In v5, custom data is emitted
+ * as SSE frames with a custom `type` field.
  */
 
-import { encodeStreamPart } from './stream-adapter.js';
+import { encodeSSE } from './stream-adapter.js';
 import type { ArtifactMapping } from './aisdk-http-types.js';
 
 /**
- * Given a tool name and its result, emit zero or more custom SSE data chunks
+ * Given a tool name and its result, emit zero or more custom SSE data frames
  * based on the configured artifact mapping.
- *
- * Custom chunks are emitted as `2:[{type, ...data}]` lines — the AI SDK
- * data-stream "data" part type.
  */
 export function buildArtifactChunks(
   toolName: string,
@@ -28,5 +25,5 @@ export function buildArtifactChunks(
     ? { type: entry.chunkType, [entry.wrapAs]: result }
     : { type: entry.chunkType, ...(typeof result === 'object' && result !== null ? result : { result }) };
 
-  return [encodeStreamPart('2', [payload])];
+  return [encodeSSE(payload)];
 }

--- a/src/channels/connectors/aisdk-http/route-parser.ts
+++ b/src/channels/connectors/aisdk-http/route-parser.ts
@@ -1,0 +1,46 @@
+/**
+ * Express-style route pattern parser for the aisdk-http channel.
+ *
+ * Converts patterns like "/agents/:agentId/stream" to a regex that captures
+ * named path parameters.
+ */
+
+interface ParsedRoute {
+  regex: RegExp;
+  paramNames: string[];
+}
+
+/**
+ * Pre-compile an Express-style route pattern to a regex + param name list.
+ * Segments like :paramName are captured as groups.
+ */
+export function parseRoute(pattern: string): ParsedRoute {
+  const paramNames: string[] = [];
+  const regexStr = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, (_match, name: string) => {
+      paramNames.push(name);
+      return '([^/]+)';
+    });
+  const regex = new RegExp(`^${regexStr}$`);
+  return { regex, paramNames };
+}
+
+/**
+ * Match a URL pathname against a route pattern.
+ * Returns extracted param values, or null if no match.
+ */
+export function matchRoute(
+  pattern: string,
+  url: string,
+): Record<string, string> | null {
+  const pathname = url.split('?')[0] ?? url;
+  const { regex, paramNames } = parseRoute(pattern);
+  const match = regex.exec(pathname);
+  if (!match) return null;
+  const params: Record<string, string> = {};
+  paramNames.forEach((name, i) => {
+    params[name] = match[i + 1] ?? '';
+  });
+  return params;
+}

--- a/src/channels/connectors/aisdk-http/stream-adapter.ts
+++ b/src/channels/connectors/aisdk-http/stream-adapter.ts
@@ -1,0 +1,63 @@
+/**
+ * AI SDK v5 data-stream SSE encoding utilities.
+ *
+ * Each function produces one or more encoded SSE lines in the format:
+ * `TYPE_CODE:JSON_VALUE\n`
+ */
+
+/**
+ * Serialise one AI SDK v5 data-stream protocol part.
+ * Format: `TYPE_CODE:JSON_VALUE\n`
+ */
+export function encodeStreamPart(type: string, value: unknown): string {
+  return `${type}:${JSON.stringify(value)}\n`;
+}
+
+/**
+ * Split agent body text into word-level text-delta chunks.
+ *
+ * When textChunkType is null, uses standard "0:" prefix.
+ * When textChunkType is set, uses that string as the prefix instead.
+ */
+export function buildTextChunks(body: string, textChunkType: string | null): string[] {
+  const tokens = body.match(/\S+\s*/g) ?? [body];
+  return tokens.map((token) =>
+    textChunkType
+      ? `${textChunkType}:${JSON.stringify(token)}\n`
+      : encodeStreamPart('0', token),
+  );
+}
+
+/**
+ * Build the two finish chunks that close an AI SDK stream:
+ * 1. finish-step (`e`) — marks the end of a reasoning step
+ * 2. finish-message (`d`) — marks the end of the assistant message
+ */
+export function buildFinishChunks(): string[] {
+  const finishStep = encodeStreamPart('e', {
+    finishReason: 'stop',
+    usage: { promptTokens: 0, completionTokens: 0 },
+    isContinued: false,
+  });
+  const finishMessage = encodeStreamPart('d', {
+    finishReason: 'stop',
+    usage: { promptTokens: 0, completionTokens: 0 },
+  });
+  return [finishStep, finishMessage];
+}
+
+/**
+ * SSE comment line used as a keep-alive tick.
+ * Browsers and proxies treat comment lines as no-ops but they reset
+ * connection timeout timers.
+ */
+export function buildKeepAlive(): string {
+  return ': keep-alive\n\n';
+}
+
+/**
+ * Build the start-step chunk (`f`) that opens the stream.
+ */
+export function buildStartStep(messageId: string): string {
+  return encodeStreamPart('f', { messageId });
+}

--- a/src/channels/connectors/aisdk-http/stream-adapter.ts
+++ b/src/channels/connectors/aisdk-http/stream-adapter.ts
@@ -1,63 +1,83 @@
 /**
- * AI SDK v5 data-stream SSE encoding utilities.
+ * AI SDK v5 UI Message Stream encoding utilities.
  *
- * Each function produces one or more encoded SSE lines in the format:
- * `TYPE_CODE:JSON_VALUE\n`
+ * V5 uses standard SSE format: `data: JSON\n\n`
+ * Each chunk is a JSON object with a `type` field.
+ *
+ * Protocol reference: https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol
  */
 
 /**
- * Serialise one AI SDK v5 data-stream protocol part.
- * Format: `TYPE_CODE:JSON_VALUE\n`
+ * Encode a single SSE data frame in AI SDK v5 format.
  */
-export function encodeStreamPart(type: string, value: unknown): string {
-  return `${type}:${JSON.stringify(value)}\n`;
+export function encodeSSE(value: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(value)}\n\n`;
 }
 
 /**
- * Split agent body text into word-level text-delta chunks.
- *
- * When textChunkType is null, uses standard "0:" prefix.
- * When textChunkType is set, uses that string as the prefix instead.
+ * Build the stream start chunk.
  */
-export function buildTextChunks(body: string, textChunkType: string | null): string[] {
+export function buildStart(messageId: string): string {
+  return encodeSSE({ type: 'start', messageId });
+}
+
+/**
+ * Build the start-step chunk.
+ */
+export function buildStartStep(): string {
+  return encodeSSE({ type: 'start-step' });
+}
+
+/**
+ * Split agent body text into v5 text-start / text-delta / text-end chunks.
+ * Each chunk is one SSE data frame.
+ *
+ * When textChunkType is null, uses standard text-delta type.
+ * When textChunkType is set, emits a custom data chunk instead (e.g. "data-human-readable").
+ */
+export function buildTextChunks(body: string, textChunkType: string | null, messageId: string): string[] {
+  if (textChunkType) {
+    // Custom chunk type — emit as single data frame
+    return [encodeSSE({ type: textChunkType, data: body })];
+  }
+
+  // Standard v5 text streaming: start → deltas → end
+  const chunks: string[] = [];
+  chunks.push(encodeSSE({ type: 'text-start', id: messageId }));
+
   const tokens = body.match(/\S+\s*/g) ?? [body];
-  return tokens.map((token) =>
-    textChunkType
-      ? `${textChunkType}:${JSON.stringify(token)}\n`
-      : encodeStreamPart('0', token),
-  );
+  for (const token of tokens) {
+    chunks.push(encodeSSE({ type: 'text-delta', id: messageId, delta: token }));
+  }
+
+  chunks.push(encodeSSE({ type: 'text-end', id: messageId }));
+  return chunks;
 }
 
 /**
- * Build the two finish chunks that close an AI SDK stream:
- * 1. finish-step (`e`) — marks the end of a reasoning step
- * 2. finish-message (`d`) — marks the end of the assistant message
+ * Build the finish chunks that close an AI SDK v5 stream:
+ * 1. finish-step
+ * 2. finish (message-level)
  */
 export function buildFinishChunks(): string[] {
-  const finishStep = encodeStreamPart('e', {
-    finishReason: 'stop',
-    usage: { promptTokens: 0, completionTokens: 0 },
-    isContinued: false,
-  });
-  const finishMessage = encodeStreamPart('d', {
-    finishReason: 'stop',
-    usage: { promptTokens: 0, completionTokens: 0 },
-  });
-  return [finishStep, finishMessage];
+  return [
+    encodeSSE({ type: 'finish-step' }),
+    encodeSSE({ type: 'finish' }),
+  ];
+}
+
+/**
+ * The stream terminator required by AI SDK v5.
+ */
+export function buildDone(): string {
+  return 'data: [DONE]\n\n';
 }
 
 /**
  * SSE comment line used as a keep-alive tick.
- * Browsers and proxies treat comment lines as no-ops but they reset
+ * Browsers and proxies treat SSE comment lines as no-ops but they reset
  * connection timeout timers.
  */
 export function buildKeepAlive(): string {
   return ': keep-alive\n\n';
-}
-
-/**
- * Build the start-step chunk (`f`) that opens the stream.
- */
-export function buildStartStep(messageId: string): string {
-  return encodeStreamPart('f', { messageId });
 }

--- a/src/core/config/config-schema.ts
+++ b/src/core/config/config-schema.ts
@@ -99,7 +99,7 @@ export const PersonaConfigSchema = z.object({
 // ---------------------------------------------------------------------------
 
 export const ChannelConfigSchema = z.object({
-  type: z.enum(['telegram', 'whatsapp', 'whatsappBusiness', 'whatsappBaileys', 'slack', 'email', 'discord', 'terminal']),
+  type: z.enum(['telegram', 'whatsapp', 'whatsappBusiness', 'whatsappBaileys', 'slack', 'email', 'discord', 'terminal', 'aisdk-http']),
   name: z.string().min(1),
   config: z.record(z.string(), z.unknown()).default({}),
   tokenRef: z.string().optional(),

--- a/src/daemon/channel-factory.ts
+++ b/src/daemon/channel-factory.ts
@@ -21,6 +21,7 @@ import { EmailConnector } from '../channels/connectors/email/email-connector.js'
 import type { EmailConfig } from '../channels/connectors/email/email-types.js';
 import { TerminalConnector } from '../channels/connectors/terminal/terminal-connector.js';
 import type { TerminalConfig } from '../channels/connectors/terminal/terminal-types.js';
+import { AisdkHttpConnector } from '../channels/connectors/aisdk-http/aisdk-http-connector.js';
 
 /**
  * Creates a channel connector instance for the given type.
@@ -53,6 +54,8 @@ export function createConnector(
       return new EmailConnector(config as unknown as EmailConfig, name, logger);
     case 'terminal':
       return new TerminalConnector(config as unknown as TerminalConfig, name, logger);
+    case 'aisdk-http':
+      return new AisdkHttpConnector(config, name, logger);
     default:
       return null;
   }

--- a/tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts
+++ b/tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { AisdkHttpConnector } from '../../../../src/channels/connectors/aisdk-http/aisdk-http-connector.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+async function startConnector(config: Record<string, unknown>): Promise<AisdkHttpConnector> {
+  const connector = new AisdkHttpConnector(config, 'test-aisdk', logger);
+  await connector.start();
+  return connector;
+}
+
+async function postMessage(port: number, body: object, path = '/agents/test-agent/stream'): Promise<Response> {
+  return fetch(`http://127.0.0.1:${port}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('AisdkHttpConnector', () => {
+  let connector: AisdkHttpConnector;
+
+  afterEach(async () => {
+    if (connector) await connector.stop();
+  });
+
+  it('starts and stops cleanly', async () => {
+    connector = await startConnector({ port: 4210 });
+    expect(connector.type).toBe('aisdk-http');
+    expect(connector.name).toBe('test-aisdk');
+  });
+
+  it('returns 404 for unknown routes', async () => {
+    connector = await startConnector({ port: 4211 });
+    const res = await fetch('http://127.0.0.1:4211/unknown/path', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 405 for non-POST requests', async () => {
+    connector = await startConnector({ port: 4212 });
+    const res = await fetch('http://127.0.0.1:4212/agents/test-agent/stream', { method: 'GET' });
+    expect(res.status).toBe(405);
+  });
+
+  it('fires onMessage handler with last user message content', async () => {
+    connector = await startConnector({ port: 4213 });
+    const received: string[] = [];
+    connector.onMessage((event) => { received.push(event.content); });
+
+    void postMessage(4213, {
+      messages: [{ role: 'user', content: 'Hello Talon' }],
+      id: 'thread-abc',
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(received).toContain('Hello Talon');
+  });
+
+  it('send() writes text-delta chunks and closes stream', async () => {
+    connector = await startConnector({ port: 4214 });
+    connector.onMessage(() => {
+      setTimeout(() => {
+        void connector.send('thread-xyz', { body: 'Test response' });
+      }, 50);
+    });
+
+    const res = await postMessage(4214, {
+      messages: [{ role: 'user', content: 'ping' }],
+      id: 'thread-xyz',
+    });
+
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const body = await res.text();
+    expect(body).toContain('0:');          // text-delta chunks
+    expect(body).toContain('"stop"');      // finish
+    expect(res.headers.get('x-thread-id')).toBe('thread-xyz');
+  });
+
+  it('handles CORS preflight', async () => {
+    connector = await startConnector({ port: 4215 });
+    const res = await fetch('http://127.0.0.1:4215/agents/test-agent/stream', {
+      method: 'OPTIONS',
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+  });
+
+  it('extracts forwarded headers from request', async () => {
+    connector = await startConnector({
+      port: 4216,
+      forwardHeaders: ['Authorization'],
+    });
+
+    let receivedEvent: { content: string } | null = null;
+    connector.onMessage((event) => {
+      receivedEvent = event;
+      setTimeout(() => {
+        void connector.send(event.externalThreadId, { body: 'ok' });
+      }, 50);
+    });
+
+    await postMessage(4216, {
+      messages: [{ role: 'user', content: 'test' }],
+      id: 'thread-fwd',
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(receivedEvent).not.toBeNull();
+    expect(receivedEvent!.content).toBe('test');
+  });
+
+  it('generates thread ID when not provided by client', async () => {
+    connector = await startConnector({ port: 4217 });
+    connector.onMessage((event) => {
+      setTimeout(() => {
+        void connector.send(event.externalThreadId, { body: 'ok' });
+      }, 50);
+    });
+
+    const res = await postMessage(4217, {
+      messages: [{ role: 'user', content: 'no-id' }],
+    });
+
+    const threadId = res.headers.get('x-thread-id');
+    expect(threadId).toBeTruthy();
+    expect(threadId!.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts
+++ b/tests/unit/channels/aisdk-http/aisdk-http-connector.test.ts
@@ -10,10 +10,15 @@ async function startConnector(config: Record<string, unknown>): Promise<AisdkHtt
   return connector;
 }
 
-async function postMessage(port: number, body: object, path = '/agents/test-agent/stream'): Promise<Response> {
+async function postMessage(
+  port: number,
+  body: object,
+  path = '/agents/test-agent/stream',
+  headers: Record<string, string> = {},
+): Promise<Response> {
   return fetch(`http://127.0.0.1:${port}${path}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify(body),
   });
 }
@@ -47,7 +52,7 @@ describe('AisdkHttpConnector', () => {
     expect(res.status).toBe(405);
   });
 
-  it('fires onMessage handler with last user message content', async () => {
+  it('fires onMessage handler with last user message content (v4 format)', async () => {
     connector = await startConnector({ port: 4213 });
     const received: string[] = [];
     connector.onMessage((event) => { received.push(event.content); });
@@ -61,7 +66,27 @@ describe('AisdkHttpConnector', () => {
     expect(received).toContain('Hello Talon');
   });
 
-  it('send() writes text-delta chunks and closes stream', async () => {
+  it('extracts text from v5 UIMessage parts format', async () => {
+    connector = await startConnector({ port: 4218 });
+    const received: string[] = [];
+    connector.onMessage((event) => { received.push(event.content); });
+
+    void postMessage(4218, {
+      messages: [{
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'Hello ' },
+          { type: 'text', text: 'from parts' },
+        ],
+      }],
+      id: 'thread-v5',
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(received).toContain('Hello from parts');
+  });
+
+  it('send() writes v5 SSE chunks and closes stream', async () => {
     connector = await startConnector({ port: 4214 });
     connector.onMessage(() => {
       setTimeout(() => {
@@ -75,9 +100,18 @@ describe('AisdkHttpConnector', () => {
     });
 
     expect(res.headers.get('content-type')).toContain('text/event-stream');
+    expect(res.headers.get('x-vercel-ai-ui-message-stream')).toBe('v1');
     const body = await res.text();
-    expect(body).toContain('0:');          // text-delta chunks
-    expect(body).toContain('"stop"');      // finish
+
+    // V5 protocol: start, start-step, text-start, text-delta(s), text-end, finish-step, finish, [DONE]
+    expect(body).toContain('"type":"start"');
+    expect(body).toContain('"type":"start-step"');
+    expect(body).toContain('"type":"text-start"');
+    expect(body).toContain('"type":"text-delta"');
+    expect(body).toContain('"type":"text-end"');
+    expect(body).toContain('"type":"finish-step"');
+    expect(body).toContain('"type":"finish"');
+    expect(body).toContain('data: [DONE]');
     expect(res.headers.get('x-thread-id')).toBe('thread-xyz');
   });
 
@@ -88,30 +122,6 @@ describe('AisdkHttpConnector', () => {
     });
     expect(res.status).toBe(204);
     expect(res.headers.get('access-control-allow-methods')).toContain('POST');
-  });
-
-  it('extracts forwarded headers from request', async () => {
-    connector = await startConnector({
-      port: 4216,
-      forwardHeaders: ['Authorization'],
-    });
-
-    let receivedEvent: { content: string } | null = null;
-    connector.onMessage((event) => {
-      receivedEvent = event;
-      setTimeout(() => {
-        void connector.send(event.externalThreadId, { body: 'ok' });
-      }, 50);
-    });
-
-    await postMessage(4216, {
-      messages: [{ role: 'user', content: 'test' }],
-      id: 'thread-fwd',
-    });
-
-    await new Promise((r) => setTimeout(r, 100));
-    expect(receivedEvent).not.toBeNull();
-    expect(receivedEvent!.content).toBe('test');
   });
 
   it('generates thread ID when not provided by client', async () => {
@@ -129,5 +139,23 @@ describe('AisdkHttpConnector', () => {
     const threadId = res.headers.get('x-thread-id');
     expect(threadId).toBeTruthy();
     expect(threadId!.length).toBeGreaterThan(0);
+  });
+
+  it('rejects oversized request bodies with 413', async () => {
+    connector = await startConnector({ port: 4219 });
+
+    // Create a body larger than 1MB
+    const largeContent = 'x'.repeat(1024 * 1024 + 1);
+    const res = await fetch(`http://127.0.0.1:4219/agents/test-agent/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: [{ role: 'user', content: largeContent }] }),
+    }).catch(() => null);
+
+    // Connection may be reset or return 413
+    if (res) {
+      expect(res.status).toBe(413);
+    }
+    // If res is null, the connection was reset which is also acceptable
   });
 });

--- a/tests/unit/channels/aisdk-http/artifact-mapper.test.ts
+++ b/tests/unit/channels/aisdk-http/artifact-mapper.test.ts
@@ -16,6 +16,8 @@ describe('buildArtifactChunks', () => {
   it('wraps result when wrapAs is set', () => {
     const chunks = buildArtifactChunks('assemble_experience_tree', { tree: [] }, mapping);
     expect(chunks).toHaveLength(1);
+    // V5 SSE format
+    expect(chunks[0]).toMatch(/^data: .+\n\n$/);
     expect(chunks[0]).toContain('"data-exo-output-artifact"');
     expect(chunks[0]).toContain('"jsonContent"');
     expect(chunks[0]).toContain('"tree"');
@@ -24,6 +26,7 @@ describe('buildArtifactChunks', () => {
   it('emits result as-is when wrapAs is absent', () => {
     const chunks = buildArtifactChunks('search_results', [{ id: '1' }], mapping);
     expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatch(/^data: .+\n\n$/);
     expect(chunks[0]).toContain('"data-search-results"');
     expect(chunks[0]).toContain('"id"');
   });

--- a/tests/unit/channels/aisdk-http/artifact-mapper.test.ts
+++ b/tests/unit/channels/aisdk-http/artifact-mapper.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { buildArtifactChunks } from '../../../../src/channels/connectors/aisdk-http/artifact-mapper.js';
+import type { ArtifactMapping } from '../../../../src/channels/connectors/aisdk-http/aisdk-http-types.js';
+
+const mapping: ArtifactMapping[] = [
+  { toolName: 'assemble_experience_tree', chunkType: 'data-exo-output-artifact', wrapAs: 'jsonContent' },
+  { toolName: 'search_results', chunkType: 'data-search-results' },
+];
+
+describe('buildArtifactChunks', () => {
+  it('returns empty array when tool name is not in mapping', () => {
+    const chunks = buildArtifactChunks('unknown_tool', { foo: 'bar' }, mapping);
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('wraps result when wrapAs is set', () => {
+    const chunks = buildArtifactChunks('assemble_experience_tree', { tree: [] }, mapping);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain('"data-exo-output-artifact"');
+    expect(chunks[0]).toContain('"jsonContent"');
+    expect(chunks[0]).toContain('"tree"');
+  });
+
+  it('emits result as-is when wrapAs is absent', () => {
+    const chunks = buildArtifactChunks('search_results', [{ id: '1' }], mapping);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain('"data-search-results"');
+    expect(chunks[0]).toContain('"id"');
+  });
+});

--- a/tests/unit/channels/aisdk-http/route-parser.test.ts
+++ b/tests/unit/channels/aisdk-http/route-parser.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { parseRoute, matchRoute } from '../../../../src/channels/connectors/aisdk-http/route-parser.js';
+
+describe('parseRoute', () => {
+  it('converts pattern to regex and extracts param names', () => {
+    const result = parseRoute('/agents/:agentId/stream');
+    expect(result.paramNames).toEqual(['agentId']);
+    expect(result.regex.test('/agents/exo-agent/stream')).toBe(true);
+    expect(result.regex.test('/agents/exo-agent/other')).toBe(false);
+  });
+
+  it('handles multi-segment patterns with multiple params', () => {
+    const result = parseRoute('/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream');
+    expect(result.paramNames).toEqual(['spaceId', 'envId', 'agentId']);
+    expect(result.regex.test('/spaces/abc123/environments/master/ai/agents/exo-agent/stream')).toBe(true);
+  });
+
+  it('handles patterns with no params', () => {
+    const result = parseRoute('/chat/stream');
+    expect(result.paramNames).toEqual([]);
+    expect(result.regex.test('/chat/stream')).toBe(true);
+    expect(result.regex.test('/chat/stream/extra')).toBe(false);
+  });
+});
+
+describe('matchRoute', () => {
+  it('returns null when URL does not match pattern', () => {
+    const result = matchRoute('/agents/:agentId/stream', '/other/path');
+    expect(result).toBeNull();
+  });
+
+  it('extracts named params from matching URL', () => {
+    const result = matchRoute('/agents/:agentId/stream', '/agents/my-persona/stream');
+    expect(result).toEqual({ agentId: 'my-persona' });
+  });
+
+  it('extracts multiple named params', () => {
+    const result = matchRoute(
+      '/spaces/:spaceId/environments/:envId/ai/agents/:agentId/stream',
+      '/spaces/abc/environments/master/ai/agents/exo-agent/stream',
+    );
+    expect(result).toEqual({ spaceId: 'abc', envId: 'master', agentId: 'exo-agent' });
+  });
+
+  it('ignores query string when matching', () => {
+    const result = matchRoute('/agents/:agentId/stream', '/agents/foo/stream?bar=baz');
+    expect(result).toEqual({ agentId: 'foo' });
+  });
+});

--- a/tests/unit/channels/aisdk-http/stream-adapter.test.ts
+++ b/tests/unit/channels/aisdk-http/stream-adapter.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { encodeStreamPart, buildTextChunks, buildFinishChunks, buildKeepAlive } from '../../../../src/channels/connectors/aisdk-http/stream-adapter.js';
+
+describe('encodeStreamPart', () => {
+  it('encodes a text-delta chunk', () => {
+    const line = encodeStreamPart('0', 'Hello world');
+    expect(line).toBe('0:"Hello world"\n');
+  });
+
+  it('encodes a data chunk (array)', () => {
+    const line = encodeStreamPart('2', [{ type: 'test' }]);
+    expect(line).toBe('2:[{"type":"test"}]\n');
+  });
+
+  it('encodes a finish-message chunk', () => {
+    const line = encodeStreamPart('d', { finishReason: 'stop', usage: { promptTokens: 10, completionTokens: 5 } });
+    expect(line).toBe('d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":5}}\n');
+  });
+});
+
+describe('buildTextChunks', () => {
+  it('returns array of encoded text-delta lines for word tokens', () => {
+    const chunks = buildTextChunks('Hello world', null);
+    expect(chunks.length).toBeGreaterThan(0);
+    chunks.forEach(c => expect(c).toMatch(/^0:".+"\n$/));
+  });
+
+  it('uses custom chunk type when textChunkType is set', () => {
+    const chunks = buildTextChunks('Hi', 'data-human-readable');
+    expect(chunks[0]).toMatch(/^data-human-readable:/);
+  });
+});
+
+describe('buildFinishChunks', () => {
+  it('returns finish-step and finish-message lines', () => {
+    const chunks = buildFinishChunks();
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toContain('"finishReason":"stop"');
+    expect(chunks[0]).toContain('"isContinued":false');
+    expect(chunks[1]).toContain('"finishReason":"stop"');
+  });
+});
+
+describe('buildKeepAlive', () => {
+  it('returns a comment line (SSE keep-alive)', () => {
+    const line = buildKeepAlive();
+    expect(line).toBe(': keep-alive\n\n');
+  });
+});

--- a/tests/unit/channels/aisdk-http/stream-adapter.test.ts
+++ b/tests/unit/channels/aisdk-http/stream-adapter.test.ts
@@ -1,43 +1,69 @@
 import { describe, it, expect } from 'vitest';
-import { encodeStreamPart, buildTextChunks, buildFinishChunks, buildKeepAlive } from '../../../../src/channels/connectors/aisdk-http/stream-adapter.js';
+import { encodeSSE, buildStart, buildStartStep, buildTextChunks, buildFinishChunks, buildDone, buildKeepAlive } from '../../../../src/channels/connectors/aisdk-http/stream-adapter.js';
 
-describe('encodeStreamPart', () => {
-  it('encodes a text-delta chunk', () => {
-    const line = encodeStreamPart('0', 'Hello world');
-    expect(line).toBe('0:"Hello world"\n');
+describe('encodeSSE', () => {
+  it('encodes a JSON object as an SSE data frame', () => {
+    const line = encodeSSE({ type: 'text-delta', id: 'msg1', delta: 'Hello' });
+    expect(line).toBe('data: {"type":"text-delta","id":"msg1","delta":"Hello"}\n\n');
   });
 
-  it('encodes a data chunk (array)', () => {
-    const line = encodeStreamPart('2', [{ type: 'test' }]);
-    expect(line).toBe('2:[{"type":"test"}]\n');
+  it('encodes nested objects', () => {
+    const line = encodeSSE({ type: 'finish', usage: { promptTokens: 10 } });
+    expect(line).toBe('data: {"type":"finish","usage":{"promptTokens":10}}\n\n');
   });
+});
 
-  it('encodes a finish-message chunk', () => {
-    const line = encodeStreamPart('d', { finishReason: 'stop', usage: { promptTokens: 10, completionTokens: 5 } });
-    expect(line).toBe('d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":5}}\n');
+describe('buildStart', () => {
+  it('emits a start chunk with messageId', () => {
+    const chunk = buildStart('msg-123');
+    expect(chunk).toContain('"type":"start"');
+    expect(chunk).toContain('"messageId":"msg-123"');
+    expect(chunk).toMatch(/^data: .+\n\n$/);
+  });
+});
+
+describe('buildStartStep', () => {
+  it('emits a start-step chunk', () => {
+    const chunk = buildStartStep();
+    expect(chunk).toBe('data: {"type":"start-step"}\n\n');
   });
 });
 
 describe('buildTextChunks', () => {
-  it('returns array of encoded text-delta lines for word tokens', () => {
-    const chunks = buildTextChunks('Hello world', null);
-    expect(chunks.length).toBeGreaterThan(0);
-    chunks.forEach(c => expect(c).toMatch(/^0:".+"\n$/));
+  it('returns text-start, text-delta(s), and text-end for standard mode', () => {
+    const chunks = buildTextChunks('Hello world', null, 'msg-1');
+    expect(chunks.length).toBeGreaterThanOrEqual(3); // start + at least 1 delta + end
+    expect(chunks[0]).toContain('"type":"text-start"');
+    expect(chunks[0]).toContain('"id":"msg-1"');
+    expect(chunks[chunks.length - 1]).toContain('"type":"text-end"');
+
+    // Middle chunks are text-delta
+    for (let i = 1; i < chunks.length - 1; i++) {
+      expect(chunks[i]).toContain('"type":"text-delta"');
+      expect(chunks[i]).toContain('"delta":');
+    }
   });
 
   it('uses custom chunk type when textChunkType is set', () => {
-    const chunks = buildTextChunks('Hi', 'data-human-readable');
-    expect(chunks[0]).toMatch(/^data-human-readable:/);
+    const chunks = buildTextChunks('Hi there', 'data-human-readable', 'msg-2');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain('"type":"data-human-readable"');
+    expect(chunks[0]).toContain('"data":"Hi there"');
   });
 });
 
 describe('buildFinishChunks', () => {
-  it('returns finish-step and finish-message lines', () => {
+  it('returns finish-step and finish chunks', () => {
     const chunks = buildFinishChunks();
     expect(chunks).toHaveLength(2);
-    expect(chunks[0]).toContain('"finishReason":"stop"');
-    expect(chunks[0]).toContain('"isContinued":false');
-    expect(chunks[1]).toContain('"finishReason":"stop"');
+    expect(chunks[0]).toContain('"type":"finish-step"');
+    expect(chunks[1]).toContain('"type":"finish"');
+  });
+});
+
+describe('buildDone', () => {
+  it('returns the v5 stream terminator', () => {
+    expect(buildDone()).toBe('data: [DONE]\n\n');
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a new `aisdk-http` channel type that runs a lightweight HTTP server speaking the **Vercel AI SDK v5 UI Message Stream protocol** (SSE)
- Any `@ai-sdk/react` frontend (`useChat`, `DefaultChatTransport`) can connect to a Talon persona via HTTP POST + SSE
- Generic design — all domain-specific behavior (artifact mapping, text chunk types, header forwarding) is configured per-instance via YAML, no hardcoded domain logic in the connector

### Components
- **Types & config schema** — Zod-validated config with artifact mapping, CORS, header forwarding, route patterns
- **Route parser** — Express-style named param extraction (`:agentId`, `:spaceId`, etc.)
- **Stream adapter** — AI SDK v5 SSE encoding: `start` → `start-step` → `text-start/delta/end` → `finish-step` → `finish` → `data: [DONE]`
- **Artifact mapper** — Configurable tool-name-to-custom-chunk mapping for domain-specific data chunks
- **Main connector** — HTTP server with SSE lifecycle, keep-alive ticks, CORS, body size limit (1MB)
- **Channel factory registration** — `aisdk-http` case in the switch

### Reviewed by Codex (GPT-5.2)
Initial implementation used AI SDK v4 numeric prefix format (`0:`, `d:`, `e:`). Codex review caught the protocol mismatch — rewrote to proper v5 SSE format. Also fixed: UIMessage parts parsing, dead config removal, body size limit.

### Known V1 gaps (deferred)
- Artifact mapper implemented but not wired into `send()` — needs agent runner to surface per-tool results
- `forwardedHeaders` collected but not yet passed to MCP servers (pipeline needs per-request header injection)
- No per-request persona routing (uses standard channel bindings)

## Test plan

- [x] 28 unit/integration tests passing (route parser, stream adapter, artifact mapper, connector lifecycle)
- [x] TypeScript build clean
- [ ] Manual test with `@ai-sdk/react` `useChat` frontend against running Talon instance
- [ ] Conformance test comparing stream output to agents_api ExO agent stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)