### PR TITLE
feat(channels): add group chat support for Telegram and WhatsApp Baileys

### DIFF
--- a/src/channels/connectors/telegram/telegram-connector.ts
+++ b/src/channels/connectors/telegram/telegram-connector.ts
@@ -15,6 +15,7 @@ import type {
   TelegramConfig,
   TelegramUpdate,
   TelegramUser,
+  TelegramMessage,
   TelegramSendResult,
   TelegramUpdatesResult,
 } from './telegram-types.js';
@@ -50,6 +51,7 @@ export class TelegramConnector implements ChannelConnector {
   readonly name: string;
 
   private _botUserId: string | undefined;
+  private _botUsername: string | undefined;
   private siblingBotIds: Set<string> = new Set();
 
   private handler?: (event: InboundEvent) => void | Promise<void>;
@@ -110,8 +112,9 @@ export class TelegramConnector implements ChannelConnector {
       const data = (await response.json()) as { ok: boolean; result?: TelegramUser };
       if (data.ok && data.result) {
         this._botUserId = String(data.result.id);
+        this._botUsername = data.result.username;
         this.logger.info(
-          { channelName: this.name, botUserId: this._botUserId },
+          { channelName: this.name, botUserId: this._botUserId, botUsername: this._botUsername },
           'telegram bot identity resolved',
         );
       } else {
@@ -325,6 +328,16 @@ export class TelegramConnector implements ChannelConnector {
     }
 
     const chatId = String(message.chat.id);
+    const isGroup = message.chat.type === 'group' || message.chat.type === 'supergroup';
+
+    // Drop group messages unless explicitly enabled.
+    if (isGroup && !this.config.allowGroupChats) {
+      this.logger.debug(
+        { channelName: this.name, chatId, chatType: message.chat.type },
+        'telegram group message received but allowGroupChats is not enabled, dropping',
+      );
+      return;
+    }
 
     // Enforce allowedChatIds restriction if configured.
     if (
@@ -358,6 +371,39 @@ export class TelegramConnector implements ChannelConnector {
       return;
     }
 
+    // Apply mention/trigger filter and resolve final message text.
+    let content = message.text;
+
+    if (isGroup) {
+      // In groups the bot only responds when @mentioned by username or when a
+      // triggerWord matches. Strip the matched prefix before forwarding.
+      const result = this.extractGroupContent(message);
+      if (!result) {
+        this.logger.debug(
+          { channelName: this.name, chatId },
+          'telegram group message has no @mention or trigger word, dropping',
+        );
+        return;
+      }
+      content = result;
+    } else {
+      // In DMs, apply triggerWords filter if configured.
+      const triggerWords = this.config.triggerWords;
+      if (triggerWords && triggerWords.length > 0) {
+        const lower = content.toLowerCase();
+        const matched = triggerWords.find((tw) => lower.startsWith(tw.toLowerCase()));
+        if (!matched) {
+          this.logger.debug(
+            { channelName: this.name, chatId },
+            'telegram DM message has no trigger word, dropping',
+          );
+          return;
+        }
+        content = content.slice(matched.length).trimStart();
+        if (!content) return;
+      }
+    }
+
     const senderId = message.from ? String(message.from.id) : chatId;
 
     const event: InboundEvent = {
@@ -366,7 +412,7 @@ export class TelegramConnector implements ChannelConnector {
       externalThreadId: chatId,
       senderId,
       idempotencyKey: String(update.update_id),
-      content: message.text,
+      content,
       timestamp: message.date * 1000, // Telegram sends seconds; we want ms
       raw: update,
     };
@@ -387,6 +433,48 @@ export class TelegramConnector implements ChannelConnector {
         'telegram connector handler threw an error',
       );
     }
+  }
+
+  /**
+   * For group messages: check if the text contains the bot's @mention (detected
+   * via Telegram entities for precision) or starts with a configured trigger word.
+   * Returns the stripped content on match, or null if neither condition is met.
+   */
+  private extractGroupContent(message: TelegramMessage): string | null {
+    const text = message.text;
+    if (!text) return null;
+
+    const botUsername = this._botUsername;
+
+    // Use Telegram entities for exact @mention detection — avoids false
+    // positives like "@talon" matching "@talon2".
+    if (botUsername && message.entities) {
+      for (const entity of message.entities) {
+        if (entity.type === 'mention') {
+          const mentionText = text.slice(entity.offset, entity.offset + entity.length);
+          if (mentionText.toLowerCase() === `@${botUsername.toLowerCase()}`) {
+            // Strip the specific mention by position, then clean up surrounding whitespace.
+            const stripped = (
+              text.slice(0, entity.offset) + text.slice(entity.offset + entity.length)
+            ).trim();
+            return stripped || null;
+          }
+        }
+      }
+    }
+
+    // Fall back to triggerWords prefix match.
+    const triggerWords = this.config.triggerWords;
+    if (triggerWords && triggerWords.length > 0) {
+      const lower = text.toLowerCase();
+      const matched = triggerWords.find((tw) => lower.startsWith(tw.toLowerCase()));
+      if (matched) {
+        const stripped = text.slice(matched.length).trimStart();
+        return stripped || null;
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/src/channels/connectors/telegram/telegram-types.ts
+++ b/src/channels/connectors/telegram/telegram-types.ts
@@ -26,6 +26,19 @@ export interface TelegramConfig {
    * If set, messages from chats not in this list are silently dropped.
    */
   allowedChatIds?: string[];
+  /**
+   * Allow messages from group and supergroup chats.
+   * In group chats the bot only responds when @mentioned by username or when
+   * a message starts with one of the configured triggerWords.
+   * Defaults to false.
+   */
+  allowGroupChats?: boolean;
+  /**
+   * Optional trigger words. A message must start with one of these (case-
+   * insensitive) for the bot to respond. The matched prefix is stripped before
+   * the message reaches the agent. Applies to both DMs and group chats.
+   */
+  triggerWords?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -53,6 +66,17 @@ export interface TelegramChat {
 }
 
 /**
+ * A Telegram message entity (bold, mention, etc.).
+ */
+export interface TelegramMessageEntity {
+  type: string;
+  offset: number;
+  length: number;
+  /** For type 'text_mention', the user object. */
+  user?: TelegramUser;
+}
+
+/**
  * A Telegram message object.
  * Only fields relevant to the connector are included.
  */
@@ -64,6 +88,8 @@ export interface TelegramMessage {
   date: number;
   /** Text of the message (absent for non-text messages). */
   text?: string;
+  /** Special entities in the message text (mentions, commands, etc.). */
+  entities?: TelegramMessageEntity[];
 }
 
 /**

--- a/src/channels/connectors/whatsapp-baileys/whatsapp-baileys-connector.ts
+++ b/src/channels/connectors/whatsapp-baileys/whatsapp-baileys-connector.ts
@@ -44,6 +44,8 @@ interface InboundWAMessage {
     fromMe?: boolean | null;
     remoteJid?: string | null;
     id?: string | null;
+    /** Set on group messages — the individual sender's JID. */
+    participant?: string | null;
   };
   message?: Record<string, unknown> | null;
   messageTimestamp?: number | { low: number; high: number; unsigned: boolean } | null;
@@ -311,14 +313,47 @@ export class WhatsAppBaileysConnector implements ChannelConnector {
       // ── Normal mode ───────────────────────────────────────────────
       if (fromMe) return;
 
+      const isGroup = jid.endsWith('@g.us');
+
+      if (isGroup) {
+        if (!this.config.allowGroupChats) {
+          this.logger.debug(
+            { channelName: this.name, jid },
+            'whatsapp-baileys: skipping group message (allowGroupChats not enabled)',
+          );
+          return;
+        }
+        // Require at least one triggerWord for groups — without one every group
+        // message would reach the agent.
+        const triggerWords = this.config.triggerWords;
+        if (!triggerWords || triggerWords.length === 0) {
+          this.logger.warn(
+            { channelName: this.name, jid },
+            'whatsapp-baileys: group message dropped — allowGroupChats is true but no triggerWords are configured',
+          );
+          return;
+        }
+        // Require a valid participant JID so senderId is always a real sender.
+        if (!msg.key.participant) {
+          this.logger.warn(
+            { channelName: this.name, jid },
+            'whatsapp-baileys: group message has no participant JID, dropping',
+          );
+          return;
+        }
+        // Group messages fall through to the triggerWords filter below.
+      }
+
       // Enforce allowedSenders restriction if configured.
+      // For group messages check the participant JID (individual sender), not the group JID.
       // Accepts the identifier part of any JID format:
       //   - Phone-based: "31612345678@s.whatsapp.net" or "31612345678:42@s.whatsapp.net"
       //   - LID-based:   "96490886312027@lid"
       // Strip the @domain suffix and any :device suffix to get the bare sender ID.
       const allowedSenders = this.config.allowedSenders;
       if (allowedSenders && allowedSenders.length > 0) {
-        const senderId = jid.replace(/@.*$/, '').replace(/:\d+$/, '');
+        const senderJid = isGroup ? msg.key.participant! : jid;
+        const senderId = senderJid.replace(/@.*$/, '').replace(/:\d+$/, '');
         if (!allowedSenders.includes(senderId)) {
           this.logger.warn(
             { channelName: this.name, jid, senderId },
@@ -326,15 +361,6 @@ export class WhatsAppBaileysConnector implements ChannelConnector {
           );
           return;
         }
-      }
-
-      // Skip group messages in normal mode.
-      if (jid.endsWith('@g.us')) {
-        this.logger.debug(
-          { channelName: this.name, jid },
-          'whatsapp-baileys: skipping group message',
-        );
-        return;
       }
     }
 
@@ -378,11 +404,15 @@ export class WhatsAppBaileysConnector implements ChannelConnector {
     }
     const epochMs = epochSeconds * 1000;
 
+    // For group messages the individual sender is in key.participant; jid is the group.
+    // Participant is guaranteed non-null here — groups without a participant are dropped above.
+    const senderId = jid.endsWith('@g.us') ? msg.key.participant! : jid;
+
     const event: InboundEvent = {
       channelType: this.type,
       channelName: this.name,
       externalThreadId: jid,
-      senderId: jid,
+      senderId,
       idempotencyKey: msg.key.id,
       content: text,
       timestamp: epochMs,

--- a/src/channels/connectors/whatsapp-baileys/whatsapp-baileys-types.ts
+++ b/src/channels/connectors/whatsapp-baileys/whatsapp-baileys-types.ts
@@ -48,6 +48,15 @@ export interface WhatsAppBaileysConfig {
    * for it to be processed (case-insensitive). The trigger word is stripped
    * before the message reaches the agent. Example: ['@Talon', '@Bot'].
    * When empty or omitted, all messages pass through without filtering.
+   * In group chats at least one triggerWord must match — there is no automatic
+   * @mention detection on WhatsApp.
    */
   triggerWords?: string[];
+  /**
+   * Allow messages from WhatsApp group chats (JIDs ending in @g.us).
+   * Requires at least one triggerWord to be configured so the bot does not
+   * respond to every message in the group.
+   * Defaults to false.
+   */
+  allowGroupChats?: boolean;
 }

--- a/tests/unit/channels/connectors/telegram/telegram-bot-filter.test.ts
+++ b/tests/unit/channels/connectors/telegram/telegram-bot-filter.test.ts
@@ -47,7 +47,7 @@ function makeUpdate(
     message: {
       message_id: updateId * 10,
       from,
-      chat: { id: chatId, type: 'group' },
+      chat: { id: chatId, type: 'private' },
       date: 1_700_000_000,
       text,
     },


### PR DESCRIPTION
## Summary

- **Telegram**: new `allowGroupChats` and `triggerWords` config options. In groups, the bot only responds when @mentioned (detected via Telegram entities — no false positives) or a `triggerWord` prefix matches. The matched mention/trigger is stripped before the message reaches the agent. `triggerWords` also applies to DMs when configured.
- **WhatsApp Baileys**: new `allowGroupChats` config option. Group messages are accepted when enabled and at least one `triggerWord` is configured (enforced at runtime — drops with warning otherwise). Groups without a `key.participant` JID are dropped. `senderId` in `InboundEvent` is now the participant JID for group messages, not the group JID.
- **Thread model**: one shared thread per group (all members share context), `externalThreadId` is the group chat ID / JID.

## Config examples

```yaml
# Telegram
config:
  botToken: "123:ABC..."
  allowGroupChats: true
  # triggerWords: ["!ask"]  — optional, @mention always works

# WhatsApp Baileys
config:
  authDir: ./baileys-auth
  allowGroupChats: true
  triggerWords: ["@Talon"]  # required for groups
```

## Test Plan
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] All 568 channel tests pass
- [x] Reviewed by GPT-5.4 (high reasoning) — all HIGH/MEDIUM issues addressed
- [ ] Smoke test: add a Telegram bot to a group, send `@botname hello`, verify response
- [ ] Smoke test: add bot to WhatsApp group, send `@Talon hello`, verify response
- [ ] Verify DM behaviour unchanged on both connectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)