### PR TITLE
Store schedules on dedicated execution threads, not live chat threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -2027,6 +2027,14 @@ Agents create schedules like:
 
 Scheduled tasks are enqueued through the standard queue pipeline, subject to the same retry and dead-letter policies as regular messages. Cron expressions evaluate in system local time.
 
+### Dedicated Execution Threads
+
+Schedules created by the agent via `schedule_manage` are stored against a dedicated execution thread keyed by `(persona, channel, origin chat)` — not the live chat thread. This keeps scheduled runs from polluting the live conversation's session state, observational-memory log, and session resumption id.
+
+The dedicated thread records the origin chat's `external_id` in metadata (`kind: "schedule"`, `originExternalId: "<chat id>"`). Outbound delivery (`channel_send`, typing indicators) reads that field and routes messages back to the originating chat, so users still receive scheduled notifications on the channel they set the schedule up from.
+
+List / update / cancel / delete remain persona-scoped rather than thread-scoped, so schedules created from the live chat are still fully visible and editable from the live chat thread.
+
 ### Task Prompt Files
 
 Schedules can reference reusable prompt files stored in a persona's `prompts/` directory instead of embedding prompt text inline. This keeps long or complex prompts version-controlled and editable without touching the schedule itself.

--- a/src/core/database/repositories/schedule-repository.ts
+++ b/src/core/database/repositories/schedule-repository.ts
@@ -199,6 +199,31 @@ export class ScheduleRepository extends BaseRepository {
     }
   }
 
