### PR TITLE
feat: local git-worktree execution environment adapter

### DIFF
--- a/src/core/config/config-schema.ts
+++ b/src/core/config/config-schema.ts
@@ -296,6 +296,29 @@ export const SpritesConfigSchema = z
   });
 
 // ---------------------------------------------------------------------------
+// Local worktree execution environments
+// ---------------------------------------------------------------------------
+
+export const LocalWorktreeConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    /** Root directory for git worktrees. Each env gets a subdirectory. */
+    worktreeRoot: z.string().default('/tmp/talon-envs'),
+    /** Command to run after worktree creation (e.g. "npm ci"). */
+    prepareCommand: z.string().optional(),
+    /** Default working directory inside the worktree. */
+    workingDirectory: z.string().default('/workspace'),
+    /** Max exec timeout in ms. */
+    execTimeoutMs: z.number().int().min(1000).default(10 * 60 * 1000),
+    /** Destroy worktree on task completion. */
+    autoDestroyOnCompletion: z.boolean().default(true),
+    /** Resource limits (advisory — not enforced without OS sandbox). */
+    resourceLimits: ExecutionEnvResourceLimitsSchema.default(() =>
+      ExecutionEnvResourceLimitsSchema.parse({}),
+    ),
+  });
+
+// ---------------------------------------------------------------------------
 // Langfuse observability
 // ---------------------------------------------------------------------------
 