+  /**
+   * Rebinds a schedule to a different thread.
+   *
+   * Used by the startup migration to move pre-existing schedules from live
+   * chat threads (or old-style dedicated threads without the metadata
+   * marker) onto the canonical dedicated schedule thread. Not exposed via
+   * schedule.manage — thread re-assignment is an internal concern.
+   */
+  rebindThread(id: string, threadId: string): Result<void, DbError> {
+    try {
+      const stmt = this.db.prepare(
+        `UPDATE schedules SET thread_id = @thread_id, updated_at = @updated_at WHERE id = @id`,
+      );
+      stmt.run({ id, thread_id: threadId, updated_at: this.now() });
+      return ok(undefined);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to rebind schedule thread: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
   /** Enables a schedule. */
   enable(id: string): Result<void, DbError> {
     return this._setEnabled(id, 1);

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -27,6 +27,25 @@ import type { StartedObservationHandle } from '../observability/langfuse/observa
 /** Default maximum time (ms) a provider query (SDK or CLI) may run before being aborted. */
 const DEFAULT_QUERY_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
+/**
+ * Returns the origin chat's external_id recorded in a dedicated schedule
+ * thread's metadata, or null when the thread is not a schedule thread.
+ * Dedicated schedule threads are created by the schedule.manage tool and
+ * carry `{ kind: 'schedule', originExternalId: '<live chat external id>' }`.
+ */
+function readScheduleOriginExternalId(metadataJson: string | null | undefined): string | null {
+  if (!metadataJson) return null;
+  try {
+    const parsed = JSON.parse(metadataJson) as Record<string, unknown>;
+    if (parsed && parsed.kind === 'schedule' && typeof parsed.originExternalId === 'string') {
+      return parsed.originExternalId;
+    }
+  } catch {
+    /* ignore — treat unparseable metadata as absent */
+  }
+  return null;
+}
+
 class AgentQueryAttemptError extends Error {
   constructor(
     message: string,
@@ -350,8 +369,16 @@ export class AgentRunner {
               channelRow && channelRow.isOk() && channelRow.value
                 ? this.ctx.channelRegistry.get(channelRow.value.name)
                 : undefined;
+            // For dedicated schedule execution threads (kind='schedule'),
+            // the thread's own external_id is a synthetic marker, not a
+            // valid provider recipient. Prefer metadata.originExternalId
+            // so typing indicators and any agent-runner-originated
+            // outbound reach the originating chat (issue #200).
             const externalId =
-              threadResult.isOk() && threadResult.value ? threadResult.value.external_id : undefined;
+              threadResult.isOk() && threadResult.value
+                ? (readScheduleOriginExternalId(threadResult.value.metadata)
+                    ?? threadResult.value.external_id)
+                : undefined;
             const channelConfig =
               channelRow?.isOk() && channelRow.value
                 ? this.ctx.config.channels?.find((c) => c.name === channelRow!.value!.name)
@@ -415,9 +442,16 @@ export class AgentRunner {
                     },
                   },
                   async (retrieverObservation) => {
+                    // Exclude the message being processed (if any) from the
+                    // "Recent Messages" block. That message is already passed
+                    // as the live prompt (`content`), and re-echoing it in
+                    // the system prompt made stateless providers respond
+                    // twice — once to the `[previous turn, user]: …` entry
+                    // and once to the prompt itself.
                     const assembled = this.ctx.contextAssembler.assemble(
                       item.threadId,
                       freshSessionRecentMessageCount,
+                      { excludeMessageId: item.messageId },
                     );
                     retrieverObservation.update({
                       output: assembled.text,

--- a/src/daemon/context-assembler.ts
+++ b/src/daemon/context-assembler.ts
@@ -45,10 +45,19 @@ export class ContextAssembler {
    *   way for context to grow toward the rotation threshold is to replay
    *   the full thread history. Once rotation fires and a summary is
    *   written, subsequent turns get summary + last N instead.
+   * @param options.excludeMessageId — optional message id to drop from the
+   *   "Recent Messages" block. The message being processed is already
+   *   passed to the provider as the live prompt; echoing it in the system
+   *   prompt as a `[previous turn, user]: …` entry caused stateless
+   *   providers to respond twice (once to the replay, once to the prompt).
    *
    * Returns a markdown string and metadata for observability.
    */
-  assemble(threadId: string, recentMessageLimit: number): AssembledContext {
+  assemble(
+    threadId: string,
+    recentMessageLimit: number,
+    options: { excludeMessageId?: string } = {},
+  ): AssembledContext {
     const sections: string[] = [];
     let summaryFound = false;
     let recentMessageCount = 0;
@@ -152,9 +161,14 @@ export class ContextAssembler {
           Math.max(recentMessageLimit, PRE_SUMMARY_MESSAGE_CAP),
         );
     if (messagesResult.isOk() && messagesResult.value.length > 0) {
-      const formatted = this.formatMessages(messagesResult.value);
-      sections.push(`### Recent Messages\n\n${formatted}`);
-      recentMessageCount = messagesResult.value.length;
+      const filtered = options.excludeMessageId
+        ? messagesResult.value.filter((m) => m.id !== options.excludeMessageId)
+        : messagesResult.value;
+      if (filtered.length > 0) {
+        const formatted = this.formatMessages(filtered);
+        sections.push(`### Recent Messages\n\n${formatted}`);
+        recentMessageCount = filtered.length;
+      }
     }
 
     if (sections.length === 0) {

--- a/src/daemon/daemon-bootstrap.ts
+++ b/src/daemon/daemon-bootstrap.ts
@@ -42,6 +42,7 @@ import { registerChannels } from '../channels/channel-setup.js';
 import { MessagePipeline } from '../pipeline/message-pipeline.js';
 import { QueueManager } from '../queue/queue-manager.js';
 import { Scheduler } from '../scheduler/scheduler.js';
+import { migrateLegacySchedules } from '../scheduler/legacy-schedule-migration.js';
 import { DaemonError, SubAgentError } from '../core/errors/error-types.js';
 import { AuditLogger } from '../core/logging/audit-logger.js';
 import { RepositoryAuditStore } from '../core/database/repositories/audit-repository.js';
@@ -593,6 +594,16 @@ export async function bootstrap(
   }
 
   // 14. Scheduler
+  // Heal any legacy schedules (pre-dedicated-thread-model, PR #201) before
+  // the scheduler starts ticking so the first fire after upgrade delivers
+  // via the canonical dedicated-thread + origin-external-id path.
+  migrateLegacySchedules({
+    scheduleRepo: repos.schedule,
+    threadRepo: repos.thread,
+    channelRepo: repos.channel,
+    personaRepo: repos.persona,
+    logger,
+  });
   const scheduler = new Scheduler(repos.schedule, queueManager, personaLoader, config.scheduler, logger);
 
   // 15. Message pipeline and channel registration

--- a/src/scheduler/legacy-schedule-migration.ts
+++ b/src/scheduler/legacy-schedule-migration.ts
@@ -1,0 +1,285 @@
+/**
+ * One-shot startup migration for schedules that predate the dedicated
+ * schedule-thread model.
+ *
+ * Three legacy shapes exist in production databases and all three block
+ * outbound delivery from scheduled runs (PR #201, https://github.com/ivo-toby/talon/issues/200):
+ *
+ *  1. Schedule.thread_id points at a live chat thread (pre-issue-#200).
+ *     Execution mixes with the live conversation's session/OM state, but
+ *     delivery still worked because the live thread's external_id is the
+ *     real chat id.
+ *  2. Schedule.thread_id points at an old-style dedicated thread whose
+ *     external_id matches `schedule:<persona>:<channel>...` but whose
+ *     metadata lacks `{ kind: 'schedule', originExternalId: ... }` (the
+ *     partial local fix referenced in #200). channel.send for such runs
+ *     now falls back to the synthetic external_id and the provider
+ *     rejects with "chat not found".
+ *  3. Schedule.thread_id references a thread row that no longer exists.
+ *     Cannot be healed automatically — logged and skipped.
+ *
+ * This module rehydrates metadata on old-style dedicated threads and
+ * rebinds legacy-live-thread schedules onto the canonical dedicated
+ * thread for their (persona, channel, origin) triple, using the same
+ * logic as schedule.manage so all schedules end up in one consistent
+ * shape after startup.
+ *
+ * Safe to run on every boot — already-healed schedules are detected by
+ * the presence of the schedule-metadata marker and skipped.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type pino from 'pino';
+import type { ScheduleRepository } from '../core/database/repositories/schedule-repository.js';
+import type { ThreadRepository } from '../core/database/repositories/thread-repository.js';
+import type { ChannelRepository } from '../core/database/repositories/channel-repository.js';
+import type { PersonaRepository } from '../core/database/repositories/persona-repository.js';
+
+/** Metadata marker shared with schedule-manage.ts. */
+const SCHEDULE_THREAD_KIND = 'schedule';
+
+export interface LegacyScheduleMigrationDeps {
+  scheduleRepo: ScheduleRepository;
+  threadRepo: ThreadRepository;
+  channelRepo: ChannelRepository;
+  personaRepo: PersonaRepository;
+  logger: pino.Logger;
+}
+
+export interface LegacyScheduleMigrationResult {
+  /** Schedules whose dedicated thread was already correctly annotated. */
+  alreadyMigrated: number;
+  /** Old-style dedicated threads that needed metadata rehydration. */
+  metadataRehydrated: number;
+  /** Legacy-live-thread schedules that were rebound onto a dedicated thread. */
+  rebound: number;
+  /** Schedules that could not be healed (missing thread row, missing persona, etc.). */
+  skipped: number;
+}
+
+/**
+ * Checks whether a thread's metadata already carries the schedule marker.
+ * Returns the embedded originExternalId when present, otherwise null.
+ */
+function readMarker(metadataJson: string | null | undefined): string | null {
+  if (!metadataJson) return null;
+  try {
+    const parsed = JSON.parse(metadataJson) as Record<string, unknown>;
+    if (parsed && parsed.kind === SCHEDULE_THREAD_KIND && typeof parsed.originExternalId === 'string') {
+      return parsed.originExternalId;
+    }
+  } catch {
+    /* fall through — treat malformed metadata as absent */
+  }
+  return null;
+}
+
+/**
+ * Parses the origin external_id out of an old-style synthetic
+ * `schedule:<persona>:<channel>:<origin>` external id. Returns null when
+ * the id doesn't match the expected prefix.
+ *
+ * Origin external ids may themselves contain colons (Slack encodes
+ * `<channelId>:<thread_ts>`), so the origin is everything after the
+ * third colon.
+ */
+function parseSyntheticOrigin(externalId: string): string | null {
+  if (!externalId.startsWith('schedule:')) return null;
+  const parts = externalId.split(':');
+  if (parts.length < 4) return null;
+  return parts.slice(3).join(':');
+}
+
+/**
+ * Run the migration over every schedule in the database.
+ *
+ * Idempotent: schedules already on a thread with the correct marker are
+ * a no-op. Safe to invoke on every daemon start.
+ */
+export function migrateLegacySchedules(
+  deps: LegacyScheduleMigrationDeps,
+): LegacyScheduleMigrationResult {
+  const { scheduleRepo, threadRepo, channelRepo, personaRepo, logger } = deps;
+  const result: LegacyScheduleMigrationResult = {
+    alreadyMigrated: 0,
+    metadataRehydrated: 0,
+    rebound: 0,
+    skipped: 0,
+  };
+
+  const schedulesResult = scheduleRepo.findAll();
+  if (schedulesResult.isErr()) {
+    logger.error({ err: schedulesResult.error }, 'schedule-migration: failed to list schedules, skipping');
+    return result;
+  }
+
+  for (const schedule of schedulesResult.value) {
+    if (schedule.thread_id === null) {
+      // Nothing to heal — the scheduler already refuses to dispatch
+      // schedules with a null thread_id.
+      result.skipped += 1;
+      continue;
+    }
+
+    const threadResult = threadRepo.findById(schedule.thread_id);
+    if (threadResult.isErr()) {
+      logger.warn(
+        { scheduleId: schedule.id, threadId: schedule.thread_id, err: threadResult.error },
+        'schedule-migration: failed to load thread, skipping',
+      );
+      result.skipped += 1;
+      continue;
+    }
+    const thread = threadResult.value;
+    if (!thread) {
+      logger.warn(
+        { scheduleId: schedule.id, threadId: schedule.thread_id },
+        'schedule-migration: thread referenced by schedule is missing — cannot heal automatically',
+      );
+      result.skipped += 1;
+      continue;
+    }
+
+    // Case A — already migrated.
+    if (readMarker(thread.metadata) !== null) {
+      result.alreadyMigrated += 1;
+      continue;
+    }
+
+    // Case B — old-style dedicated thread whose metadata was never written.
+    // Recover the origin from the synthetic external_id and rehydrate
+    // metadata in place. No rebind needed: the schedule is already on the
+    // right thread, only the marker is missing.
+    const syntheticOrigin = parseSyntheticOrigin(thread.external_id);
+    if (syntheticOrigin !== null) {
+      const personaResult = personaRepo.findById(schedule.persona_id);
+      const channelResult = channelRepo.findById(thread.channel_id);
+      const metadata = JSON.stringify({
+        kind: SCHEDULE_THREAD_KIND,
+        originExternalId: syntheticOrigin,
+        personaName:
+          personaResult.isOk() && personaResult.value ? personaResult.value.name : undefined,
+        channelName:
+          channelResult.isOk() && channelResult.value ? channelResult.value.name : undefined,
+        migratedFrom: 'legacy-dedicated-thread-without-marker',
+      });
+      const updateResult = threadRepo.update(thread.id, { metadata });
+      if (updateResult.isErr()) {
+        logger.warn(
+          { scheduleId: schedule.id, threadId: thread.id, err: updateResult.error },
+          'schedule-migration: failed to rehydrate thread metadata, skipping',
+        );
+        result.skipped += 1;
+        continue;
+      }
+      logger.info(
+        {
+          scheduleId: schedule.id,
+          threadId: thread.id,
+          originExternalId: syntheticOrigin,
+        },
+        'schedule-migration: rehydrated metadata on legacy dedicated schedule thread',
+      );
+      result.metadataRehydrated += 1;
+      continue;
+    }
+
+    // Case C — schedule stored on a live chat thread (pre-issue-#200).
+    // Provision or reuse the canonical dedicated schedule thread and
+    // rebind the schedule onto it. The live thread's external_id is a
+    // real provider recipient, so we capture it as the originExternalId.
+    const personaResult = personaRepo.findById(schedule.persona_id);
+    if (personaResult.isErr() || !personaResult.value) {
+      logger.warn(
+        { scheduleId: schedule.id, personaId: schedule.persona_id },
+        'schedule-migration: persona not found, skipping',
+      );
+      result.skipped += 1;
+      continue;
+    }
+    const channelResult = channelRepo.findById(thread.channel_id);
+    if (channelResult.isErr() || !channelResult.value) {
+      logger.warn(
+        { scheduleId: schedule.id, channelId: thread.channel_id },
+        'schedule-migration: channel not found, skipping',
+      );
+      result.skipped += 1;
+      continue;
+    }
+    const personaName = personaResult.value.name;
+    const channelName = channelResult.value.name;
+    const originExternalId = thread.external_id;
+    const dedicatedExternalId = `schedule:${personaName}:${channelName}:${originExternalId}`;
+
+    const existing = threadRepo.findByExternalId(thread.channel_id, dedicatedExternalId);
+    if (existing.isErr()) {
+      logger.warn(
+        { scheduleId: schedule.id, dedicatedExternalId, err: existing.error },
+        'schedule-migration: failed to look up dedicated thread, skipping',
+      );
+      result.skipped += 1;
+      continue;
+    }
+
+    let dedicatedThreadId: string;
+    if (existing.value) {
+      dedicatedThreadId = existing.value.id;
+    } else {
+      dedicatedThreadId = uuidv4();
+      const metadata = JSON.stringify({
+        kind: SCHEDULE_THREAD_KIND,
+        originExternalId,
+        personaName,
+        channelName,
+        migratedFrom: 'legacy-live-thread',
+      });
+      const insertResult = threadRepo.insert({
+        id: dedicatedThreadId,
+        channel_id: thread.channel_id,
+        external_id: dedicatedExternalId,
+        metadata,
+      });
+      if (insertResult.isErr()) {
+        // Race: another migration step or schedule.manage already inserted
+        // the same dedicated thread. Re-query and reuse.
+        const retry = threadRepo.findByExternalId(thread.channel_id, dedicatedExternalId);
+        if (retry.isOk() && retry.value) {
+          dedicatedThreadId = retry.value.id;
+        } else {
+          logger.warn(
+            { scheduleId: schedule.id, dedicatedExternalId, err: insertResult.error },
+            'schedule-migration: failed to create dedicated thread, skipping',
+          );
+          result.skipped += 1;
+          continue;
+        }
+      }
+    }
+
+    const rebindResult = scheduleRepo.rebindThread(schedule.id, dedicatedThreadId);
+    if (rebindResult.isErr()) {
+      logger.warn(
+        { scheduleId: schedule.id, dedicatedThreadId, err: rebindResult.error },
+        'schedule-migration: failed to rebind schedule to dedicated thread, skipping',
+      );
+      result.skipped += 1;
+      continue;
+    }
+
+    logger.info(
+      {
+        scheduleId: schedule.id,
+        oldThreadId: schedule.thread_id,
+        newThreadId: dedicatedThreadId,
+        personaName,
+        channelName,
+        originExternalId,
+      },
+      'schedule-migration: rebound legacy live-thread schedule onto dedicated schedule thread',
+    );
+    result.rebound += 1;
+  }
+
+  logger.info(result, 'schedule-migration: complete');
+  return result;
+}

--- a/src/tools/host-tools-bridge.ts
+++ b/src/tools/host-tools-bridge.ts
@@ -69,6 +69,9 @@ export class HostToolsBridge {
 
     this.scheduleHandler = new ScheduleManageHandler({
       scheduleRepository: ctx.repos.schedule,
+      threadRepository: ctx.repos.thread,
+      channelRepository: ctx.repos.channel,
+      personaRepository: ctx.repos.persona,
       logger: ctx.logger,
     });
 

--- a/src/tools/host-tools/channel-send.ts
+++ b/src/tools/host-tools/channel-send.ts
@@ -134,11 +134,25 @@ export class ChannelSendHandler {
     // external_id in metadata.originExternalId — prefer that so scheduled
     // runs notify the originating user rather than the synthetic schedule
     // thread id, which is not a valid provider-side recipient.
+    //
+    // Fail loud when the thread row is missing or unreadable: falling back
+    // to context.threadId (a UUID) produced 400 "chat not found" errors
+    // that the agent paraphrased as "Telegram unreachable — delivering
+    // inline", silently swallowing scheduled notifications (observed in
+    // PR #201 production rollout).
     const threadResult = this.deps.threadRepository.findById(context.threadId);
+    if (threadResult.isErr()) {
+      const msg = `channel.send: failed to resolve thread "${context.threadId}" — ${threadResult.error.message}`;
+      this.deps.logger.error({ requestId, threadId: context.threadId, err: threadResult.error }, msg);
+      return { requestId, tool: 'channel.send', status: 'error', error: msg };
+    }
+    if (!threadResult.value) {
+      const msg = `channel.send: thread "${context.threadId}" not found — cannot resolve recipient`;
+      this.deps.logger.error({ requestId, threadId: context.threadId, channelId }, msg);
+      return { requestId, tool: 'channel.send', status: 'error', error: msg };
+    }
     const externalThreadId =
-      threadResult.isOk() && threadResult.value
-        ? (readOriginExternalId(threadResult.value.metadata) ?? threadResult.value.external_id)
-        : context.threadId;
+      readOriginExternalId(threadResult.value.metadata) ?? threadResult.value.external_id;
 
     const result = await connector.send(externalThreadId, output);
 

--- a/src/tools/host-tools/channel-send.ts
+++ b/src/tools/host-tools/channel-send.ts
@@ -12,6 +12,25 @@ import type { ChannelRegistry } from '../../channels/channel-registry.js';
 import type { ThreadRepository } from '../../core/database/repositories/thread-repository.js';
 import { ToolError } from '../../core/errors/error-types.js';
 
+/**
+ * Returns the origin chat's external_id recorded in a dedicated schedule
+ * thread's metadata, or null if the thread is not a schedule thread or the
+ * metadata is malformed. Dedicated schedule threads are created by
+ * schedule.manage and carry `{ kind: 'schedule', originExternalId: ... }`.
+ */
+function readOriginExternalId(metadataJson: string | null | undefined): string | null {
+  if (!metadataJson) return null;
+  try {
+    const parsed = JSON.parse(metadataJson) as Record<string, unknown>;
+    if (parsed && parsed.kind === 'schedule' && typeof parsed.originExternalId === 'string') {
+      return parsed.originExternalId;
+    }
+  } catch {
+    /* ignore — treat unparseable metadata as absent */
+  }
+  return null;
+}
+
 /** Manifest for the channel.send host tool. */
 export interface ChannelSendTool {
   readonly manifest: ToolManifest;
@@ -111,10 +130,14 @@ export class ChannelSendHandler {
     };
 
     // Resolve the thread's external_id (e.g. Telegram chat_id) from the DB.
+    // Dedicated schedule execution threads store the originating chat's
+    // external_id in metadata.originExternalId — prefer that so scheduled
+    // runs notify the originating user rather than the synthetic schedule
+    // thread id, which is not a valid provider-side recipient.
     const threadResult = this.deps.threadRepository.findById(context.threadId);
     const externalThreadId =
       threadResult.isOk() && threadResult.value
-        ? threadResult.value.external_id
+        ? (readOriginExternalId(threadResult.value.metadata) ?? threadResult.value.external_id)
         : context.threadId;
 
     const result = await connector.send(externalThreadId, output);

--- a/src/tools/host-tools/schedule-manage.ts
+++ b/src/tools/host-tools/schedule-manage.ts
@@ -55,6 +55,26 @@ const CRON_PATTERN = /^(\S+\s+){4}\S+$/;
 const SCHEDULE_THREAD_KIND = 'schedule';
 
 /**
+ * Returns the origin chat's external_id stored in a dedicated schedule
+ * thread's metadata, or null when the thread is not a schedule thread.
+ * Used by handleCreate to unwrap nested schedule-thread invocations so
+ * a schedule created from a schedule run still chains back to the real
+ * live chat, not to another synthetic id.
+ */
+function readOriginExternalIdFromMetadata(metadataJson: string | null | undefined): string | null {
+  if (!metadataJson) return null;
+  try {
+    const parsed = JSON.parse(metadataJson) as Record<string, unknown>;
+    if (parsed && parsed.kind === SCHEDULE_THREAD_KIND && typeof parsed.originExternalId === 'string') {
+      return parsed.originExternalId;
+    }
+  } catch {
+    /* ignore — treat unparseable metadata as absent */
+  }
+  return null;
+}
+
+/**
  * Handler class for the schedule.manage host tool.
  *
  * Creates, updates, or cancels scheduled tasks via the ScheduleRepository.
@@ -210,11 +230,21 @@ export class ScheduleManageHandler {
       return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
     }
 
+    // If this tool is invoked from an already-dedicated schedule thread
+    // (e.g. a scheduled run itself creating follow-up schedules), the
+    // invoking thread's external_id is the synthetic `schedule:...` id
+    // — not a provider-valid recipient. Unwrap it from thread metadata
+    // so the new schedule chains back to the real live chat instead of
+    // building a second-level synthetic origin that outbound routing
+    // cannot resolve.
+    const originExternalId =
+      readOriginExternalIdFromMetadata(originThread.metadata) ?? originThread.external_id;
+
     const dedicatedThreadResult = this.resolveDedicatedThread({
       channelId: channelRow.id,
       channelName: channelRow.name,
       personaName: personaRow.name,
-      originExternalId: originThread.external_id,
+      originExternalId,
       requestId,
     });
     if (dedicatedThreadResult.isErr()) {
@@ -583,6 +613,17 @@ export class ScheduleManageHandler {
       metadata,
     });
     if (insertResult.isErr()) {
+      // UNIQUE(channel_id, external_id) race: a concurrent create may have
+      // just inserted the same dedicated thread. Re-query before bailing —
+      // schedule creation should succeed regardless of who won the race.
+      const retry = this.deps.threadRepository.findByExternalId(channelId, dedicatedExternalId);
+      if (retry.isOk() && retry.value) {
+        this.deps.logger.info(
+          { requestId, channelId, dedicatedExternalId, threadId: retry.value.id },
+          'schedule.manage: dedicated schedule thread materialised by concurrent create, reusing',
+        );
+        return ok(retry.value.id);
+      }
       const msg = `schedule.manage: failed to create dedicated schedule thread — ${insertResult.error.message}`;
       this.deps.logger.error({ requestId, channelId, dedicatedExternalId, err: insertResult.error }, msg);
       return err(new ToolError(msg));

--- a/src/tools/host-tools/schedule-manage.ts
+++ b/src/tools/host-tools/schedule-manage.ts
@@ -10,6 +10,9 @@ import { ok, err, type Result } from 'neverthrow';
 import { v4 as uuidv4 } from 'uuid';
 import type { ToolManifest, ToolCallResult } from '../tool-types.js';
 import type { ScheduleRepository } from '../../core/database/repositories/schedule-repository.js';
+import type { ThreadRepository } from '../../core/database/repositories/thread-repository.js';
+import type { ChannelRepository } from '../../core/database/repositories/channel-repository.js';
+import type { PersonaRepository } from '../../core/database/repositories/persona-repository.js';
 import { ToolError } from '../../core/errors/error-types.js';
 import { getNextCronTime } from '../../scheduler/cron-evaluator.js';
 import type { SchedulePayload } from '../../scheduler/schedule-types.js';
@@ -48,11 +51,18 @@ const VALID_ACTIONS = new Set(['create', 'update', 'cancel', 'delete', 'list']);
  */
 const CRON_PATTERN = /^(\S+\s+){4}\S+$/;
 
+/** Metadata marker applied to dedicated schedule execution threads. */
+const SCHEDULE_THREAD_KIND = 'schedule';
+
 /**
  * Handler class for the schedule.manage host tool.
  *
  * Creates, updates, or cancels scheduled tasks via the ScheduleRepository.
- * Schedules are owned by the persona and scoped to the current thread.
+ * Schedules are owned by the persona. On create, the schedule is stored on
+ * a dedicated per-(persona, channel, origin-chat) thread so scheduled runs
+ * do not pollute the live conversation session — but listing/updating/
+ * cancelling/deleting remain persona-scoped so those operations are visible
+ * from the live thread that invoked the tool.
  */
 export class ScheduleManageHandler {
   /** Static manifest describing the tool. */
@@ -67,6 +77,9 @@ export class ScheduleManageHandler {
   constructor(
     private readonly deps: {
       scheduleRepository: ScheduleRepository;
+      threadRepository: ThreadRepository;
+      channelRepository: ChannelRepository;
+      personaRepository: PersonaRepository;
       logger: pino.Logger;
     },
   ) {}
@@ -120,7 +133,7 @@ export class ScheduleManageHandler {
     }
   }
 
-  /** Handle the 'create' action — insert a new schedule. */
+  /** Handle the 'create' action — insert a new schedule on a dedicated execution thread. */
   private handleCreate(
     args: ScheduleManageArgs,
     context: ToolExecutionContext,
@@ -153,6 +166,67 @@ export class ScheduleManageHandler {
       };
     }
 
+    // Resolve the invoking thread + its channel so the schedule can be
+    // stored on a dedicated execution thread rather than polluting the
+    // live conversation session. The origin thread's external_id is
+    // captured in the dedicated thread's metadata so scheduled runs can
+    // still deliver notifications back to the originating chat.
+    const threadResult = this.deps.threadRepository.findById(context.threadId);
+    if (threadResult.isErr()) {
+      const msg = `schedule.manage: failed to load invoking thread — ${threadResult.error.message}`;
+      this.deps.logger.error({ requestId, threadId: context.threadId, err: threadResult.error }, msg);
+      return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
+    }
+    const originThread = threadResult.value;
+    if (!originThread) {
+      const msg = `schedule.manage: invoking thread "${context.threadId}" not found`;
+      this.deps.logger.warn({ requestId, threadId: context.threadId }, msg);
+      return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
+    }
+
+    const channelResult = this.deps.channelRepository.findById(originThread.channel_id);
+    if (channelResult.isErr()) {
+      const msg = `schedule.manage: failed to load channel — ${channelResult.error.message}`;
+      this.deps.logger.error({ requestId, channelId: originThread.channel_id, err: channelResult.error }, msg);
+      return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
+    }
+    const channelRow = channelResult.value;
+    if (!channelRow) {
+      const msg = `schedule.manage: channel "${originThread.channel_id}" not found`;
+      this.deps.logger.warn({ requestId, channelId: originThread.channel_id }, msg);
+      return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
+    }
+
+    const personaResult = this.deps.personaRepository.findById(context.personaId);
+    if (personaResult.isErr()) {
+      const msg = `schedule.manage: failed to load persona — ${personaResult.error.message}`;
+      this.deps.logger.error({ requestId, personaId: context.personaId, err: personaResult.error }, msg);
+      return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
+    }
+    const personaRow = personaResult.value;
+    if (!personaRow) {
+      const msg = `schedule.manage: persona "${context.personaId}" not found`;
+      this.deps.logger.warn({ requestId, personaId: context.personaId }, msg);
+      return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
+    }
+
+    const dedicatedThreadResult = this.resolveDedicatedThread({
+      channelId: channelRow.id,
+      channelName: channelRow.name,
+      personaName: personaRow.name,
+      originExternalId: originThread.external_id,
+      requestId,
+    });
+    if (dedicatedThreadResult.isErr()) {
+      return {
+        requestId,
+        tool: 'schedule.manage',
+        status: 'error',
+        error: dedicatedThreadResult.error.message,
+      };
+    }
+    const dedicatedThreadId = dedicatedThreadResult.value;
+
     const scheduleId = uuidv4();
     const payload = JSON.stringify(payloadResult.value);
 
@@ -168,7 +242,7 @@ export class ScheduleManageHandler {
     const insertResult = this.deps.scheduleRepository.insert({
       id: scheduleId,
       persona_id: context.personaId,
-      thread_id: context.threadId,
+      thread_id: dedicatedThreadId,
       type: 'cron',
       expression: cronExpr.trim(),
       payload,
@@ -184,8 +258,16 @@ export class ScheduleManageHandler {
     }
 
     this.deps.logger.info(
-      { requestId, scheduleId, personaId: context.personaId },
-      'schedule.manage: schedule created',
+      {
+        requestId,
+        scheduleId,
+        personaId: context.personaId,
+        personaName: personaRow.name,
+        channelName: channelRow.name,
+        originThreadId: context.threadId,
+        dedicatedThreadId,
+      },
+      'schedule.manage: schedule created on dedicated execution thread',
     );
 
     return {
@@ -245,6 +327,9 @@ export class ScheduleManageHandler {
         return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
       }
 
+      // Ownership check by persona — NOT by invoking thread. A schedule
+      // created on a dedicated execution thread must still be editable
+      // from the live chat thread that owns the persona.
       if (existingSchedule.value.persona_id !== context.personaId) {
         const msg = `schedule.manage: schedule "${scheduleId}" does not belong to this persona`;
         this.deps.logger.warn({ requestId, scheduleId, personaId: context.personaId }, msg);
@@ -319,6 +404,25 @@ export class ScheduleManageHandler {
       return { requestId, tool: 'schedule.manage', status: 'error', error: error.message };
     }
 
+    // Persona-ownership check: cancel must work from any invoking thread
+    // that owns the persona, not only the dedicated schedule thread.
+    const existing = this.deps.scheduleRepository.findById(scheduleId);
+    if (existing.isErr()) {
+      const msg = `schedule.manage: failed to load schedule — ${existing.error.message}`;
+      this.deps.logger.error({ requestId, scheduleId, err: existing.error }, msg);
+      return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
+    }
+    if (!existing.value) {
+      const msg = `schedule.manage: schedule "${scheduleId}" not found`;
+      this.deps.logger.warn({ requestId, scheduleId }, msg);
+      return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
+    }
+    if (existing.value.persona_id !== context.personaId) {
+      const msg = `schedule.manage: schedule "${scheduleId}" does not belong to this persona`;
+      this.deps.logger.warn({ requestId, scheduleId, personaId: context.personaId }, msg);
+      return { requestId, tool: 'schedule.manage', status: 'error', error: msg };
+    }
+
     const disableResult = this.deps.scheduleRepository.disable(scheduleId);
     if (disableResult.isErr()) {
       const msg = `schedule.manage: cancel failed — ${disableResult.error.message}`;
@@ -379,7 +483,13 @@ export class ScheduleManageHandler {
     };
   }
 
-  /** Handle the 'list' action — return all schedules for the persona. */
+  /**
+   * Handle the 'list' action — return all schedules for the persona.
+   *
+   * Returns every schedule owned by the invoking persona regardless of which
+   * thread (live or dedicated) it is stored against. This keeps schedules
+   * visible from the live chat that will normally be used to inspect them.
+   */
   private handleList(context: ToolExecutionContext, requestId: string): ToolCallResult {
     const result = this.deps.scheduleRepository.findByPersona(context.personaId);
     if (result.isErr()) {
@@ -428,6 +538,56 @@ export class ScheduleManageHandler {
       status: 'success',
       result: { schedules, count: schedules.length },
     };
+  }
+
+  /**
+   * Resolve (find or create) the dedicated execution thread for a schedule.
+   *
+   * Dedicated threads are keyed by `schedule:<persona>:<channel>:<origin>` so
+   * each originating chat has its own execution container. Scheduled runs
+   * therefore do not overwrite live-conversation session state, while the
+   * origin chat's external_id is persisted in the thread metadata so outbound
+   * notifications can still be routed back to the user.
+   */
+  private resolveDedicatedThread(input: {
+    channelId: string;
+    channelName: string;
+    personaName: string;
+    originExternalId: string;
+    requestId: string;
+  }): Result<string, ToolError> {
+    const { channelId, channelName, personaName, originExternalId, requestId } = input;
+    const dedicatedExternalId = `schedule:${personaName}:${channelName}:${originExternalId}`;
+
+    const existing = this.deps.threadRepository.findByExternalId(channelId, dedicatedExternalId);
+    if (existing.isErr()) {
+      const msg = `schedule.manage: failed to look up dedicated schedule thread — ${existing.error.message}`;
+      this.deps.logger.error({ requestId, channelId, dedicatedExternalId, err: existing.error }, msg);
+      return err(new ToolError(msg));
+    }
+    if (existing.value) {
+      return ok(existing.value.id);
+    }
+
+    const dedicatedThreadId = uuidv4();
+    const metadata = JSON.stringify({
+      kind: SCHEDULE_THREAD_KIND,
+      originExternalId,
+      personaName,
+      channelName,
+    });
+    const insertResult = this.deps.threadRepository.insert({
+      id: dedicatedThreadId,
+      channel_id: channelId,
+      external_id: dedicatedExternalId,
+      metadata,
+    });
+    if (insertResult.isErr()) {
+      const msg = `schedule.manage: failed to create dedicated schedule thread — ${insertResult.error.message}`;
+      this.deps.logger.error({ requestId, channelId, dedicatedExternalId, err: insertResult.error }, msg);
+      return err(new ToolError(msg));
+    }
+    return ok(dedicatedThreadId);
   }
 
   private buildSchedulePayload(

--- a/tests/unit/daemon/agent-runner.test.ts
+++ b/tests/unit/daemon/agent-runner.test.ts
@@ -570,7 +570,11 @@ describe('AgentRunner', () => {
     it('uses the selected provider recentMessageCount when assembling fresh-session context', async () => {
       await runner.run(makeQueueItem());
 
-      expect(ctx.contextAssembler.assemble).toHaveBeenCalledWith('thread-001', 10);
+      expect(ctx.contextAssembler.assemble).toHaveBeenCalledWith(
+        'thread-001',
+        10,
+        expect.any(Object),
+      );
     });
 
     it('passes the configured cache-read trigger metric into the roller', async () => {

--- a/tests/unit/daemon/context-assembler.test.ts
+++ b/tests/unit/daemon/context-assembler.test.ts
@@ -56,8 +56,8 @@ describe('ContextAssembler', () => {
     const deps = makeDeps({
       messageRepo: {
         findLatestByThread: vi.fn().mockReturnValue(ok([
-          { direction: 'inbound', content: JSON.stringify({ body: 'how is the deploy going?' }) },
-          { direction: 'outbound', content: JSON.stringify({ body: 'All green, deployed 5 minutes ago.' }) },
+          { id: 'msg-a', direction: 'inbound', content: JSON.stringify({ body: 'how is the deploy going?' }) },
+          { id: 'msg-b', direction: 'outbound', content: JSON.stringify({ body: 'All green, deployed 5 minutes ago.' }) },
         ])),
         findLatestByThreadSince: vi.fn().mockReturnValue(ok([])),
       } as any,
@@ -459,5 +459,47 @@ describe('ContextAssembler', () => {
     const result = assembler.assemble('thread-1', 10);
     expect(result.recentMessageCount).toBe(1);
     expect(result.text).toContain('[previous turn, user]: plain text');
+  });
+
+  it('excludes the current inbound message from Recent Messages when excludeMessageId is provided', () => {
+    // The message being processed is already passed to the provider as the
+    // live prompt; echoing it in the system prompt as a `[previous turn, user]`
+    // entry caused stateless providers to respond twice — once to the replay,
+    // once to the prompt itself. The agent runner now passes the processed
+    // message id so the assembler drops it.
+    const deps = makeDeps({
+      messageRepo: {
+        findLatestByThread: vi.fn().mockReturnValue(ok([
+          { id: 'msg-prev', direction: 'inbound', content: JSON.stringify({ body: 'prior turn' }) },
+          { id: 'msg-current', direction: 'inbound', content: JSON.stringify({ body: 'current question' }) },
+        ])),
+        findLatestByThreadSince: vi.fn().mockReturnValue(ok([])),
+      } as any,
+    });
+
+    const assembler = new ContextAssembler(deps);
+    const result = assembler.assemble('thread-1', 10, { excludeMessageId: 'msg-current' });
+
+    expect(result.recentMessageCount).toBe(1);
+    expect(result.text).toContain('[previous turn, user]: prior turn');
+    expect(result.text).not.toContain('current question');
+  });
+
+  it('suppresses the Recent Messages block entirely when excluding the only message', () => {
+    const deps = makeDeps({
+      messageRepo: {
+        findLatestByThread: vi.fn().mockReturnValue(ok([
+          { id: 'msg-current', direction: 'inbound', content: JSON.stringify({ body: 'only message' }) },
+        ])),
+        findLatestByThreadSince: vi.fn().mockReturnValue(ok([])),
+      } as any,
+    });
+
+    const assembler = new ContextAssembler(deps);
+    const result = assembler.assemble('thread-1', 10, { excludeMessageId: 'msg-current' });
+
+    expect(result.recentMessageCount).toBe(0);
+    expect(result.text).not.toContain('Recent Messages');
+    expect(result.text).not.toContain('only message');
   });
 });

--- a/tests/unit/daemon/daemon-bootstrap.test.ts
+++ b/tests/unit/daemon/daemon-bootstrap.test.ts
@@ -35,7 +35,11 @@ vi.mock('../../../src/core/database/repositories/index.js', () => ({
   BackgroundTaskRepository: vi.fn().mockImplementation(() => ({})),
   ExecutionEnvRepository: vi.fn().mockImplementation(() => ({})),
   ExecutionEnvCheckpointRepository: vi.fn().mockImplementation(() => ({})),
-  ScheduleRepository: vi.fn().mockImplementation(() => ({})),
+  ScheduleRepository: vi.fn().mockImplementation(() => ({
+    // Bootstrap now invokes migrateLegacySchedules() before the scheduler
+    // starts ticking; mock findAll() so the mocked repo satisfies it.
+    findAll: vi.fn().mockReturnValue({ isErr: () => true, isOk: () => false, error: new Error('mock: migration skipped') }),
+  })),
   AuditRepository: vi.fn().mockImplementation(() => ({})),
   MessageRepository: vi.fn().mockImplementation(() => ({})),
   RunRepository: vi.fn().mockImplementation(() => ({})),

--- a/tests/unit/scheduler/legacy-schedule-migration.test.ts
+++ b/tests/unit/scheduler/legacy-schedule-migration.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Unit tests for the legacy schedule migration.
+ *
+ * Uses real in-memory SQLite + real repositories (via helpers.ts) so the
+ * migration exercises the actual row shapes and FK constraints it would
+ * see in production.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import { ScheduleRepository } from '../../../src/core/database/repositories/schedule-repository.js';
+import { ThreadRepository } from '../../../src/core/database/repositories/thread-repository.js';
+import { ChannelRepository } from '../../../src/core/database/repositories/channel-repository.js';
+import { PersonaRepository } from '../../../src/core/database/repositories/persona-repository.js';
+import { migrateLegacySchedules } from '../../../src/scheduler/legacy-schedule-migration.js';
+import { createTestDb, createTestLogger, seedPersona } from './helpers.js';
+
+interface Seeded {
+  channelId: string;
+  liveThreadId: string;
+  liveExternalId: string;
+  personaId: string;
+  personaName: string;
+  channelName: string;
+}
+
+function seedChannelAndLiveThread(db: ReturnType<typeof createTestDb>, liveExternalId = '74575531'): Seeded {
+  const channels = new ChannelRepository(db);
+  const threads = new ThreadRepository(db);
+  const personas = new PersonaRepository(db);
+
+  const channelId = uuidv4();
+  const channelName = `ch-${uuidv4()}`;
+  channels.insert({
+    id: channelId,
+    type: 'telegram',
+    name: channelName,
+    config: '{}',
+    credentials_ref: null,
+    enabled: 1,
+  });
+
+  const liveThreadId = uuidv4();
+  threads.insert({
+    id: liveThreadId,
+    channel_id: channelId,
+    external_id: liveExternalId,
+    metadata: JSON.stringify({ providerAffinityResetAt: null }),
+  });
+
+  const personaId = uuidv4();
+  const personaName = `persona-${uuidv4()}`;
+  personas.insert({
+    id: personaId,
+    name: personaName,
+    model: 'claude-sonnet-4-6',
+    system_prompt_file: null,
+    skills: '[]',
+    capabilities: '{}',
+    mounts: '[]',
+    max_concurrent: null,
+  });
+
+  return {
+    channelId,
+    liveThreadId,
+    liveExternalId,
+    personaId,
+    personaName,
+    channelName,
+  };
+}
+
+function seedSchedule(
+  db: ReturnType<typeof createTestDb>,
+  personaId: string,
+  threadId: string,
+  overrides: { payload?: string; expression?: string } = {},
+): string {
+  const repo = new ScheduleRepository(db);
+  const id = uuidv4();
+  repo.insert({
+    id,
+    persona_id: personaId,
+    thread_id: threadId,
+    type: 'cron',
+    expression: overrides.expression ?? '0 9 * * *',
+    payload: overrides.payload ?? '{"label":"legacy","prompt":"ping"}',
+    enabled: 1,
+    last_run_at: null,
+    next_run_at: Date.now() + 60_000,
+  });
+  return id;
+}
+
+describe('migrateLegacySchedules', () => {
+  it('rebinds schedules stored on a live chat thread onto a dedicated schedule thread', () => {
+    const db = createTestDb();
+    const seeded = seedChannelAndLiveThread(db);
+    const scheduleId = seedSchedule(db, seeded.personaId, seeded.liveThreadId);
+
+    const threads = new ThreadRepository(db);
+    const result = migrateLegacySchedules({
+      scheduleRepo: new ScheduleRepository(db),
+      threadRepo: threads,
+      channelRepo: new ChannelRepository(db),
+      personaRepo: new PersonaRepository(db),
+      logger: createTestLogger(),
+    });
+
+    expect(result.rebound).toBe(1);
+    expect(result.metadataRehydrated).toBe(0);
+    expect(result.alreadyMigrated).toBe(0);
+    expect(result.skipped).toBe(0);
+
+    // Schedule now points at a dedicated thread whose external_id encodes
+    // persona:channel:origin AND whose metadata carries the origin marker.
+    const schedRow = new ScheduleRepository(db).findById(scheduleId);
+    expect(schedRow.isOk()).toBe(true);
+    const newThreadId = schedRow._unsafeUnwrap()!.thread_id!;
+    expect(newThreadId).not.toBe(seeded.liveThreadId);
+
+    const dedicated = threads.findById(newThreadId);
+    const dedicatedRow = dedicated._unsafeUnwrap()!;
+    expect(dedicatedRow.external_id).toBe(
+      `schedule:${seeded.personaName}:${seeded.channelName}:${seeded.liveExternalId}`,
+    );
+    const meta = JSON.parse(dedicatedRow.metadata) as Record<string, unknown>;
+    expect(meta.kind).toBe('schedule');
+    expect(meta.originExternalId).toBe(seeded.liveExternalId);
+    expect(meta.migratedFrom).toBe('legacy-live-thread');
+  });
+
+  it('rehydrates metadata on old-style dedicated threads whose marker was never written', () => {
+    const db = createTestDb();
+    const seeded = seedChannelAndLiveThread(db);
+    const threads = new ThreadRepository(db);
+
+    // Old-style dedicated thread: correct external_id shape but metadata
+    // never carried the { kind: 'schedule', ... } marker (the partial local
+    // fix referenced in issue #200).
+    const oldStyleId = uuidv4();
+    threads.insert({
+      id: oldStyleId,
+      channel_id: seeded.channelId,
+      external_id: `schedule:${seeded.personaName}:${seeded.channelName}:${seeded.liveExternalId}`,
+      metadata: '{}',
+    });
+    const scheduleId = seedSchedule(db, seeded.personaId, oldStyleId);
+
+    const result = migrateLegacySchedules({
+      scheduleRepo: new ScheduleRepository(db),
+      threadRepo: threads,
+      channelRepo: new ChannelRepository(db),
+      personaRepo: new PersonaRepository(db),
+      logger: createTestLogger(),
+    });
+
+    expect(result.metadataRehydrated).toBe(1);
+    expect(result.rebound).toBe(0);
+
+    // Schedule.thread_id is unchanged — only the thread's metadata gained
+    // the marker.
+    const schedRow = new ScheduleRepository(db).findById(scheduleId);
+    expect(schedRow._unsafeUnwrap()!.thread_id).toBe(oldStyleId);
+
+    const dedicated = threads.findById(oldStyleId);
+    const meta = JSON.parse(dedicated._unsafeUnwrap()!.metadata) as Record<string, unknown>;
+    expect(meta.kind).toBe('schedule');
+    expect(meta.originExternalId).toBe(seeded.liveExternalId);
+    expect(meta.migratedFrom).toBe('legacy-dedicated-thread-without-marker');
+  });
+
+  it('is idempotent on schedules already on a properly-marked dedicated thread', () => {
+    const db = createTestDb();
+    const seeded = seedChannelAndLiveThread(db);
+    const threads = new ThreadRepository(db);
+
+    const dedicatedId = uuidv4();
+    threads.insert({
+      id: dedicatedId,
+      channel_id: seeded.channelId,
+      external_id: `schedule:${seeded.personaName}:${seeded.channelName}:${seeded.liveExternalId}`,
+      metadata: JSON.stringify({
+        kind: 'schedule',
+        originExternalId: seeded.liveExternalId,
+        personaName: seeded.personaName,
+        channelName: seeded.channelName,
+      }),
+    });
+    seedSchedule(db, seeded.personaId, dedicatedId);
+
+    const result = migrateLegacySchedules({
+      scheduleRepo: new ScheduleRepository(db),
+      threadRepo: threads,
+      channelRepo: new ChannelRepository(db),
+      personaRepo: new PersonaRepository(db),
+      logger: createTestLogger(),
+    });
+
+    expect(result.alreadyMigrated).toBe(1);
+    expect(result.rebound).toBe(0);
+    expect(result.metadataRehydrated).toBe(0);
+    expect(result.skipped).toBe(0);
+  });
+
+  it('reuses an existing dedicated thread rather than creating a duplicate on rebind', () => {
+    const db = createTestDb();
+    const seeded = seedChannelAndLiveThread(db);
+    const threads = new ThreadRepository(db);
+
+    // A canonical dedicated thread already exists (e.g. schedule.manage ran
+    // once after the upgrade).
+    const canonicalId = uuidv4();
+    threads.insert({
+      id: canonicalId,
+      channel_id: seeded.channelId,
+      external_id: `schedule:${seeded.personaName}:${seeded.channelName}:${seeded.liveExternalId}`,
+      metadata: JSON.stringify({
+        kind: 'schedule',
+        originExternalId: seeded.liveExternalId,
+      }),
+    });
+
+    // Legacy schedule still on the live thread.
+    const scheduleId = seedSchedule(db, seeded.personaId, seeded.liveThreadId);
+
+    const result = migrateLegacySchedules({
+      scheduleRepo: new ScheduleRepository(db),
+      threadRepo: threads,
+      channelRepo: new ChannelRepository(db),
+      personaRepo: new PersonaRepository(db),
+      logger: createTestLogger(),
+    });
+
+    expect(result.rebound).toBe(1);
+    const schedRow = new ScheduleRepository(db).findById(scheduleId);
+    expect(schedRow._unsafeUnwrap()!.thread_id).toBe(canonicalId);
+  });
+
+  it('preserves colons inside the origin external_id when parsing the synthetic marker', () => {
+    // Slack encodes origin external_ids as `<channelId>:<thread_ts>` so the
+    // migration must keep everything after the third colon intact.
+    const db = createTestDb();
+    const seeded = seedChannelAndLiveThread(db);
+    const threads = new ThreadRepository(db);
+
+    const slackLikeOrigin = 'C01234:1700000000.123';
+    const oldStyleId = uuidv4();
+    threads.insert({
+      id: oldStyleId,
+      channel_id: seeded.channelId,
+      external_id: `schedule:${seeded.personaName}:${seeded.channelName}:${slackLikeOrigin}`,
+      metadata: '{}',
+    });
+    seedSchedule(db, seeded.personaId, oldStyleId);
+
+    const result = migrateLegacySchedules({
+      scheduleRepo: new ScheduleRepository(db),
+      threadRepo: threads,
+      channelRepo: new ChannelRepository(db),
+      personaRepo: new PersonaRepository(db),
+      logger: createTestLogger(),
+    });
+
+    expect(result.metadataRehydrated).toBe(1);
+    const meta = JSON.parse(threads.findById(oldStyleId)._unsafeUnwrap()!.metadata) as Record<string, unknown>;
+    expect(meta.originExternalId).toBe(slackLikeOrigin);
+  });
+
+  it('skips schedules whose thread row no longer exists and logs a warning', () => {
+    const db = createTestDb();
+    const personaId = seedPersona(db);
+    // Schedule points at a UUID that was never inserted into threads.
+    // Schedule FK references threads(id), so we have to temporarily disable
+    // FKs for this test seed — this mirrors the "dangling thread" state the
+    // migration is designed to tolerate in production.
+    db.pragma('foreign_keys = OFF');
+    const scheduleRepo = new ScheduleRepository(db);
+    const scheduleId = uuidv4();
+    scheduleRepo.insert({
+      id: scheduleId,
+      persona_id: personaId,
+      thread_id: uuidv4(),
+      type: 'cron',
+      expression: '0 9 * * *',
+      payload: '{}',
+      enabled: 1,
+      last_run_at: null,
+      next_run_at: Date.now() + 60_000,
+    });
+    db.pragma('foreign_keys = ON');
+
+    const result = migrateLegacySchedules({
+      scheduleRepo,
+      threadRepo: new ThreadRepository(db),
+      channelRepo: new ChannelRepository(db),
+      personaRepo: new PersonaRepository(db),
+      logger: createTestLogger(),
+    });
+
+    expect(result.skipped).toBe(1);
+    expect(result.rebound).toBe(0);
+    expect(result.metadataRehydrated).toBe(0);
+  });
+
+  it('skips schedules with a null thread_id', () => {
+    const db = createTestDb();
+    const personaId = seedPersona(db);
+    db.pragma('foreign_keys = OFF');
+    const scheduleRepo = new ScheduleRepository(db);
+    scheduleRepo.insert({
+      id: uuidv4(),
+      persona_id: personaId,
+      thread_id: null,
+      type: 'cron',
+      expression: '0 9 * * *',
+      payload: '{}',
+      enabled: 1,
+      last_run_at: null,
+      next_run_at: Date.now() + 60_000,
+    });
+    db.pragma('foreign_keys = ON');
+
+    const result = migrateLegacySchedules({
+      scheduleRepo,
+      threadRepo: new ThreadRepository(db),
+      channelRepo: new ChannelRepository(db),
+      personaRepo: new PersonaRepository(db),
+      logger: createTestLogger(),
+    });
+
+    expect(result.skipped).toBe(1);
+  });
+});

--- a/tests/unit/tools/host-tools-bridge.test.ts
+++ b/tests/unit/tools/host-tools-bridge.test.ts
@@ -217,11 +217,35 @@ describe('HostToolsBridge', () => {
           id: 'thread-001',
           channel_id: 'channel-001',
           external_id: 'telegram-thread-001',
+          metadata: '{}',
+          created_at: 1,
+          updated_at: 1,
         }),
       ),
+      findByExternalId: vi.fn().mockReturnValue(ok(null)),
+      findByChannelId: vi.fn().mockReturnValue(ok([])),
+      insert: vi.fn().mockImplementation((row) =>
+        ok({
+          ...row,
+          created_at: 1,
+          updated_at: 1,
+        }),
+      ),
+      update: vi.fn().mockReturnValue(ok(null)),
     } as any;
     mockCtx.repos.channel = {
-      findById: vi.fn().mockReturnValue(ok({ id: 'channel-001', name: 'telegram-main' })),
+      findById: vi.fn().mockReturnValue(
+        ok({
+          id: 'channel-001',
+          type: 'telegram',
+          name: 'telegram-main',
+          config: '{}',
+          credentials_ref: null,
+          enabled: 1,
+          created_at: 1,
+          updated_at: 1,
+        }),
+      ),
       findEnabled: vi.fn().mockReturnValue(ok([
         { id: 'channel-001', name: 'telegram-main' },
         { id: 'channel-002', name: 'slack-general' },

--- a/tests/unit/tools/host-tools/channel-send.test.ts
+++ b/tests/unit/tools/host-tools/channel-send.test.ts
@@ -234,3 +234,95 @@ describe('ChannelSendHandler — connector send failure', () => {
     expect(result.error).toMatch(/Telegram API timeout/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Schedule-thread delivery routing
+// ---------------------------------------------------------------------------
+
+describe('ChannelSendHandler — schedule-thread routing', () => {
+  it('delivers to the origin external_id when the thread metadata marks it as a schedule thread', async () => {
+    // Dedicated schedule execution threads created by schedule.manage have
+    // kind='schedule' + originExternalId set — channel.send must route to the
+    // origin chat, not the synthetic schedule thread id (issue #200).
+    const threadRepo = {
+      findById: vi.fn().mockReturnValue(
+        ok({
+          id: 'dedicated-schedule-thread-001',
+          channel_id: 'chan-001',
+          external_id: 'schedule:assistant:telegram-main:chat-42',
+          metadata: JSON.stringify({
+            kind: 'schedule',
+            originExternalId: 'chat-42',
+            personaName: 'assistant',
+            channelName: 'telegram-main',
+          }),
+        }),
+      ),
+    } as any;
+    const connector = makeConnector(ok(undefined));
+    const registry = makeRegistry(connector);
+    const handler = new ChannelSendHandler({
+      channelRegistry: registry,
+      threadRepository: threadRepo,
+      logger: makeLogger(),
+    });
+
+    await handler.execute(makeArgs(), makeContext({ threadId: 'dedicated-schedule-thread-001' }));
+
+    expect(connector.send).toHaveBeenCalledWith(
+      'chat-42',
+      expect.objectContaining({ body: 'Hello from persona!' }),
+    );
+  });
+
+  it('falls back to the thread external_id when metadata is not a schedule marker', async () => {
+    const threadRepo = {
+      findById: vi.fn().mockReturnValue(
+        ok({
+          id: 'live-thread-001',
+          channel_id: 'chan-001',
+          external_id: 'chat-42',
+          metadata: JSON.stringify({ kind: 'live' }),
+        }),
+      ),
+    } as any;
+    const connector = makeConnector(ok(undefined));
+    const registry = makeRegistry(connector);
+    const handler = new ChannelSendHandler({
+      channelRegistry: registry,
+      threadRepository: threadRepo,
+      logger: makeLogger(),
+    });
+
+    await handler.execute(makeArgs(), makeContext());
+
+    expect(connector.send).toHaveBeenCalledWith(
+      'chat-42',
+      expect.any(Object),
+    );
+  });
+
+  it('ignores malformed metadata JSON and falls back to the thread external_id', async () => {
+    const threadRepo = {
+      findById: vi.fn().mockReturnValue(
+        ok({
+          id: 'live-thread-001',
+          channel_id: 'chan-001',
+          external_id: 'chat-42',
+          metadata: '{not-json',
+        }),
+      ),
+    } as any;
+    const connector = makeConnector(ok(undefined));
+    const registry = makeRegistry(connector);
+    const handler = new ChannelSendHandler({
+      channelRegistry: registry,
+      threadRepository: threadRepo,
+      logger: makeLogger(),
+    });
+
+    await handler.execute(makeArgs(), makeContext());
+
+    expect(connector.send).toHaveBeenCalledWith('chat-42', expect.any(Object));
+  });
+});

--- a/tests/unit/tools/host-tools/channel-send.test.ts
+++ b/tests/unit/tools/host-tools/channel-send.test.ts
@@ -326,3 +326,54 @@ describe('ChannelSendHandler — schedule-thread routing', () => {
     expect(connector.send).toHaveBeenCalledWith('chat-42', expect.any(Object));
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fail-loud on missing thread
+// ---------------------------------------------------------------------------
+
+describe('ChannelSendHandler — missing thread fail-loud', () => {
+  it('returns a ToolError and does not call connector.send when the thread row is missing', async () => {
+    // Regression: before PR #201 review feedback, channel.send fell back
+    // to context.threadId (a UUID) when the thread row was missing,
+    // sending an unresolvable recipient to Telegram/Slack/Discord and
+    // producing "chat not found" errors the agent paraphrased as
+    // "channel unreachable — delivering inline" (silent delivery loss).
+    const threadRepo = {
+      findById: vi.fn().mockReturnValue(ok(null)),
+    } as any;
+    const connector = makeConnector(ok(undefined));
+    const registry = makeRegistry(connector);
+    const handler = new ChannelSendHandler({
+      channelRegistry: registry,
+      threadRepository: threadRepo,
+      logger: makeLogger(),
+    });
+
+    const result = await handler.execute(makeArgs(), makeContext({ threadId: 'missing-thread-uuid' }));
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/thread "missing-thread-uuid" not found/);
+    expect(connector.send).not.toHaveBeenCalled();
+  });
+
+  it('returns a ToolError when the thread lookup itself fails', async () => {
+    const { DbError } = await import('../../../../src/core/errors/error-types.js');
+    const { err: errFn } = await import('neverthrow');
+    const threadRepo = {
+      findById: vi.fn().mockReturnValue(errFn(new DbError('db locked'))),
+    } as any;
+    const connector = makeConnector(ok(undefined));
+    const registry = makeRegistry(connector);
+    const handler = new ChannelSendHandler({
+      channelRegistry: registry,
+      threadRepository: threadRepo,
+      logger: makeLogger(),
+    });
+
+    const result = await handler.execute(makeArgs(), makeContext());
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/failed to resolve thread/);
+    expect(connector.send).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/tools/host-tools/schedule-manage.test.ts
+++ b/tests/unit/tools/host-tools/schedule-manage.test.ts
@@ -2,20 +2,36 @@
  * Unit tests for ScheduleManageHandler.
  *
  * Tests cover:
- *   - create: success with valid cron, invalid cron rejected, missing cronExpr
- *   - update: success with fields, missing scheduleId, invalid cron, no fields provided
- *   - cancel: success, missing scheduleId
+ *   - create: success stores on a dedicated per-(persona, channel, origin)
+ *     execution thread; validation errors; repository error propagation
+ *   - update / cancel / delete: persona-scoped ownership (must work from
+ *     the live thread even though the schedule sits on the dedicated one)
+ *   - list: returns every schedule owned by the persona regardless of thread
  *   - invalid action
- *   - repository error propagation
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ok, err } from 'neverthrow';
 import { ScheduleManageHandler } from '../../../../src/tools/host-tools/schedule-manage.js';
 import type { ScheduleManageArgs } from '../../../../src/tools/host-tools/schedule-manage.js';
 import type { ToolExecutionContext } from '../../../../src/tools/host-tools/channel-send.js';
 import { DbError } from '../../../../src/core/errors/error-types.js';
-import type { ScheduleRepository, ScheduleRow } from '../../../../src/core/database/repositories/schedule-repository.js';
+import type {
+  ScheduleRepository,
+  ScheduleRow,
+} from '../../../../src/core/database/repositories/schedule-repository.js';
+import type {
+  ThreadRepository,
+  ThreadRow,
+} from '../../../../src/core/database/repositories/thread-repository.js';
+import type {
+  ChannelRepository,
+  ChannelRow,
+} from '../../../../src/core/database/repositories/channel-repository.js';
+import type {
+  PersonaRepository,
+  PersonaRow,
+} from '../../../../src/core/database/repositories/persona-repository.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -36,9 +52,51 @@ function makeLogger() {
 function makeContext(overrides: Partial<ToolExecutionContext> = {}): ToolExecutionContext {
   return {
     runId: 'run-001',
-    threadId: 'thread-001',
+    threadId: 'live-thread-001',
     personaId: 'persona-001',
     requestId: 'req-001',
+    ...overrides,
+  };
+}
+
+function makeThreadRow(overrides: Partial<ThreadRow> = {}): ThreadRow {
+  return {
+    id: 'live-thread-001',
+    channel_id: 'channel-001',
+    external_id: 'chat-42',
+    metadata: '{}',
+    created_at: 1000,
+    updated_at: 1000,
+    ...overrides,
+  };
+}
+
+function makeChannelRow(overrides: Partial<ChannelRow> = {}): ChannelRow {
+  return {
+    id: 'channel-001',
+    type: 'telegram',
+    name: 'telegram-main',
+    config: '{}',
+    credentials_ref: null,
+    enabled: 1,
+    created_at: 1000,
+    updated_at: 1000,
+    ...overrides,
+  };
+}
+
+function makePersonaRow(overrides: Partial<PersonaRow> = {}): PersonaRow {
+  return {
+    id: 'persona-001',
+    name: 'assistant',
+    model: 'claude-sonnet-4-6',
+    system_prompt_file: null,
+    skills: '[]',
+    capabilities: '{}',
+    mounts: '[]',
+    max_concurrent: null,
+    created_at: 1000,
+    updated_at: 1000,
     ...overrides,
   };
 }
@@ -47,7 +105,7 @@ function makeScheduleRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
   return {
     id: 'sched-001',
     persona_id: 'persona-001',
-    thread_id: 'thread-001',
+    thread_id: 'dedicated-schedule-thread-001',
     type: 'cron',
     expression: '0 9 * * 1',
     payload: '{"label":"Daily standup","prompt":"What should I focus on today?"}',
@@ -60,7 +118,7 @@ function makeScheduleRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
   };
 }
 
-function makeRepo(overrides: Partial<ScheduleRepository> = {}): ScheduleRepository {
+function makeScheduleRepo(overrides: Partial<ScheduleRepository> = {}): ScheduleRepository {
   return {
     insert: vi.fn().mockReturnValue(ok(makeScheduleRow())),
     update: vi.fn().mockReturnValue(ok(makeScheduleRow())),
@@ -73,6 +131,61 @@ function makeRepo(overrides: Partial<ScheduleRepository> = {}): ScheduleReposito
     updateNextRun: vi.fn().mockReturnValue(ok(null)),
     ...overrides,
   } as unknown as ScheduleRepository;
+}
+
+function makeThreadRepo(overrides: Partial<ThreadRepository> = {}): ThreadRepository {
+  return {
+    findById: vi.fn().mockReturnValue(ok(makeThreadRow())),
+    findByExternalId: vi.fn().mockReturnValue(ok(null)),
+    findByChannelId: vi.fn().mockReturnValue(ok([])),
+    insert: vi.fn().mockImplementation((row) => ok({
+      ...makeThreadRow(),
+      ...row,
+      created_at: 1000,
+      updated_at: 1000,
+    })),
+    update: vi.fn().mockReturnValue(ok(makeThreadRow())),
+    ...overrides,
+  } as unknown as ThreadRepository;
+}
+
+function makeChannelRepo(overrides: Partial<ChannelRepository> = {}): ChannelRepository {
+  return {
+    findById: vi.fn().mockReturnValue(ok(makeChannelRow())),
+    findByName: vi.fn().mockReturnValue(ok(makeChannelRow())),
+    findEnabled: vi.fn().mockReturnValue(ok([])),
+    insert: vi.fn().mockReturnValue(ok(makeChannelRow())),
+    update: vi.fn().mockReturnValue(ok(makeChannelRow())),
+    delete: vi.fn().mockReturnValue(ok(undefined)),
+    ...overrides,
+  } as unknown as ChannelRepository;
+}
+
+function makePersonaRepo(overrides: Partial<PersonaRepository> = {}): PersonaRepository {
+  return {
+    findById: vi.fn().mockReturnValue(ok(makePersonaRow())),
+    findByName: vi.fn().mockReturnValue(ok(makePersonaRow())),
+    findAll: vi.fn().mockReturnValue(ok([])),
+    insert: vi.fn().mockReturnValue(ok(makePersonaRow())),
+    update: vi.fn().mockReturnValue(ok(makePersonaRow())),
+    delete: vi.fn().mockReturnValue(ok(undefined)),
+    ...overrides,
+  } as unknown as PersonaRepository;
+}
+
+function makeHandler(overrides: {
+  scheduleRepository?: ScheduleRepository;
+  threadRepository?: ThreadRepository;
+  channelRepository?: ChannelRepository;
+  personaRepository?: PersonaRepository;
+} = {}) {
+  return new ScheduleManageHandler({
+    scheduleRepository: overrides.scheduleRepository ?? makeScheduleRepo(),
+    threadRepository: overrides.threadRepository ?? makeThreadRepo(),
+    channelRepository: overrides.channelRepository ?? makeChannelRepo(),
+    personaRepository: overrides.personaRepository ?? makePersonaRepo(),
+    logger: makeLogger(),
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -98,10 +211,19 @@ describe('ScheduleManageHandler — manifest', () => {
 // ---------------------------------------------------------------------------
 
 describe('ScheduleManageHandler — create', () => {
-  it('creates a schedule with valid cron expression', async () => {
-    const insertFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({ insert: insertFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+  it('creates a schedule on a newly-provisioned dedicated execution thread', async () => {
+    const insertSchedule = vi.fn().mockReturnValue(ok(makeScheduleRow()));
+    const findByExternalId = vi.fn().mockReturnValue(ok(null));
+    const insertThread = vi.fn().mockImplementation((row) => ok({
+      ...makeThreadRow(),
+      ...row,
+      created_at: 1000,
+      updated_at: 1000,
+    }));
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ insert: insertSchedule }),
+      threadRepository: makeThreadRepo({ findByExternalId, insert: insertThread }),
+    });
 
     const result = await handler.execute(
       { action: 'create', cronExpr: '0 9 * * 1', label: 'Standup', prompt: 'What to do?' },
@@ -109,25 +231,76 @@ describe('ScheduleManageHandler — create', () => {
     );
 
     expect(result.status).toBe('success');
-    expect(result.tool).toBe('schedule.manage');
-    expect((result.result as { action: string }).action).toBe('create');
     expect((result.result as { created: boolean }).created).toBe(true);
-    expect((result.result as { scheduleId: string }).scheduleId).toBeTruthy();
+
+    // A dedicated schedule thread keyed `schedule:<persona>:<channel>:<origin>`
+    // was provisioned on the same channel as the live thread.
+    expect(findByExternalId).toHaveBeenCalledWith(
+      'channel-001',
+      'schedule:assistant:telegram-main:chat-42',
+    );
+    expect(insertThread).toHaveBeenCalledTimes(1);
+    const insertedThread = insertThread.mock.calls[0][0];
+    expect(insertedThread.channel_id).toBe('channel-001');
+    expect(insertedThread.external_id).toBe('schedule:assistant:telegram-main:chat-42');
+    expect(JSON.parse(insertedThread.metadata)).toMatchObject({
+      kind: 'schedule',
+      originExternalId: 'chat-42',
+      personaName: 'assistant',
+      channelName: 'telegram-main',
+    });
+
+    // The schedule row was stored against the dedicated thread, not the live one.
+    expect(insertSchedule).toHaveBeenCalledTimes(1);
+    const insertedSchedule = insertSchedule.mock.calls[0][0];
+    expect(insertedSchedule.thread_id).toBe(insertedThread.id);
+    expect(insertedSchedule.thread_id).not.toBe('live-thread-001');
   });
 
-  it('inserts schedule with correct fields', async () => {
-    const insertFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({ insert: insertFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+  it('reuses an existing dedicated thread when one already exists for (persona, channel, origin)', async () => {
+    const existingDedicated = makeThreadRow({
+      id: 'dedicated-thread-xyz',
+      external_id: 'schedule:assistant:telegram-main:chat-42',
+      metadata: JSON.stringify({
+        kind: 'schedule',
+        originExternalId: 'chat-42',
+        personaName: 'assistant',
+        channelName: 'telegram-main',
+      }),
+    });
+    const insertSchedule = vi.fn().mockReturnValue(ok(makeScheduleRow()));
+    const insertThread = vi.fn();
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ insert: insertSchedule }),
+      threadRepository: makeThreadRepo({
+        findByExternalId: vi.fn().mockReturnValue(ok(existingDedicated)),
+        insert: insertThread,
+      }),
+    });
+
+    const result = await handler.execute(
+      { action: 'create', cronExpr: '0 9 * * *', prompt: 'Ping' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('success');
+    expect(insertThread).not.toHaveBeenCalled();
+    expect(insertSchedule.mock.calls[0][0].thread_id).toBe('dedicated-thread-xyz');
+  });
+
+  it('inserts schedule with correct persona_id, cron, and computed next_run_at', async () => {
+    const insertSchedule = vi.fn().mockReturnValue(ok(makeScheduleRow()));
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ insert: insertSchedule }),
+    });
 
     await handler.execute(
       { action: 'create', cronExpr: '*/5 * * * *', label: 'Poll', prompt: 'Check status' },
-      makeContext({ personaId: 'persona-abc', threadId: 'thread-xyz' }),
+      makeContext({ personaId: 'persona-001' }),
     );
 
-    const insertArg = insertFn.mock.calls[0][0];
-    expect(insertArg.persona_id).toBe('persona-abc');
-    expect(insertArg.thread_id).toBe('thread-xyz');
+    const insertArg = insertSchedule.mock.calls[0][0];
+    expect(insertArg.persona_id).toBe('persona-001');
     expect(insertArg.expression).toBe('*/5 * * * *');
     expect(insertArg.type).toBe('cron');
     expect(insertArg.enabled).toBe(1);
@@ -137,9 +310,10 @@ describe('ScheduleManageHandler — create', () => {
   });
 
   it('accepts promptFile when creating a schedule', async () => {
-    const insertFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({ insert: insertFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const insertSchedule = vi.fn().mockReturnValue(ok(makeScheduleRow()));
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ insert: insertSchedule }),
+    });
 
     const result = await handler.execute(
       { action: 'create', cronExpr: '0 7 * * 1-5', label: 'Morning briefing', promptFile: 'morning-briefing' },
@@ -147,15 +321,14 @@ describe('ScheduleManageHandler — create', () => {
     );
 
     expect(result.status).toBe('success');
-    expect(JSON.parse(insertFn.mock.calls[0][0].payload)).toEqual({
+    expect(JSON.parse(insertSchedule.mock.calls[0][0].payload)).toEqual({
       label: 'Morning briefing',
       promptFile: 'morning-briefing',
     });
   });
 
   it('rejects create when prompt and promptFile are both provided', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const handler = makeHandler();
 
     const result = await handler.execute(
       {
@@ -172,36 +345,28 @@ describe('ScheduleManageHandler — create', () => {
   });
 
   it('returns error when cronExpr is missing', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
-    const result = await handler.execute(
-      { action: 'create' },
-      makeContext(),
-    );
-
+    const handler = makeHandler();
+    const result = await handler.execute({ action: 'create' }, makeContext());
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/cronExpr is required/);
   });
 
   it('returns error for invalid cron expression', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
+    const handler = makeHandler();
     const result = await handler.execute(
       { action: 'create', cronExpr: 'not-a-cron' },
       makeContext(),
     );
-
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/invalid cron expression/);
   });
 
   it('propagates insert repository errors', async () => {
-    const repo = makeRepo({
-      insert: vi.fn().mockReturnValue(err(new DbError('db locked'))),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        insert: vi.fn().mockReturnValue(err(new DbError('db locked'))),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     const result = await handler.execute(
       { action: 'create', cronExpr: '0 * * * *' },
@@ -212,10 +377,92 @@ describe('ScheduleManageHandler — create', () => {
     expect(result.error).toMatch(/create failed/);
   });
 
+  it('returns an error when the invoking thread cannot be resolved', async () => {
+    const handler = makeHandler({
+      threadRepository: makeThreadRepo({
+        findById: vi.fn().mockReturnValue(ok(null)),
+      }),
+    });
+
+    const result = await handler.execute(
+      { action: 'create', cronExpr: '0 9 * * 1' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/invoking thread .* not found/);
+  });
+
+  it('returns an error when the channel cannot be resolved', async () => {
+    const handler = makeHandler({
+      channelRepository: makeChannelRepo({
+        findById: vi.fn().mockReturnValue(ok(null)),
+      }),
+    });
+
+    const result = await handler.execute(
+      { action: 'create', cronExpr: '0 9 * * 1' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/channel .* not found/);
+  });
+
+  it('returns an error when the persona cannot be resolved', async () => {
+    const handler = makeHandler({
+      personaRepository: makePersonaRepo({
+        findById: vi.fn().mockReturnValue(ok(null)),
+      }),
+    });
+
+    const result = await handler.execute(
+      { action: 'create', cronExpr: '0 9 * * 1' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/persona .* not found/);
+  });
+
+  it('surfaces errors from the dedicated-thread lookup', async () => {
+    const handler = makeHandler({
+      threadRepository: makeThreadRepo({
+        findByExternalId: vi.fn().mockReturnValue(err(new DbError('lookup failed'))),
+      }),
+    });
+
+    const result = await handler.execute(
+      { action: 'create', cronExpr: '0 9 * * 1' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/dedicated schedule thread/i);
+  });
+
+  it('surfaces errors from the dedicated-thread insert', async () => {
+    const handler = makeHandler({
+      threadRepository: makeThreadRepo({
+        findByExternalId: vi.fn().mockReturnValue(ok(null)),
+        insert: vi.fn().mockReturnValue(err(new DbError('insert failed'))),
+      }),
+    });
+
+    const result = await handler.execute(
+      { action: 'create', cronExpr: '0 9 * * 1' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/dedicated schedule thread/i);
+  });
+
   it('handles missing label and prompt gracefully', async () => {
-    const insertFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({ insert: insertFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const insertSchedule = vi.fn().mockReturnValue(ok(makeScheduleRow()));
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ insert: insertSchedule }),
+    });
 
     const result = await handler.execute(
       { action: 'create', cronExpr: '0 0 * * *' },
@@ -223,7 +470,7 @@ describe('ScheduleManageHandler — create', () => {
     );
 
     expect(result.status).toBe('success');
-    const payload = JSON.parse(insertFn.mock.calls[0][0].payload);
+    const payload = JSON.parse(insertSchedule.mock.calls[0][0].payload);
     expect(payload).toEqual({ label: '' });
   });
 });
@@ -233,14 +480,15 @@ describe('ScheduleManageHandler — create', () => {
 // ---------------------------------------------------------------------------
 
 describe('ScheduleManageHandler — update', () => {
-  it('updates an existing schedule', async () => {
+  it('updates an existing schedule from the live thread', async () => {
     const updateFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({ update: updateFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ update: updateFn }),
+    });
 
     const result = await handler.execute(
       { action: 'update', scheduleId: 'sched-001', cronExpr: '0 10 * * *', label: 'New label' },
-      makeContext(),
+      makeContext({ threadId: 'live-thread-001' }),
     );
 
     expect(result.status).toBe('success');
@@ -249,8 +497,9 @@ describe('ScheduleManageHandler — update', () => {
 
   it('recomputes next_run_at when cronExpr changes', async () => {
     const updateFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({ update: updateFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ update: updateFn }),
+    });
 
     await handler.execute(
       { action: 'update', scheduleId: 'sched-001', cronExpr: '0 10 * * *' },
@@ -263,63 +512,56 @@ describe('ScheduleManageHandler — update', () => {
     expect(updateArg.next_run_at).toBeGreaterThan(Date.now() - 60_000);
   });
 
-  it('calls update with correct persona_id for ownership enforcement', async () => {
+  it('enforces ownership by persona, not by invoking thread', async () => {
     const updateFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({ update: updateFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ update: updateFn }),
+    });
 
     await handler.execute(
       { action: 'update', scheduleId: 'sched-001', cronExpr: '0 10 * * *' },
-      makeContext({ personaId: 'persona-xyz' }),
+      makeContext({ personaId: 'persona-xyz', threadId: 'some-other-thread' }),
     );
 
     expect(updateFn).toHaveBeenCalledWith('sched-001', 'persona-xyz', expect.any(Object));
   });
 
   it('returns error when scheduleId is missing', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
+    const handler = makeHandler();
     const result = await handler.execute(
       { action: 'update', cronExpr: '0 * * * *' },
       makeContext(),
     );
-
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/scheduleId is required/);
   });
 
   it('returns error for invalid cron expression in update', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
+    const handler = makeHandler();
     const result = await handler.execute(
       { action: 'update', scheduleId: 'sched-001', cronExpr: 'bad cron here' },
       makeContext(),
     );
-
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/invalid cron expression/);
   });
 
   it('returns error when no update fields are provided', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
+    const handler = makeHandler();
     const result = await handler.execute(
       { action: 'update', scheduleId: 'sched-001' },
       makeContext(),
     );
-
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/no fields provided to update/);
   });
 
   it('propagates update repository errors', async () => {
-    const repo = makeRepo({
-      update: vi.fn().mockReturnValue(err(new DbError('not found'))),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        update: vi.fn().mockReturnValue(err(new DbError('not found'))),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     const result = await handler.execute(
       { action: 'update', scheduleId: 'sched-001', label: 'Updated label' },
@@ -332,8 +574,9 @@ describe('ScheduleManageHandler — update', () => {
 
   it('accepts promptFile when updating a schedule', async () => {
     const updateFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({ update: updateFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ update: updateFn }),
+    });
 
     const result = await handler.execute(
       { action: 'update', scheduleId: 'sched-001', promptFile: 'meeting-prep' },
@@ -348,9 +591,7 @@ describe('ScheduleManageHandler — update', () => {
   });
 
   it('rejects update when prompt and promptFile are both provided', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
+    const handler = makeHandler();
     const result = await handler.execute(
       {
         action: 'update',
@@ -367,11 +608,12 @@ describe('ScheduleManageHandler — update', () => {
 
   it('preserves the existing prompt source when only label changes', async () => {
     const updateFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({
-      update: updateFn,
-      findById: vi.fn().mockReturnValue(ok(makeScheduleRow())),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        update: updateFn,
+        findById: vi.fn().mockReturnValue(ok(makeScheduleRow())),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     await handler.execute(
       { action: 'update', scheduleId: 'sched-001', label: 'Renamed schedule' },
@@ -386,11 +628,12 @@ describe('ScheduleManageHandler — update', () => {
 
   it('replaces inline prompt with promptFile on update', async () => {
     const updateFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({
-      update: updateFn,
-      findById: vi.fn().mockReturnValue(ok(makeScheduleRow())),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        update: updateFn,
+        findById: vi.fn().mockReturnValue(ok(makeScheduleRow())),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     await handler.execute(
       { action: 'update', scheduleId: 'sched-001', promptFile: 'meeting-prep' },
@@ -404,10 +647,11 @@ describe('ScheduleManageHandler — update', () => {
   });
 
   it('rejects update when schedule does not exist', async () => {
-    const repo = makeRepo({
-      findById: vi.fn().mockReturnValue(ok(null)),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        findById: vi.fn().mockReturnValue(ok(null)),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     const result = await handler.execute(
       { action: 'update', scheduleId: 'nonexistent', label: 'New label' },
@@ -419,10 +663,11 @@ describe('ScheduleManageHandler — update', () => {
   });
 
   it('rejects update when schedule belongs to a different persona', async () => {
-    const repo = makeRepo({
-      findById: vi.fn().mockReturnValue(ok(makeScheduleRow({ persona_id: 'other-persona' }))),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        findById: vi.fn().mockReturnValue(ok(makeScheduleRow({ persona_id: 'other-persona' }))),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     const result = await handler.execute(
       { action: 'update', scheduleId: 'sched-001', label: 'New label' },
@@ -435,17 +680,18 @@ describe('ScheduleManageHandler — update', () => {
 
   it('replaces promptFile with inline prompt on update', async () => {
     const updateFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({
-      update: updateFn,
-      findById: vi.fn().mockReturnValue(
-        ok(
-          makeScheduleRow({
-            payload: '{"label":"Daily standup","promptFile":"meeting-prep"}',
-          }),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        update: updateFn,
+        findById: vi.fn().mockReturnValue(
+          ok(
+            makeScheduleRow({
+              payload: '{"label":"Daily standup","promptFile":"meeting-prep"}',
+            }),
+          ),
         ),
-      ),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     await handler.execute(
       { action: 'update', scheduleId: 'sched-001', prompt: 'Use inline prompt instead' },
@@ -464,14 +710,18 @@ describe('ScheduleManageHandler — update', () => {
 // ---------------------------------------------------------------------------
 
 describe('ScheduleManageHandler — cancel', () => {
-  it('cancels a schedule by disabling it', async () => {
+  it('cancels a schedule by disabling it when invoked from the live thread', async () => {
     const disableFn = vi.fn().mockReturnValue(ok(undefined));
-    const repo = makeRepo({ disable: disableFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        disable: disableFn,
+        findById: vi.fn().mockReturnValue(ok(makeScheduleRow())),
+      }),
+    });
 
     const result = await handler.execute(
       { action: 'cancel', scheduleId: 'sched-001' },
-      makeContext(),
+      makeContext({ threadId: 'some-live-thread' }),
     );
 
     expect(result.status).toBe('success');
@@ -480,36 +730,63 @@ describe('ScheduleManageHandler — cancel', () => {
   });
 
   it('returns error when scheduleId is missing', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
-    const result = await handler.execute(
-      { action: 'cancel' },
-      makeContext(),
-    );
-
+    const handler = makeHandler();
+    const result = await handler.execute({ action: 'cancel' }, makeContext());
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/scheduleId is required/);
   });
 
   it('returns error when scheduleId is empty string', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
+    const handler = makeHandler();
     const result = await handler.execute(
       { action: 'cancel', scheduleId: '' },
       makeContext(),
     );
-
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/scheduleId is required/);
   });
 
-  it('propagates disable repository errors', async () => {
-    const repo = makeRepo({
-      disable: vi.fn().mockReturnValue(err(new DbError('row not found'))),
+  it('rejects cancel when schedule belongs to a different persona', async () => {
+    const disableFn = vi.fn().mockReturnValue(ok(undefined));
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        disable: disableFn,
+        findById: vi.fn().mockReturnValue(ok(makeScheduleRow({ persona_id: 'other-persona' }))),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+
+    const result = await handler.execute(
+      { action: 'cancel', scheduleId: 'sched-001' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/does not belong/);
+    expect(disableFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects cancel when schedule does not exist', async () => {
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        findById: vi.fn().mockReturnValue(ok(null)),
+      }),
+    });
+
+    const result = await handler.execute(
+      { action: 'cancel', scheduleId: 'missing' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/not found/);
+  });
+
+  it('propagates disable repository errors', async () => {
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        disable: vi.fn().mockReturnValue(err(new DbError('row not found'))),
+      }),
+    });
 
     const result = await handler.execute(
       { action: 'cancel', scheduleId: 'sched-001' },
@@ -526,14 +803,15 @@ describe('ScheduleManageHandler — cancel', () => {
 // ---------------------------------------------------------------------------
 
 describe('ScheduleManageHandler — delete', () => {
-  it('permanently deletes a schedule', async () => {
+  it('permanently deletes a schedule when invoked from the live thread', async () => {
     const deleteFn = vi.fn().mockReturnValue(ok(makeScheduleRow()));
-    const repo = makeRepo({ delete: deleteFn });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ delete: deleteFn }),
+    });
 
     const result = await handler.execute(
       { action: 'delete', scheduleId: 'sched-001' },
-      makeContext(),
+      makeContext({ threadId: 'some-live-thread' }),
     );
 
     expect(result.status).toBe('success');
@@ -542,36 +820,28 @@ describe('ScheduleManageHandler — delete', () => {
   });
 
   it('returns error when scheduleId is missing', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
-    const result = await handler.execute(
-      { action: 'delete' },
-      makeContext(),
-    );
-
+    const handler = makeHandler();
+    const result = await handler.execute({ action: 'delete' }, makeContext());
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/scheduleId is required/);
   });
 
   it('returns error when scheduleId is empty string', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
+    const handler = makeHandler();
     const result = await handler.execute(
       { action: 'delete', scheduleId: '' },
       makeContext(),
     );
-
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/scheduleId is required/);
   });
 
   it('returns error when schedule not found or not owned', async () => {
-    const repo = makeRepo({
-      delete: vi.fn().mockReturnValue(ok(null)),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        delete: vi.fn().mockReturnValue(ok(null)),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     const result = await handler.execute(
       { action: 'delete', scheduleId: 'nonexistent' },
@@ -583,10 +853,11 @@ describe('ScheduleManageHandler — delete', () => {
   });
 
   it('propagates delete repository errors', async () => {
-    const repo = makeRepo({
-      delete: vi.fn().mockReturnValue(err(new DbError('db locked'))),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        delete: vi.fn().mockReturnValue(err(new DbError('db locked'))),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     const result = await handler.execute(
       { action: 'delete', scheduleId: 'sched-001' },
@@ -604,27 +875,21 @@ describe('ScheduleManageHandler — delete', () => {
 
 describe('ScheduleManageHandler — invalid action', () => {
   it('returns error for unknown action', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
+    const handler = makeHandler();
     const result = await handler.execute(
       { action: 'pause' as ScheduleManageArgs['action'] },
       makeContext(),
     );
-
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/invalid action/);
   });
 
   it('returns error for missing action', async () => {
-    const repo = makeRepo();
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
-
+    const handler = makeHandler();
     const result = await handler.execute(
       { action: undefined as unknown as ScheduleManageArgs['action'] },
       makeContext(),
     );
-
     expect(result.status).toBe('error');
     expect(result.error).toMatch(/invalid action/);
   });
@@ -635,23 +900,37 @@ describe('ScheduleManageHandler — invalid action', () => {
 // ---------------------------------------------------------------------------
 
 describe('ScheduleManageHandler — list', () => {
-  it('returns all schedules for the persona', async () => {
+  it('returns every schedule owned by the persona regardless of invoking thread', async () => {
     const schedules = [
-      makeScheduleRow({ id: 'sched-001', expression: '0 9 * * 1', next_run_at: 1700000000000 }),
+      // Schedule stored against the dedicated execution thread — must still be listed
+      // when the agent invokes list from the live chat thread.
+      makeScheduleRow({
+        id: 'sched-001',
+        expression: '0 9 * * 1',
+        next_run_at: 1700000000000,
+        thread_id: 'dedicated-schedule-thread-001',
+      }),
       makeScheduleRow({
         id: 'sched-002',
         expression: '30 18 * * *',
         next_run_at: 1700050000000,
         enabled: 0,
         payload: '{"label":"Meeting prep","promptFile":"meeting-prep"}',
+        thread_id: 'dedicated-schedule-thread-001',
       }),
     ];
-    const repo = makeRepo({ findByPersona: vi.fn().mockReturnValue(ok(schedules)) });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const findByPersona = vi.fn().mockReturnValue(ok(schedules));
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ findByPersona }),
+    });
 
-    const result = await handler.execute({ action: 'list' }, makeContext());
+    const result = await handler.execute(
+      { action: 'list' },
+      makeContext({ threadId: 'live-thread-001' }),
+    );
 
     expect(result.status).toBe('success');
+    expect(findByPersona).toHaveBeenCalledWith('persona-001');
     const data = result.result as { schedules: unknown[]; count: number };
     expect(data.count).toBe(2);
     expect(data.schedules).toHaveLength(2);
@@ -669,8 +948,11 @@ describe('ScheduleManageHandler — list', () => {
   });
 
   it('returns empty list when no schedules exist', async () => {
-    const repo = makeRepo({ findByPersona: vi.fn().mockReturnValue(ok([])) });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        findByPersona: vi.fn().mockReturnValue(ok([])),
+      }),
+    });
 
     const result = await handler.execute({ action: 'list' }, makeContext());
 
@@ -681,10 +963,11 @@ describe('ScheduleManageHandler — list', () => {
   });
 
   it('returns error when repository fails', async () => {
-    const repo = makeRepo({
-      findByPersona: vi.fn().mockReturnValue(err(new DbError('DB read failed'))),
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({
+        findByPersona: vi.fn().mockReturnValue(err(new DbError('DB read failed'))),
+      }),
     });
-    const handler = new ScheduleManageHandler({ scheduleRepository: repo, logger: makeLogger() });
 
     const result = await handler.execute({ action: 'list' }, makeContext());
 

--- a/tests/unit/tools/host-tools/schedule-manage.test.ts
+++ b/tests/unit/tools/host-tools/schedule-manage.test.ts
@@ -288,6 +288,124 @@ describe('ScheduleManageHandler — create', () => {
     expect(insertSchedule.mock.calls[0][0].thread_id).toBe('dedicated-thread-xyz');
   });
 
+  it('recovers from a UNIQUE-key race by re-querying the dedicated thread on insert failure (Codex P1)', async () => {
+    // Two concurrent schedule.manage create calls for the same
+    // (persona, channel, origin) can both pass findByExternalId → null
+    // and both attempt the insert. The first wins; the second hits
+    // threads.UNIQUE(channel_id, external_id). That second call must
+    // still succeed by re-querying the just-materialised row.
+    const winnerRow = makeThreadRow({
+      id: 'dedicated-winner',
+      external_id: 'schedule:assistant:telegram-main:chat-42',
+      metadata: JSON.stringify({
+        kind: 'schedule',
+        originExternalId: 'chat-42',
+      }),
+    });
+    let findCallCount = 0;
+    const findByExternalId = vi.fn().mockImplementation(() => {
+      findCallCount += 1;
+      // First lookup (before insert attempt): no thread yet.
+      // Second lookup (after insert failure): winner now materialised.
+      return findCallCount === 1 ? ok(null) : ok(winnerRow);
+    });
+    const insertThread = vi.fn().mockReturnValue(err(new DbError('UNIQUE constraint failed')));
+    const insertSchedule = vi.fn().mockReturnValue(ok(makeScheduleRow()));
+
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ insert: insertSchedule }),
+      threadRepository: makeThreadRepo({ findByExternalId, insert: insertThread }),
+    });
+
+    const result = await handler.execute(
+      { action: 'create', cronExpr: '0 9 * * *', prompt: 'Ping' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('success');
+    expect(findByExternalId).toHaveBeenCalledTimes(2);
+    expect(insertSchedule.mock.calls[0][0].thread_id).toBe('dedicated-winner');
+  });
+
+  it('unwraps origin external_id from metadata when invoked from an existing schedule thread (Codex P2)', async () => {
+    // When a scheduled run itself invokes schedule.manage to create a
+    // follow-up schedule, the invoking thread's external_id is the
+    // synthetic `schedule:persona:channel:origin` id. Passing that as
+    // the new schedule's origin would chain synthetic → synthetic and
+    // break outbound routing. The handler must unwrap the real origin
+    // from the invoking thread's metadata.
+    const invokingScheduleThread = makeThreadRow({
+      id: 'live-thread-001',
+      channel_id: 'channel-001',
+      external_id: 'schedule:assistant:telegram-main:chat-42',
+      metadata: JSON.stringify({
+        kind: 'schedule',
+        originExternalId: 'chat-42',
+      }),
+    });
+    const findById = vi.fn().mockReturnValue(ok(invokingScheduleThread));
+    const findByExternalId = vi.fn().mockReturnValue(ok(null));
+    const insertThread = vi.fn().mockImplementation((row) => ok({
+      ...makeThreadRow(),
+      ...row,
+      created_at: 1000,
+      updated_at: 1000,
+    }));
+    const insertSchedule = vi.fn().mockReturnValue(ok(makeScheduleRow()));
+
+    const handler = makeHandler({
+      scheduleRepository: makeScheduleRepo({ insert: insertSchedule }),
+      threadRepository: makeThreadRepo({ findById, findByExternalId, insert: insertThread }),
+    });
+
+    const result = await handler.execute(
+      { action: 'create', cronExpr: '0 9 * * *', prompt: 'Follow-up' },
+      makeContext(),
+    );
+
+    expect(result.status).toBe('success');
+    // The resolved dedicated thread must re-use the unwrapped origin,
+    // not the synthetic external_id of the invoking thread.
+    expect(findByExternalId).toHaveBeenCalledWith(
+      'channel-001',
+      'schedule:assistant:telegram-main:chat-42',
+    );
+    const insertedMetadata = JSON.parse(insertThread.mock.calls[0][0].metadata) as Record<string, unknown>;
+    expect(insertedMetadata.originExternalId).toBe('chat-42');
+    expect(insertedMetadata.originExternalId).not.toMatch(/^schedule:/);
+  });
+
+  it('writes thread metadata that round-trips back through the schedule-thread marker reader', async () => {
+    // Regression cover: if the insert-call shape test passes but the
+    // metadata the handler emits is not in the shape channel.send /
+    // agent-runner consume, scheduled delivery silently breaks. Assert
+    // the contract end-to-end by parsing the metadata the way the
+    // consumers do.
+    const insertThread = vi.fn().mockImplementation((row) => ok({
+      ...makeThreadRow(),
+      ...row,
+      created_at: 1000,
+      updated_at: 1000,
+    }));
+    const handler = makeHandler({
+      threadRepository: makeThreadRepo({
+        findByExternalId: vi.fn().mockReturnValue(ok(null)),
+        insert: insertThread,
+      }),
+    });
+
+    await handler.execute(
+      { action: 'create', cronExpr: '0 9 * * *', prompt: 'Round trip' },
+      makeContext(),
+    );
+
+    const rawMetadata: string = insertThread.mock.calls[0][0].metadata;
+    // Mirrors readOriginExternalId in channel-send.ts / agent-runner.ts.
+    const parsed = JSON.parse(rawMetadata) as Record<string, unknown>;
+    expect(parsed.kind).toBe('schedule');
+    expect(parsed.originExternalId).toBe('chat-42');
+  });
+
   it('inserts schedule with correct persona_id, cron, and computed next_run_at', async () => {
     const insertSchedule = vi.fn().mockReturnValue(ok(makeScheduleRow()));
     const handler = makeHandler({


### PR DESCRIPTION
## Summary

Refactors schedule creation to store schedules on dedicated per-(persona, channel, origin) execution threads rather than on the live conversation thread. This prevents scheduled task runs from polluting the conversation history while maintaining persona-scoped ownership for update/cancel/delete/list operations.

## Key Changes

- **Schedule creation isolation**: When `schedule.manage` creates a schedule, it now:
  - Resolves the invoking thread, channel, and persona
  - Generates a synthetic external_id: `schedule:<persona>:<channel>:<origin-chat-id>`
  - Provisions or reuses a dedicated thread with metadata `{ kind: 'schedule', originExternalId: '...' }`
  - Stores the schedule against the dedicated thread instead of the live thread

- **Persona-scoped ownership**: Update, cancel, delete, and list operations now enforce ownership by persona rather than by invoking thread, allowing operations from any thread that owns the persona (including the live chat thread)

- **Message routing for schedule threads**: 
  - `channel.send` now detects schedule threads via metadata and routes messages to the `originExternalId` instead of the synthetic schedule thread id
  - `agent-runner` applies the same routing logic for typing indicators and agent-originated outbound messages
  - Both include fallback handling for malformed metadata

- **Test coverage**: Comprehensive test updates covering:
  - Dedicated thread provisioning and reuse
  - Persona-scoped ownership enforcement across operations
  - Thread resolution and error handling
  - Schedule-thread routing in channel.send and agent-runner

- **Documentation**: Updated README to explain dedicated execution threads and their purpose

## Implementation Details

- New helper function `readOriginExternalId()` (and `readScheduleOriginExternalId()` in agent-runner) safely parses thread metadata to extract the origin chat id
- ScheduleManageHandler now requires ThreadRepository, ChannelRepository, and PersonaRepository in addition to ScheduleRepository
- Dedicated threads are created with metadata containing persona name, channel name, and origin external id for observability and routing
- All repository lookups include proper error handling and logging

https://claude.ai/code/session_01Q3aQmcesthVybpjN1SteEL