@@ -369,6 +392,7 @@ export const TalondConfigSchema = z.object({
   agentRunner: AgentRunnerConfigSchema.default(() => AgentRunnerConfigSchema.parse({})),
   backgroundAgent: BackgroundAgentConfigSchema.default(() => BackgroundAgentConfigSchema.parse({})),
   sprites: SpritesConfigSchema.default(() => SpritesConfigSchema.parse({})),
+  localWorktree: LocalWorktreeConfigSchema.default(() => LocalWorktreeConfigSchema.parse({})),
   langfuse: LangfuseConfigSchema.default(() => LangfuseConfigSchema.parse({})),
   subagents: SubAgentsConfigSchema.default({}),
   logLevel: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),

--- a/src/core/config/config-types.ts
+++ b/src/core/config/config-types.ts
@@ -16,6 +16,7 @@ import type {
   MountConfigSchema,
   PersonaConfigSchema,
   SpritesConfigSchema,
+  LocalWorktreeConfigSchema,
   ChannelConfigSchema,
   BindingConfigSchema,
   IpcConfigSchema,
@@ -89,6 +90,9 @@ export type BackgroundAgentConfig = z.infer<typeof BackgroundAgentConfigSchema>;
 
 /** Sprites provider settings. */
 export type SpritesConfig = z.infer<typeof SpritesConfigSchema>;
+
+/** Local worktree execution environment settings. */
+export type LocalWorktreeConfig = z.infer<typeof LocalWorktreeConfigSchema>;
 
 /** Langfuse Cloud observability settings. */
 export type LangfuseConfig = z.infer<typeof LangfuseConfigSchema>;

--- a/src/core/database/repositories/execution-env-checkpoint-repository.ts
+++ b/src/core/database/repositories/execution-env-checkpoint-repository.ts
@@ -5,12 +5,13 @@ import { BaseRepository } from './base-repository.js';
 import type {
   CreateExecutionEnvCheckpointInput,
   ExecutionEnvCheckpoint,
+  ExecutionEnvProvider,
 } from '../../../execution-env/execution-env-types.js';
 
 interface ExecutionEnvCheckpointRow {
   id: string;
   env_id: string;
-  provider: 'sprites';
+  provider: ExecutionEnvProvider;
   remote_ref: string;
   label: string | null;
   status: ExecutionEnvCheckpoint['status'];

--- a/src/core/database/repositories/execution-env-repository.ts
+++ b/src/core/database/repositories/execution-env-repository.ts
@@ -5,12 +5,13 @@ import { BaseRepository } from './base-repository.js';
 import type {
   CreateExecutionEnvironmentRecordInput,
   ExecutionEnvironment,
+  ExecutionEnvProvider,
   ExecutionEnvStatus,
 } from '../../../execution-env/execution-env-types.js';
 
 interface ExecutionEnvironmentRow {
   id: string;
-  provider: 'sprites';
+  provider: ExecutionEnvProvider;
   sprite_id: string;
   thread_id: string;
   persona_id: string;

--- a/src/daemon/daemon-bootstrap.ts
+++ b/src/daemon/daemon-bootstrap.ts
@@ -54,6 +54,7 @@ import { HostToolsBridge } from '../tools/host-tools-bridge.js';
 import { BackgroundAgentManager } from '../subagents/background/background-agent-manager.js';
 import { ExecutionEnvManager } from '../execution-env/execution-env-manager.js';
 import { SpritesClient } from '../execution-env/sprites-client.js';
+import { LocalWorktreeAdapter } from '../execution-env/local-worktree-adapter.js';
 import { SubAgentLoader } from '../subagents/subagent-loader.js';
 import { SubAgentRunner } from '../subagents/subagent-runner.js';
 import { ModelResolver } from '../subagents/model-resolver.js';
@@ -551,6 +552,19 @@ export async function bootstrap(
       defaultAutoDestroy: config.sprites.autoDestroyOnCompletion,
       defaultExecTimeoutMs: config.sprites.execTimeoutMs,
       defaultResourceLimits: config.sprites.resourceLimits,
+      logger,
+    });
+    await executionEnvManager.recoverOrphanedEnvironments();
+  } else if (config.localWorktree.enabled) {
+    const repoRoot = process.cwd();
+    executionEnvManager = new ExecutionEnvManager({
+      repository: repos.executionEnv,
+      checkpointRepository: repos.executionEnvCheckpoint,
+      client: new LocalWorktreeAdapter(config.localWorktree, repoRoot, logger),
+      defaultWorkingDirectory: config.localWorktree.workingDirectory,
+      defaultAutoDestroy: config.localWorktree.autoDestroyOnCompletion,
+      defaultExecTimeoutMs: config.localWorktree.execTimeoutMs,
+      defaultResourceLimits: config.localWorktree.resourceLimits,
       logger,
     });
     await executionEnvManager.recoverOrphanedEnvironments();

--- a/src/execution-env/execution-env-types.ts
+++ b/src/execution-env/execution-env-types.ts
@@ -1,4 +1,4 @@
-export type ExecutionEnvProvider = 'sprites';
+export type ExecutionEnvProvider = 'sprites' | 'local';
 
 export type ExecutionEnvStatus =
   | 'creating'

--- a/src/execution-env/local-worktree-adapter.ts
+++ b/src/execution-env/local-worktree-adapter.ts
@@ -1,0 +1,388 @@
+/**
+ * Local git-worktree-based execution environment adapter.
+ *
+ * Implements the same SpritesClientAdapter interface so ExecutionEnvManager
+ * can drive it identically to the remote Sprites provider. Uses git worktrees
+ * for filesystem isolation, git commits for checkpoints, and git checkout for
+ * restore.
+ */
+
+import { execFile, spawn } from 'node:child_process';
+import { cp, mkdir, rm, stat } from 'node:fs/promises';
+import { join, resolve, isAbsolute, relative } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { promisify } from 'node:util';
+import type pino from 'pino';
+import type { SpritesClientAdapter } from './sprites-client-adapter.js';
+import type { ExecutionEnvResourceLimits } from './execution-env-types.js';
+import type { LocalWorktreeConfig } from '../core/config/config-types.js';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WorktreeInfo {
+  id: string;
+  path: string;
+  branch: string;
+  createdAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// LocalWorktreeAdapter
+// ---------------------------------------------------------------------------
+
+export class LocalWorktreeAdapter implements SpritesClientAdapter {
+  /** Track worktrees by their sprite-equivalent ID. */
+  private readonly worktrees = new Map<string, WorktreeInfo>();
+
+  constructor(
+    private readonly config: LocalWorktreeConfig,
+    private readonly repoRoot: string,
+    private readonly logger: pino.Logger,
+  ) {}
+
+  async create(input: {
+    baseSnapshot?: string;
+    resourceLimits: ExecutionEnvResourceLimits;
+    workingDirectory: string;
+    metadata: Record<string, string>;
+  }): Promise<{ spriteId: string }> {
+    const id = this.generateId(input.metadata);
+    const branch = `talon-env/${id}`;
+    const worktreePath = resolve(this.config.worktreeRoot, id);
+
+    await mkdir(this.config.worktreeRoot, { recursive: true });
+
+    // Create an orphan branch so the worktree starts clean from HEAD
+    await this.git(['worktree', 'add', '-b', branch, worktreePath, 'HEAD'], this.repoRoot);
+
+    this.logger.info(
+      { envId: id, path: worktreePath, branch },
+      'local-worktree: created',
+    );
+
+    // Run the prepare command if configured (e.g. npm ci)
+    if (this.config.prepareCommand) {
+      this.logger.info(
+        { envId: id, command: this.config.prepareCommand },
+        'local-worktree: running prepare command',
+      );
+      const result = await this.runCommand(
+        this.config.prepareCommand,
+        worktreePath,
+        this.config.execTimeoutMs,
+      );
+      if (result.exitCode !== 0) {
+        // Clean up the worktree on prepare failure
+        this.logger.warn(
+          { envId: id, exitCode: result.exitCode, stderr: result.stderr.slice(0, 500) },
+          'local-worktree: prepareCommand failed, cleaning up',
+        );
+        await this.git(['worktree', 'remove', worktreePath, '--force'], this.repoRoot).catch(() => {});
+        await rm(worktreePath, { recursive: true, force: true }).catch(() => {});
+        await this.git(['branch', '-D', branch], this.repoRoot).catch(() => {});
+        throw new Error(
+          `local-worktree: prepareCommand failed (exit ${result.exitCode}): ${result.stderr.slice(0, 200)}`,
+        );
+      }
+    }
+
+    this.worktrees.set(id, {
+      id,
+      path: worktreePath,
+      branch,
+      createdAt: Date.now(),
+    });
+
+    return { spriteId: id };
+  }
+
+  async exec(input: {
+    spriteId: string;
+    command: string;
+    cwd: string;
+    timeoutMs: number;
+    detach?: boolean;
+    env?: Record<string, string>;
+  }): Promise<{
+    exitCode: number | null;
+    stdout: string;
+    stderr: string;
+    timedOut: boolean;
+    processId?: string;
+  }> {
+    const worktree = this.requireWorktree(input.spriteId);
+
+    // All cwd paths are resolved relative to the worktree root.
+    // Absolute paths like /workspace are treated as relative to the worktree.
+    const cwdInput = isAbsolute(input.cwd)
+      ? input.cwd.replace(/^\/+/, '')
+      : input.cwd;
+    const cwd = this.resolveEnvPath(worktree.path, cwdInput || '.');
+
+    if (input.detach) {
+      const child = spawn('bash', ['-lc', input.command], {
+        cwd,
+        env: { ...process.env, ...input.env },
+        detached: true,
+        stdio: 'ignore',
+      });
+      child.unref();
+      const processId = String(child.pid ?? randomUUID());
+      return {
+        exitCode: null,
+        stdout: '',
+        stderr: '',
+        timedOut: false,
+        processId,
+      };
+    }
+
+    return await this.runCommand(
+      input.command,
+      cwd,
+      input.timeoutMs,
+      input.env,
+    );
+  }
+
+  async upload(input: {
+    spriteId: string;
+    sourcePath: string;
+    destinationPath: string;
+    recursive?: boolean;
+  }): Promise<{ bytes: number }> {
+    const worktree = this.requireWorktree(input.spriteId);
+    const dest = this.resolveEnvPath(worktree.path, input.destinationPath);
+
+    const sourceStats = await stat(input.sourcePath);
+    if (sourceStats.isDirectory() && !input.recursive) {
+      throw new Error('recursive=true is required to upload directories');
+    }
+
+    await mkdir(join(dest, '..'), { recursive: true });
+    await cp(input.sourcePath, dest, { recursive: input.recursive ?? false });
+
+    const destStats = await stat(dest).catch(() => null);
+    return { bytes: destStats?.size ?? sourceStats.size };
+  }
+
+  async download(input: {
+    spriteId: string;
+    sourcePath: string;
+    destinationPath: string;
+    overwrite?: boolean;
+  }): Promise<{ bytes: number }> {
+    const worktree = this.requireWorktree(input.spriteId);
+    const src = this.resolveEnvPath(worktree.path, input.sourcePath);
+
+    if (!input.overwrite) {
+      const exists = await stat(input.destinationPath).catch(() => null);
+      if (exists) {
+        throw new Error(`destination "${input.destinationPath}" already exists and overwrite is false`);
+      }
+    }
+
+    await mkdir(join(input.destinationPath, '..'), { recursive: true });
+    await cp(src, input.destinationPath, { recursive: true });
+
+    const srcStats = await stat(src);
+    return { bytes: srcStats.size };
+  }
+
+  async checkpoint(input: {
+    spriteId: string;
+    label?: string;
+  }): Promise<{ remoteRef: string }> {
+    const worktree = this.requireWorktree(input.spriteId);
+    const label = input.label ?? `checkpoint-${Date.now()}`;
+
+    // Stage all changes including ignored files (e.g. node_modules, build outputs)
+    await this.git(['add', '-Af'], worktree.path);
+
+    // Check if there are changes to commit
+    const { stdout: statusOut } = await execFileAsync(
+      'git', ['status', '--porcelain'], { cwd: worktree.path },
+    );
+
+    let commitSha: string;
+    if (statusOut.trim().length === 0) {
+      // No changes — use current HEAD as the checkpoint
+      const { stdout: headSha } = await execFileAsync(
+        'git', ['rev-parse', 'HEAD'], { cwd: worktree.path },
+      );
+      commitSha = headSha.trim();
+      this.logger.info(
+        { envId: input.spriteId, sha: commitSha, label },
+        'local-worktree: checkpoint (no changes, using HEAD)',
+      );
+    } else {
+      await this.git(
+        ['commit', '-m', `checkpoint: ${label}`, '--allow-empty'],
+        worktree.path,
+      );
+
+      const { stdout: sha } = await execFileAsync(
+        'git', ['rev-parse', 'HEAD'], { cwd: worktree.path },
+      );
+      commitSha = sha.trim();
+      this.logger.info(
+        { envId: input.spriteId, sha: commitSha, label },
+        'local-worktree: checkpoint created',
+      );
+    }
+
+    return { remoteRef: commitSha };
+  }
+
+  async restore(input: {
+    spriteId: string;
+    remoteRef: string;
+  }): Promise<void> {
+    const worktree = this.requireWorktree(input.spriteId);
+
+    // Hard reset to the checkpoint commit
+    await this.git(['checkout', input.remoteRef, '--', '.'], worktree.path);
+    await this.git(['clean', '-fdx'], worktree.path);
+
+    this.logger.info(
+      { envId: input.spriteId, ref: input.remoteRef },
+      'local-worktree: restored',
+    );
+  }
+
+  async destroy(spriteId: string): Promise<void> {
+    const tracked = this.worktrees.get(spriteId);
+
+    // Derive path and branch even if not in the in-memory map (e.g. after restart)
+    const worktreePath = tracked?.path ?? resolve(this.config.worktreeRoot, spriteId);
+    const branch = tracked?.branch ?? `talon-env/${spriteId}`;
+
+    // Check if the worktree directory actually exists
+    const exists = await stat(worktreePath).catch(() => null);
+    if (!exists && !tracked) {
+      return; // Nothing to clean up
+    }
+
+    try {
+      await this.git(
+        ['worktree', 'remove', worktreePath, '--force'],
+        this.repoRoot,
+      );
+    } catch {
+      // If worktree remove fails, try manual cleanup
+      await rm(worktreePath, { recursive: true, force: true });
+      await this.git(['worktree', 'prune'], this.repoRoot).catch(() => {});
+    }
+
+    // Delete the branch
+    try {
+      await this.git(['branch', '-D', branch], this.repoRoot);
+    } catch {
+      // Branch may not exist if worktree was created from detached HEAD
+    }
+
+    this.worktrees.delete(spriteId);
+    this.logger.info({ envId: spriteId }, 'local-worktree: destroyed');
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private generateId(metadata: Record<string, string>): string {
+    const base = metadata.ownerTaskId ?? metadata.threadId ?? 'env';
+    const sanitized = base.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/g, '');
+    return `${sanitized || 'env'}-${randomUUID().slice(0, 12)}`;
+  }
+
+  private requireWorktree(spriteId: string): WorktreeInfo {
+    const worktree = this.worktrees.get(spriteId);
+    if (!worktree) {
+      throw new Error(`local-worktree: environment "${spriteId}" not found`);
+    }
+    return worktree;
+  }
+
+  /**
+   * Resolve a path to be contained within the worktree.
+   * Both absolute and relative paths are confined — `../../etc/passwd` is rejected.
+   */
+  private resolveEnvPath(worktreePath: string, envPath: string): string {
+    const resolved = isAbsolute(envPath)
+      ? resolve(envPath)
+      : resolve(worktreePath, envPath);
+    const rel = relative(worktreePath, resolved);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      throw new Error(
+        `local-worktree: path "${envPath}" escapes the worktree root`,
+      );
+    }
+    return resolved;
+  }
+
+  private async git(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
+    const result = await execFileAsync('git', args, {
+      cwd,
+      timeout: 30_000,
+      env: {
+        ...process.env,
+        // Prevent git from prompting for credentials
+        GIT_TERMINAL_PROMPT: '0',
+      },
+    });
+    return { stdout: result.stdout, stderr: result.stderr };
+  }
+
+  private async runCommand(
+    command: string,
+    cwd: string,
+    timeoutMs: number,
+    env?: Record<string, string>,
+  ): Promise<{
+    exitCode: number | null;
+    stdout: string;
+    stderr: string;
+    timedOut: boolean;
+  }> {
+    return new Promise((resolvePromise) => {
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let settled = false;
+      let timedOut = false;
+
+      const child = spawn('bash', ['-lc', command], {
+        cwd,
+        env: { ...process.env, ...env },
+      });
+
+      const timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+        // Force kill after 5s if still alive
+        setTimeout(() => child.kill('SIGKILL'), 5000);
+      }, timeoutMs);
+
+      child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+      const finish = (code: number | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutHandle);
+        resolvePromise({
+          exitCode: code,
+          stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+          stderr: Buffer.concat(stderrChunks).toString('utf8'),
+          timedOut,
+        });
+      };
+
+      child.on('exit', (code) => finish(code));
+      child.on('error', () => finish(null));
+    });
+  }
+}

--- a/tests/unit/execution-env/local-worktree-adapter.test.ts
+++ b/tests/unit/execution-env/local-worktree-adapter.test.ts
@@ -1,0 +1,409 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rm } from 'node:fs/promises';
+import { LocalWorktreeAdapter } from '../../../src/execution-env/local-worktree-adapter.js';
+import type { LocalWorktreeConfig } from '../../../src/core/config/config-types.js';
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => makeLogger(),
+  } as any;
+}
+
+function makeConfig(overrides: Partial<LocalWorktreeConfig> = {}): LocalWorktreeConfig {
+  return {
+    enabled: true,
+    worktreeRoot: join(tmpdir(), `talon-worktree-test-${Date.now()}`),
+    workingDirectory: '/workspace',
+    execTimeoutMs: 30_000,
+    autoDestroyOnCompletion: true,
+    resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+    ...overrides,
+  };
+}
+
+/** Create a minimal git repo to serve as the "source" repo for worktrees. */
+function createTestRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'talon-test-repo-'));
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe' });
+  writeFileSync(join(dir, 'hello.txt'), 'hello world\n');
+  execSync('git add -A && git commit -m "initial"', { cwd: dir, stdio: 'pipe' });
+  return dir;
+}
+
+describe('LocalWorktreeAdapter', () => {
+  let repoRoot: string;
+  let config: LocalWorktreeConfig;
+  let adapter: LocalWorktreeAdapter;
+  let logger: ReturnType<typeof makeLogger>;
+
+  beforeEach(() => {
+    repoRoot = createTestRepo();
+    config = makeConfig();
+    logger = makeLogger();
+    adapter = new LocalWorktreeAdapter(config, repoRoot, logger);
+  });
+
+  afterEach(async () => {
+    // Clean up all worktrees via git
+    try {
+      execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' });
+    } catch { /* ignore */ }
+    await rm(repoRoot, { recursive: true, force: true });
+    await rm(config.worktreeRoot, { recursive: true, force: true });
+  });
+
+  describe('create', () => {
+    it('creates a worktree directory', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      expect(spriteId).toBeTruthy();
+      // The worktree should exist
+      const worktreePath = join(config.worktreeRoot, spriteId);
+      expect(existsSync(worktreePath)).toBe(true);
+      // It should have the initial file
+      expect(existsSync(join(worktreePath, 'hello.txt'))).toBe(true);
+
+      await adapter.destroy(spriteId);
+    });
+
+    it('runs prepareCommand after creation', async () => {
+      const configWithPrepare = makeConfig({
+        prepareCommand: 'echo "prepared" > prepared.txt',
+      });
+      const adapterWithPrepare = new LocalWorktreeAdapter(configWithPrepare, repoRoot, logger);
+      config = configWithPrepare; // for cleanup
+
+      const { spriteId } = await adapterWithPrepare.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      const worktreePath = join(configWithPrepare.worktreeRoot, spriteId);
+      expect(existsSync(join(worktreePath, 'prepared.txt'))).toBe(true);
+      const content = readFileSync(join(worktreePath, 'prepared.txt'), 'utf8');
+      expect(content.trim()).toBe('prepared');
+
+      await adapterWithPrepare.destroy(spriteId);
+    });
+  });
+
+  describe('exec', () => {
+    it('runs commands in the worktree', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      const result = await adapter.exec({
+        spriteId,
+        command: 'cat hello.txt',
+        cwd: '.',
+        timeoutMs: 5000,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('hello world');
+      expect(result.timedOut).toBe(false);
+
+      await adapter.destroy(spriteId);
+    });
+
+    it('captures stderr and exit code', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      const result = await adapter.exec({
+        spriteId,
+        command: 'echo "err" >&2; exit 42',
+        cwd: '.',
+        timeoutMs: 5000,
+      });
+
+      expect(result.exitCode).toBe(42);
+      expect(result.stderr.trim()).toBe('err');
+
+      await adapter.destroy(spriteId);
+    });
+
+    it('times out long commands', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      const result = await adapter.exec({
+        spriteId,
+        command: 'sleep 60',
+        cwd: '.',
+        timeoutMs: 500,
+      });
+
+      expect(result.timedOut).toBe(true);
+
+      await adapter.destroy(spriteId);
+    });
+  });
+
+  describe('checkpoint and restore', () => {
+    it('checkpoints and restores filesystem state', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      const worktreePath = join(config.worktreeRoot, spriteId);
+
+      // Modify a file and checkpoint
+      writeFileSync(join(worktreePath, 'hello.txt'), 'modified\n');
+      const { remoteRef } = await adapter.checkpoint({
+        spriteId,
+        label: 'after-modification',
+      });
+      expect(remoteRef).toBeTruthy();
+
+      // Modify again
+      writeFileSync(join(worktreePath, 'hello.txt'), 'modified-again\n');
+
+      // Restore to checkpoint
+      await adapter.restore({ spriteId, remoteRef });
+
+      const content = readFileSync(join(worktreePath, 'hello.txt'), 'utf8');
+      expect(content).toBe('modified\n');
+
+      await adapter.destroy(spriteId);
+    });
+
+    it('checkpoint with no changes uses HEAD', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      const { remoteRef } = await adapter.checkpoint({ spriteId });
+      expect(remoteRef).toBeTruthy();
+      // Should be a valid git sha
+      expect(remoteRef).toMatch(/^[0-9a-f]{40}$/);
+
+      await adapter.destroy(spriteId);
+    });
+  });
+
+  describe('upload and download', () => {
+    it('copies files into the worktree', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      // Create a source file outside the worktree
+      const srcFile = join(repoRoot, 'upload-test.txt');
+      writeFileSync(srcFile, 'upload content');
+
+      const result = await adapter.upload({
+        spriteId,
+        sourcePath: srcFile,
+        destinationPath: 'uploaded.txt',
+      });
+
+      expect(result.bytes).toBeGreaterThan(0);
+
+      const worktreePath = join(config.worktreeRoot, spriteId);
+      expect(readFileSync(join(worktreePath, 'uploaded.txt'), 'utf8')).toBe('upload content');
+
+      await adapter.destroy(spriteId);
+    });
+
+    it('copies files out of the worktree', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      const destFile = join(repoRoot, 'downloaded.txt');
+      const result = await adapter.download({
+        spriteId,
+        sourcePath: 'hello.txt',
+        destinationPath: destFile,
+      });
+
+      expect(result.bytes).toBeGreaterThan(0);
+      expect(readFileSync(destFile, 'utf8').trim()).toBe('hello world');
+
+      await adapter.destroy(spriteId);
+    });
+  });
+
+  describe('destroy', () => {
+    it('removes the worktree and branch', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      const worktreePath = join(config.worktreeRoot, spriteId);
+      expect(existsSync(worktreePath)).toBe(true);
+
+      await adapter.destroy(spriteId);
+      expect(existsSync(worktreePath)).toBe(false);
+    });
+
+    it('is idempotent', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      await adapter.destroy(spriteId);
+      // Second destroy should not throw
+      await adapter.destroy(spriteId);
+    });
+
+    it('cleans up worktrees not in memory (orphan recovery)', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      const worktreePath = join(config.worktreeRoot, spriteId);
+      expect(existsSync(worktreePath)).toBe(true);
+
+      // Create a fresh adapter (simulates daemon restart — empty in-memory map)
+      const freshAdapter = new LocalWorktreeAdapter(config, repoRoot, logger);
+      await freshAdapter.destroy(spriteId);
+      expect(existsSync(worktreePath)).toBe(false);
+    });
+  });
+
+  describe('path containment', () => {
+    it('rejects path traversal in upload destinationPath', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      await expect(
+        adapter.upload({
+          spriteId,
+          sourcePath: join(repoRoot, 'hello.txt'),
+          destinationPath: '../../etc/passwd',
+        }),
+      ).rejects.toThrow('escapes the worktree root');
+
+      await adapter.destroy(spriteId);
+    });
+
+    it('rejects path traversal in download sourcePath', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      await expect(
+        adapter.download({
+          spriteId,
+          sourcePath: '../../../etc/passwd',
+          destinationPath: join(repoRoot, 'stolen.txt'),
+        }),
+      ).rejects.toThrow('escapes the worktree root');
+
+      await adapter.destroy(spriteId);
+    });
+
+    it('rejects absolute path outside worktree in exec cwd', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      // /tmp should resolve to an escape since it's outside the worktree
+      // after the leading slash is stripped, "tmp" relative to worktree is fine,
+      // but ../../tmp would escape
+      await expect(
+        adapter.exec({
+          spriteId,
+          command: 'pwd',
+          cwd: '../../../../../../tmp',
+          timeoutMs: 5000,
+        }),
+      ).rejects.toThrow('escapes the worktree root');
+
+      await adapter.destroy(spriteId);
+    });
+
+    it('resolves absolute cwd as relative to worktree', async () => {
+      const { spriteId } = await adapter.create({
+        resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+        workingDirectory: '/workspace',
+        metadata: { threadId: 'test-thread' },
+      });
+
+      // /workspace should be treated as "workspace" inside the worktree
+      // It may not exist, but the containment check should pass
+      const result = await adapter.exec({
+        spriteId,
+        command: 'pwd',
+        cwd: '.',
+        timeoutMs: 5000,
+      });
+
+      expect(result.exitCode).toBe(0);
+      // cwd should be within the worktree
+      expect(result.stdout.trim()).toContain(config.worktreeRoot);
+
+      await adapter.destroy(spriteId);
+    });
+  });
+
+  describe('prepareCommand failure', () => {
+    it('cleans up worktree when prepareCommand fails', async () => {
+      const configWithBadPrepare = makeConfig({
+        prepareCommand: 'exit 1',
+      });
+      const adapterWithBadPrepare = new LocalWorktreeAdapter(configWithBadPrepare, repoRoot, logger);
+
+      await expect(
+        adapterWithBadPrepare.create({
+          resourceLimits: { cpus: 1, memoryMb: 512, diskGb: 1 },
+          workingDirectory: '/workspace',
+          metadata: { threadId: 'test-thread' },
+        }),
+      ).rejects.toThrow('prepareCommand failed');
+
+      // Worktree root should have no leftover directories
+      const entries = existsSync(configWithBadPrepare.worktreeRoot)
+        ? require('node:fs').readdirSync(configWithBadPrepare.worktreeRoot)
+        : [];
+      expect(entries.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `LocalWorktreeAdapter` as a local, zero-cost alternative to Sprites for execution environments
- Uses git worktrees for filesystem isolation, git commits for checkpoints, git checkout for restore
- Same `SpritesClientAdapter` interface — `ExecutionEnvManager`, host-tools, and DB tracking work unchanged

## Config
```yaml
localWorktree:
  enabled: true
  worktreeRoot: /tmp/talon-envs
  prepareCommand: npm ci        # optional
  execTimeoutMs: 600000
  autoDestroyOnCompletion: true
```

## Security
- Path containment enforced on all exec cwd, upload, and download operations (rejects `../../` traversal)
- Absolute paths in exec cwd are stripped and resolved relative to worktree
- PrepareCommand failure triggers automatic worktree cleanup

## Changes
- `src/execution-env/local-worktree-adapter.ts` — new adapter (~300 lines)
- `src/core/config/config-schema.ts` — `LocalWorktreeConfigSchema`
- `src/daemon/daemon-bootstrap.ts` — wired alongside Sprites provider
- `src/execution-env/execution-env-types.ts` — `'local'` added to provider union
- DB repository row types widened from `'sprites'` to `ExecutionEnvProvider`

## Test plan
- [x] 17 unit tests: lifecycle, path traversal, orphan recovery, prepareCommand failure
- [x] 53/53 execution-env suite passes (no regressions)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Codex (GPT-5.4) review: all critical/high issues resolved

Closes #183 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)