### PR TITLE
fix(agent-runner): gate rotation on per-step usage, not cumulative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ talond.yaml
 .worktrees/
 
 # WhatsApp Baileys auth session
-baileys-auth/
+baileys-auth*
 .claude/settings.json
 
 # Local tooling scratch / session state

--- a/README.md
+++ b/README.md
@@ -1278,6 +1278,7 @@ contextManagement:
   thresholdRatio: 0.75
   recentMessageCount: 10
   summarizer: session-observer    # enables observational memory
+  reflectionThresholdChars: 40000 # observation-log size that triggers session-reflector (default 40000)
 
 # 2. Add the observer and reflector to the persona's subagents list
 personas:

--- a/config/talond.example.yaml
+++ b/config/talond.example.yaml
@@ -136,6 +136,7 @@ agentRunner:
         thresholdRatio: 0.5
         recentMessageCount: 10
         summarizer: session-summarizer       # or session-observer for observational memory
+        # reflectionThresholdChars: 40000   # OM only: observation log size that triggers session-reflector. Default 40000.
     gemini-cli:
       enabled: false
       command: gemini

--- a/package-lock.json
+++ b/package-lock.json
@@ -838,6 +838,7 @@
       "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1594,6 +1595,7 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1718,6 +1720,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1734,6 +1737,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1750,6 +1754,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1858,6 +1863,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1880,6 +1886,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1902,6 +1909,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1987,6 +1995,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -2028,6 +2037,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2526,7 +2536,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2560,7 +2569,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
       "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2576,7 +2584,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.213.0.tgz",
       "integrity": "sha512-tnRmJD39aWrE/Sp7F6AbRNAjKHToDkAqBi6i0lESpGWz3G+f4bhVAV6mgSXH2o18lrDVJXo6jf9bAywQw43wRA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/otlp-exporter-base": "0.213.0",
@@ -2856,7 +2863,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -3460,8 +3466,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
@@ -3604,8 +3609,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -3790,7 +3794,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -4259,7 +4262,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5395,7 +5397,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5720,7 +5721,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6328,7 +6328,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6758,7 +6757,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -6973,7 +6971,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9964,7 +9961,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10200,7 +10196,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10714,7 +10709,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -11026,7 +11020,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/core/config/config-schema.ts
+++ b/src/core/config/config-schema.ts
@@ -183,6 +183,11 @@ export const ContextManagementConfigSchema = z
     thresholdRatio: z.number().min(0).max(1).optional(),
     recentMessageCount: z.number().int().min(0).default(10),
     summarizer: z.string().trim().min(1).optional(),
+    // Max combined size, in characters, of the per-thread observation log
+    // before the reflector sub-agent is invoked to consolidate it. Only
+    // applies when `summarizer` is `session-observer` (observational memory
+    // path). Defaults to 40_000 (~10K tokens).
+    reflectionThresholdChars: z.number().int().min(1000).default(40_000),
   })
   .superRefine((value, ctx) => {
     if (!value.enabled) {

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -421,6 +421,7 @@ export class AgentRunner {
                   thresholdRatio: contextManagement.thresholdRatio!,
                   recentMessageCount: contextManagement.recentMessageCount!,
                   summarizer: contextManagement.summarizer!,
+                  reflectionThresholdChars: contextManagement.reflectionThresholdChars,
                 }
               : null;
             // Fresh-session history injection is independent of automatic rotation.
@@ -497,6 +498,7 @@ export class AgentRunner {
               fullOutputText: string;
               resultSessionId: string | undefined;
               usage: AgentUsage;
+              lastStepUsage: AgentUsage | undefined;
             }> => {
               const toolInstructionsBlock = resolveToolInstructions(
                 this.ctx.toolInstructions,
@@ -633,6 +635,12 @@ export class AgentRunner {
                     inputTokens: 0,
                     outputTokens: 0,
                   };
+                  // Distinct accumulator for per-step usage (final model
+                  // turn only). When the provider reports it, rotation
+                  // gating uses this in preference to the cumulative
+                  // `usage` so multi-tool runs don't trigger spurious
+                  // rotations from inflated cross-turn token sums.
+                  let lastStepUsage: AgentUsage | undefined;
                   let sawEvents = false;
                   const activeProviderToolObservations = new Map<string, StartedObservationHandle>();
                   const ignoredProviderToolUseIds = new Set<string>();
@@ -682,6 +690,7 @@ export class AgentRunner {
                         } else if (event.type === 'result') {
                           resultSessionId = event.result.sessionId;
                           usage = event.result.usage;
+                          lastStepUsage = event.result.lastStepUsage;
 
                           if (!fullOutputText && event.result.output) {
                             outputText = event.result.output;
@@ -766,6 +775,7 @@ export class AgentRunner {
                     fullOutputText = result.output;
                     resultSessionId = result.sessionId;
                     usage = result.usage;
+                    lastStepUsage = result.lastStepUsage;
 
                     if (result.isError) {
                       throw new Error(`CLI provider returned error: ${result.output || 'unknown error'}`);
@@ -828,6 +838,7 @@ export class AgentRunner {
                     fullOutputText: fullOutputText.replace(/\n\n$/, ''),
                     resultSessionId,
                     usage,
+                    lastStepUsage,
                   };
                 },
               );
@@ -840,6 +851,7 @@ export class AgentRunner {
               inputTokens: 0,
               outputTokens: 0,
             };
+            let lastStepUsage: AgentUsage | undefined;
 
             try {
               ({
@@ -847,6 +859,7 @@ export class AgentRunner {
                 fullOutputText,
                 resultSessionId,
                 usage,
+                lastStepUsage,
               } = await executeAgentQuery(existingSessionId));
             } catch (cause) {
               if (strategy.type === 'sdk' && this.shouldRetryFreshSession(cause)) {
@@ -864,6 +877,7 @@ export class AgentRunner {
                   fullOutputText,
                   resultSessionId,
                   usage,
+                  lastStepUsage,
                 } = await executeAgentQuery(undefined));
               } else {
                 throw cause;
@@ -970,7 +984,14 @@ export class AgentRunner {
             // picked up until rotation completes, preserving per-thread ordering.
             // (issue #164)
             if (this.ctx.contextRoller && enabledContextManagement) {
-              const contextUsage = providerEntry.provider.estimateContextUsage(usage);
+              // Gate rotation on per-step usage when the provider reports
+              // it; cumulative `usage` across a multi-tool agent loop can
+              // easily exceed the per-call context window even when each
+              // individual prompt fits, which would trigger spurious
+              // rotations. Telemetry/accounting still uses the cumulative
+              // `usage` further down (it's what the user was billed for).
+              const usageForRotation = lastStepUsage ?? usage;
+              const contextUsage = providerEntry.provider.estimateContextUsage(usageForRotation);
               const selectedMetricValue = contextUsage.metrics[enabledContextManagement.triggerMetric];
               if (selectedMetricValue === undefined) {
                 this.ctx.logger.error(
@@ -1000,6 +1021,8 @@ export class AgentRunner {
                           contextUsagePayload,
                           enabledContextManagement.thresholdRatio,
                           enabledContextManagement.summarizer,
+                          'session-reflector',
+                          enabledContextManagement.reflectionThresholdChars,
                         )
                       : await this.ctx.contextRoller.checkAndRotate(
                           item.threadId,

--- a/src/daemon/context-roller.ts
+++ b/src/daemon/context-roller.ts
@@ -65,11 +65,12 @@ export interface ContextRotationResult {
 export type ReflectorRunFn = SummarizerRunFn;
 
 /**
- * Maximum character budget for the accumulated observation log before
- * the reflector is triggered to consolidate observations.
- * ~40K chars ≈ ~10K tokens — keeps observations manageable.
+ * Default character budget for the accumulated observation log before the
+ * reflector is triggered to consolidate observations. ~40K chars ≈ ~10K
+ * tokens — keeps observations manageable. Operators can override via
+ * `agentRunner.providers.<name>.contextManagement.reflectionThresholdChars`.
  */
-const MAX_OBSERVATION_CHARS = 40_000;
+export const DEFAULT_MAX_OBSERVATION_CHARS = 40_000;
 
 export interface ContextRollerDeps {
   messageRepo: Pick<MessageRepository, 'findLatestByThread'>;
@@ -322,6 +323,7 @@ export class ContextRoller {
     overrideThreshold?: number,
     observerName: string = 'session-observer',
     reflectorName: string = 'session-reflector',
+    reflectionThresholdChars: number = DEFAULT_MAX_OBSERVATION_CHARS,
   ): Promise<ContextRotationResult> {
     const noRotation: ContextRotationResult = { rotated: false, hasOpenThreads: false };
     const threshold = overrideThreshold ?? this.deps.thresholdRatio ?? 0.4;
@@ -543,7 +545,7 @@ export class ContextRoller {
     );
 
     // 7. Check if accumulated observations need reflection (consolidation).
-    await this.maybeReflect(threadId, personaId, reflectorName);
+    await this.maybeReflect(threadId, personaId, reflectorName, reflectionThresholdChars);
 
     // hasOpenThreads gates the stateless-provider auto-"continue" in agent-runner.
     // Fire it only when the observer explicitly flags unfinished work — i.e.
@@ -562,6 +564,7 @@ export class ContextRoller {
     threadId: string,
     personaId: string,
     reflectorName: string,
+    reflectionThresholdChars: number,
   ): Promise<void> {
     const observationsResult = this.deps.memoryRepo.findByThread(threadId, 'observation');
     if (observationsResult.isErr() || observationsResult.value.length === 0) {
@@ -571,12 +574,12 @@ export class ContextRoller {
     const allObservations = observationsResult.value;
     const fullLog = allObservations.map((o) => o.content).join('\n\n');
 
-    if (fullLog.length < MAX_OBSERVATION_CHARS) {
+    if (fullLog.length < reflectionThresholdChars) {
       return;
     }
 
     this.deps.logger.info(
-      { threadId, observationChars: fullLog.length, threshold: MAX_OBSERVATION_CHARS },
+      { threadId, observationChars: fullLog.length, threshold: reflectionThresholdChars },
       'context-roller-om: observation log exceeds threshold, triggering reflector',
     );
 

--- a/src/providers/openai-compatible-provider.ts
+++ b/src/providers/openai-compatible-provider.ts
@@ -88,6 +88,17 @@ type WrapperEvent =
         outputTokens?: number;
         cacheReadTokens?: number;
       };
+      /**
+       * Per-step usage from the FINAL model turn — distinct from
+       * cumulative `usage`. Forwarded to ProviderResult.lastStepUsage so
+       * context-rotation can gate on per-call prompt size rather than the
+       * inflated sum across the agent loop.
+       */
+      lastStepUsage?: {
+        inputTokens?: number;
+        outputTokens?: number;
+        cacheReadTokens?: number;
+      };
     }
   | { type: 'error'; message: string };
 
@@ -192,6 +203,14 @@ export class OpenAiCompatibleProvider implements AgentProvider {
         cacheReadTokens: resultEvent.usage.cacheReadTokens,
       };
     }
+    let lastStepUsage: AgentUsage | undefined;
+    if (resultEvent?.lastStepUsage) {
+      lastStepUsage = {
+        inputTokens: resultEvent.lastStepUsage.inputTokens ?? 0,
+        outputTokens: resultEvent.lastStepUsage.outputTokens ?? 0,
+        cacheReadTokens: resultEvent.lastStepUsage.cacheReadTokens,
+      };
+    }
 
     const failed = raw.exitCode !== 0 || raw.timedOut || errorEvent !== undefined || !resultEvent;
     const combinedStderr = failed
@@ -204,6 +223,7 @@ export class OpenAiCompatibleProvider implements AgentProvider {
       exitCode: failed && raw.exitCode === 0 ? 1 : raw.exitCode,
       timedOut: raw.timedOut,
       usage,
+      ...(lastStepUsage ? { lastStepUsage } : {}),
     };
   }
 
@@ -329,12 +349,20 @@ export class OpenAiCompatibleProvider implements AgentProvider {
               cacheReadTokens: event.usage.cacheReadTokens,
             };
           }
+          const lastStepUsage = event.lastStepUsage
+            ? {
+                inputTokens: event.lastStepUsage.inputTokens ?? 0,
+                outputTokens: event.lastStepUsage.outputTokens ?? 0,
+                cacheReadTokens: event.lastStepUsage.cacheReadTokens,
+              }
+            : undefined;
           yield {
             type: 'result',
             result: {
               output: resultOutput,
               sessionId: undefined,
               usage,
+              ...(lastStepUsage ? { lastStepUsage } : {}),
               isError: false,
             },
           };

--- a/src/providers/openai-compatible/agent-cli/index.ts
+++ b/src/providers/openai-compatible/agent-cli/index.ts
@@ -6,7 +6,8 @@ import { MCPClient, type MastraMCPServerDefinition } from '@mastra/mcp';
 import { z } from 'zod';
 import {
   chooseUsage,
-  extractUsage,
+  extractCumulativeUsage,
+  extractPerStepUsage,
   mergeUsage,
   normalizeUsage,
   type UsageSnapshot,
@@ -246,15 +247,46 @@ async function main(): Promise<void> {
     // so the agent can do meaningful multi-tool work.
     const stream = await agent.stream(input.prompt, { maxSteps: 25 });
     const shouldStream = input.streamEvents !== false;
-    let streamedUsage: UsageSnapshot | undefined;
+    // Track per-step and cumulative usage in SEPARATE accumulators so we
+    // can surface each to the right consumer downstream:
+    //   - `cumulativeUsage` → reported as the result's `usage` field for
+    //     telemetry/accounting (Langfuse, `runs.input_tokens`, etc).
+    //   - `perStepUsage` → reported as `lastStepUsage` for rotation gating
+    //     in agent-runner. Per-step is what answers "is the next prompt
+    //     going to exceed the model context window?".
+    // Mixing them within one snapshot leads either to inflated rotation
+    // ratios (using cumulative) or under-reported billing (using per-step).
+    let cumulativeUsage: UsageSnapshot | undefined;
+    let perStepUsage: UsageSnapshot | undefined;
+    // Third accumulator: running SUM of per-step values across the agent
+    // loop. Used as a cumulative fallback when the provider/version never
+    // emits a native cumulative shape (no `totalUsage`, no `output.usage`).
+    // For those providers, summed per-step equals what `totalUsage` would
+    // have reported, so it correctly preserves billing accuracy without
+    // leaking back into the per-step accumulator used for rotation gating.
+    const summedPerStep: UsageSnapshot = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+    };
+    let sawAnyPerStep = false;
 
     for await (const rawChunk of stream.fullStream as AsyncIterable<unknown>) {
       const chunk = normalizeStreamChunk(rawChunk);
       if (!chunk) continue;
 
-      const chunkUsage = extractUsage(chunk.payload);
-      if (chunkUsage) {
-        streamedUsage = mergeUsage(streamedUsage, chunkUsage);
+      const perStep = extractPerStepUsage(chunk.payload);
+      if (perStep) {
+        perStepUsage = mergeUsage(perStepUsage, perStep);
+        sawAnyPerStep = true;
+        summedPerStep.inputTokens = (summedPerStep.inputTokens ?? 0) + (perStep.inputTokens ?? 0);
+        summedPerStep.outputTokens = (summedPerStep.outputTokens ?? 0) + (perStep.outputTokens ?? 0);
+        summedPerStep.cachedInputTokens =
+          (summedPerStep.cachedInputTokens ?? 0) + (perStep.cachedInputTokens ?? 0);
+      }
+      const cumulative = extractCumulativeUsage(chunk.payload);
+      if (cumulative) {
+        cumulativeUsage = mergeUsage(cumulativeUsage, cumulative);
       }
 
       if (chunk.type === 'text-delta') {
@@ -325,7 +357,34 @@ async function main(): Promise<void> {
     await stream.consumeStream().catch(() => {});
     const [finalText, promiseUsage] = await Promise.all([stream.text, stream.usage]);
     const resolvedText = finalText && finalText.length > 0 ? finalText : aggregatedText;
-    const finalUsage = chooseUsage(streamedUsage, promiseUsage);
+    // `usage` is the cumulative total — what the user was billed for and
+    // what telemetry/accounting expects. Resolution order:
+    //   1. Native cumulative chunks (`totalUsage`, `output.usage`) — most
+    //      authoritative when the provider emits them.
+    //   2. `stream.usage` promise — Mastra's official end-of-stream total.
+    //   3. SUM of per-step chunks across the loop — for providers/versions
+    //      that only emit per-step shapes, the per-step sum equals what
+    //      `totalUsage` would have reported, so it preserves billing
+    //      accuracy. Without this fallback the wrapper would emit
+    //      `{ inputTokens: 0 }` while `lastStepUsage` was populated, and
+    //      Langfuse + `runs.input_tokens` would silently under-report.
+    const cumulativeFallback = sawAnyPerStep ? summedPerStep : undefined;
+    // Chain chooseUsage so that a non-zero source always wins over a zero
+    // one. Without the chain, `chooseUsage(cumulativeUsage, promiseUsage)`
+    // could return `{0, 0}` when the promise settles with zeros after
+    // `fullStream` is externally drained, and a plain `??` wouldn't fall
+    // through to `summedPerStep`.
+    const finalCumulativeUsage = chooseUsage(
+      chooseUsage(cumulativeUsage, promiseUsage),
+      cumulativeFallback,
+    );
+    // `lastStepUsage` is the per-step total from the FINAL model turn —
+    // what context-rotation gating uses to estimate the next prompt size.
+    // No fallback to the promise (which is cumulative); if we never saw a
+    // per-step shape, we omit the field and let agent-runner fall back to
+    // the cumulative usage (degraded signal, but better than nothing).
+    const normalizedCumulative = normalizeUsage(finalCumulativeUsage);
+    const normalizedPerStep = perStepUsage ? normalizeUsage(perStepUsage) : undefined;
 
     if (input.outputFilePath) {
       try {
@@ -342,7 +401,8 @@ async function main(): Promise<void> {
       emit({
         type: 'result',
         output: '',
-        usage: normalizeUsage(finalUsage),
+        usage: normalizedCumulative,
+        ...(normalizedPerStep ? { lastStepUsage: normalizedPerStep } : {}),
       });
       return;
     }
@@ -350,7 +410,8 @@ async function main(): Promise<void> {
     emit({
       type: 'result',
       output: resolvedText,
-      usage: normalizeUsage(finalUsage),
+      usage: normalizedCumulative,
+      ...(normalizedPerStep ? { lastStepUsage: normalizedPerStep } : {}),
     });
   } catch (error) {
     const message = error instanceof Error ? (error.stack ?? error.message) : String(error);

--- a/src/providers/openai-compatible/agent-cli/usage.ts
+++ b/src/providers/openai-compatible/agent-cli/usage.ts
@@ -3,13 +3,31 @@
  * CLI. Kept in their own module so they can be unit-tested without having
  * to spawn Mastra or connect to a real LLM endpoint.
  *
- * Mastra and the AI SDK place the authoritative token counts on the
- * `finish` / `step-finish` chunks that flow through `fullStream`. The
- * exact location varies by provider and version — sometimes
- * `payload.output.usage`, sometimes `payload.totalUsage`, sometimes
- * `payload.usage`. We scan every known location and prefer chunk-derived
- * counts over the `stream.usage` promise, because some providers resolve
- * that promise with zeros once `fullStream` has been externally drained.
+ * Mastra and the AI SDK place token counts on `step-finish` and `finish`
+ * chunks in fullStream. The exact location varies by provider and version
+ * — sometimes `payload.usage`, sometimes `payload.totalUsage`, sometimes
+ * `payload.output.usage`, sometimes `payload.stepResult.{usage,totalUsage}`.
+ * We scan every known location and prefer chunk-derived counts over the
+ * `stream.usage` promise, because some providers resolve that promise with
+ * zeros once `fullStream` has been externally drained.
+ *
+ * Per-step vs cumulative
+ * ----------------------
+ * `usage` on a step-finish chunk reports tokens for THAT step (the last
+ * model call). `totalUsage` (and the cumulative-shaped `output.usage` on a
+ * finish chunk) reports the running total across all steps in the current
+ * agent loop. Downstream consumers care about each separately:
+ *
+ * - Telemetry / accounting (Langfuse, `runs.input_tokens`) wants
+ *   CUMULATIVE — that is what the user was actually billed for.
+ * - Context-rotation gating wants PER-STEP — it asks "is the NEXT prompt
+ *   going to exceed the model's context window?". Cumulative across a
+ *   multi-tool loop can easily exceed the per-call window and would
+ *   trigger spurious session rotations.
+ *
+ * These are exposed as two distinct extractors so the caller can maintain
+ * separate accumulators and surface both upstream. Mixing the two within a
+ * single snapshot is never correct.
  */
 
 export interface UsageSnapshot {
@@ -23,33 +41,56 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Scan a stream-chunk payload for a usage record in any of the known
- * shapes. Returns `undefined` if the payload carries no token counts.
+ * Extract PER-STEP usage from a stream chunk payload.
+ *
+ * Scans only the locations that carry per-step (single-turn) token counts:
+ * `payload.usage` and `payload.stepResult.usage`. Returns `undefined` if
+ * neither is present, so callers never mistake cumulative shapes for
+ * per-step data.
  */
-export function extractUsage(payload: Record<string, unknown>): UsageSnapshot | undefined {
+export function extractPerStepUsage(payload: Record<string, unknown>): UsageSnapshot | undefined {
   const stepResult = isRecord(payload.stepResult) ? payload.stepResult : undefined;
-  const output = isRecord(payload.output) ? payload.output : undefined;
-
-  const candidates: unknown[] = [
-    // Top-level locations Mastra uses on finish/step-finish chunks.
-    payload.totalUsage,
-    payload.usage,
-    // FinishPayload.output.usage.
-    output?.usage,
-    // StepFinishPayload.stepResult.{usage,totalUsage}. Some Mastra versions
-    // and providers prefer one over the other, so scan both.
-    stepResult?.usage,
-    stepResult?.totalUsage,
-  ];
-
+  const candidates: unknown[] = [payload.usage, stepResult?.usage];
   for (const candidate of candidates) {
     const snapshot = toUsageSnapshot(candidate);
     if (snapshot) {
       return snapshot;
     }
   }
-
   return undefined;
+}
+
+/**
+ * Extract CUMULATIVE usage from a stream chunk payload.
+ *
+ * Scans only the locations that carry running totals across the agent
+ * loop: `payload.output.usage` (final cumulative on finish chunks),
+ * `payload.totalUsage`, and `payload.stepResult.totalUsage`. Returns
+ * `undefined` if none is present.
+ */
+export function extractCumulativeUsage(
+  payload: Record<string, unknown>,
+): UsageSnapshot | undefined {
+  const stepResult = isRecord(payload.stepResult) ? payload.stepResult : undefined;
+  const output = isRecord(payload.output) ? payload.output : undefined;
+  const candidates: unknown[] = [output?.usage, payload.totalUsage, stepResult?.totalUsage];
+  for (const candidate of candidates) {
+    const snapshot = toUsageSnapshot(candidate);
+    if (snapshot) {
+      return snapshot;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Legacy combined extractor — preferred order is per-step first, then
+ * cumulative. Retained for callers that want a single "best available"
+ * usage signal without caring about provenance. Avoid in code paths that
+ * need to distinguish the two (use the specialized extractors instead).
+ */
+export function extractUsage(payload: Record<string, unknown>): UsageSnapshot | undefined {
+  return extractPerStepUsage(payload) ?? extractCumulativeUsage(payload);
 }
 
 export function toUsageSnapshot(value: unknown): UsageSnapshot | undefined {
@@ -75,9 +116,15 @@ export function toUsageSnapshot(value: unknown): UsageSnapshot | undefined {
 
 /**
  * Merge a newer usage snapshot into an accumulator. Later chunks always
- * win: OpenAI-compatible servers emit the final, authoritative counts on
- * the last stream event, so we let them overwrite any partial numbers
- * seen earlier in the stream.
+ * win: openai-compatible servers emit the final, authoritative counts on
+ * the last stream event, so newer values overwrite earlier ones.
+ *
+ * IMPORTANT: callers must keep per-step and cumulative accumulators in
+ * SEPARATE variables and only merge values of the same kind into each.
+ * This function does not enforce that — it cannot know what kind a
+ * snapshot is — so cross-kind merges are the caller's responsibility to
+ * avoid (e.g. by extracting via `extractPerStepUsage` vs
+ * `extractCumulativeUsage` and routing into the matching accumulator).
  */
 export function mergeUsage(
   current: UsageSnapshot | undefined,

--- a/src/providers/provider-types.ts
+++ b/src/providers/provider-types.ts
@@ -55,7 +55,19 @@ export interface ProviderResult {
   exitCode: number | null;
   timedOut: boolean;
   stderr: string;
+  /**
+   * Cumulative token usage for the whole run — what the user was billed
+   * for. Use this for telemetry and `runs` table accounting.
+   */
   usage?: AgentUsage;
+  /**
+   * Per-step token usage from the FINAL model turn, when the provider can
+   * report it. For multi-turn agent loops this is the prompt size of the
+   * last model call rather than the sum across all tool-call iterations.
+   * Use this for context-rotation gating; falls back to `usage` when
+   * absent.
+   */
+  lastStepUsage?: AgentUsage;
 }
 
 export interface ProviderSpawnInput {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -26,7 +26,18 @@ export interface AgentRunInput {
 export interface AgentRunResult {
   output: string;
   sessionId?: string;
+  /**
+   * Cumulative token usage for the whole run — used for telemetry and
+   * `runs` table accounting (what the user was billed for).
+   */
   usage: AgentUsage;
+  /**
+   * Per-step usage from the FINAL model turn, when the provider can report
+   * it. For multi-turn agent loops this is the prompt size of the last
+   * model call rather than the sum across all tool-call iterations. Use
+   * for context-rotation gating; falls back to `usage` when absent.
+   */
+  lastStepUsage?: AgentUsage;
   isError: boolean;
 }
 

--- a/tests/unit/core/config/config-loader.test.ts
+++ b/tests/unit/core/config/config-loader.test.ts
@@ -254,6 +254,7 @@ agentRunner:
           thresholdRatio: 0.5,
           recentMessageCount: 10,
           summarizer: 'session-summarizer',
+          reflectionThresholdChars: 40_000,
         },
       });
     }
@@ -288,6 +289,7 @@ agentRunner:
           thresholdRatio: 0.5,
           recentMessageCount: 10,
           summarizer: 'session-summarizer',
+          reflectionThresholdChars: 40_000,
         },
       });
     }

--- a/tests/unit/core/config/config-schema.test.ts
+++ b/tests/unit/core/config/config-schema.test.ts
@@ -641,6 +641,7 @@ describe('AgentRunnerConfigSchema', () => {
               thresholdRatio: 0.5,
               recentMessageCount: 10,
               summarizer: 'session-summarizer',
+              reflectionThresholdChars: 40_000,
             },
           },
         },
@@ -678,6 +679,7 @@ describe('AgentRunnerConfigSchema', () => {
           thresholdRatio: 0.5,
           recentMessageCount: 12,
           summarizer: 'session-summarizer',
+          reflectionThresholdChars: 40_000,
         },
       });
     }
@@ -852,6 +854,7 @@ describe('TalondConfigSchema', () => {
               thresholdRatio: 0.5,
               recentMessageCount: 10,
               summarizer: 'session-summarizer',
+              reflectionThresholdChars: 40_000,
             },
           },
         },

--- a/tests/unit/daemon/context-roller.test.ts
+++ b/tests/unit/daemon/context-roller.test.ts
@@ -1348,6 +1348,111 @@ describe('ContextRoller', () => {
       expect(consolidated!.meta.suggestedContinuation).toBe('finish step 3');
     });
 
+    it('honors configurable reflectionThresholdChars when accumulated observations are short', async () => {
+      // Two 5K-char observations total 10K chars + separator — under the 40K
+      // default, so the reflector would not fire with defaults. With a 5K
+      // override the threshold is crossed, so the reflector MUST run.
+      const shortContent = 'x'.repeat(5_000);
+      const observations = [
+        {
+          id: 'obs-1',
+          type: 'observation',
+          content: shortContent,
+          created_at: 2_000,
+          metadata: JSON.stringify({ source: 'context-roller-om', rotatedThroughTs: 1_500 }),
+        },
+        {
+          id: 'obs-2',
+          type: 'observation',
+          content: shortContent,
+          created_at: 1_000,
+          metadata: JSON.stringify({ source: 'context-roller-om', rotatedThroughTs: 500 }),
+        },
+      ];
+
+      const messages = [
+        { direction: 'inbound', content: JSON.stringify({ body: 'hi' }), created_at: 1_000 },
+      ];
+
+      const reflectorRun = vi.fn().mockResolvedValueOnce(ok({
+        summary: 'Consolidated',
+        data: { consolidatedLog: 'Date: 2026-04-19\n- 🔴 10:00 consolidated' },
+      }));
+      const observerRun = vi.fn().mockResolvedValueOnce(ok({
+        summary: 'noop',
+        data: {
+          observations: [{ date: '2026-04-19', time: '11:00', priority: 'low', text: 'tick' }],
+          taskComplete: true,
+          memoryUpdates: [],
+        },
+      }));
+
+      const deps = makeDeps({
+        messageRepo: {
+          findLatestByThread: vi.fn().mockReturnValue(ok(messages)),
+        } as any,
+        resolveSummarizerRun: vi.fn().mockImplementation((name: string) => {
+          if (name === 'session-observer') return observerRun;
+          if (name === 'session-reflector') return reflectorRun;
+          return null;
+        }),
+        memoryRepo: {
+          insert: vi.fn().mockReturnValue(ok({})),
+          findById: vi.fn().mockReturnValue(ok(null)),
+          findByThread: vi.fn().mockImplementation((_tid: string, type?: string) => {
+            if (type === 'observation') return ok(observations);
+            return ok([]);
+          }),
+          upsertByKey: vi.fn().mockReturnValue(ok({})),
+          delete: vi.fn().mockReturnValue(ok(undefined)),
+          runInTransaction: vi.fn().mockImplementation((fn: () => unknown) => ok(fn())),
+        } as any,
+      });
+      const roller = new ContextRoller(deps);
+
+      // First: default threshold (40K) — observations only total ~10K, so
+      // reflector must NOT fire.
+      await roller.checkAndRotateOM('thread-1', 'persona-1', {
+        ratio: 0.5,
+        inputTokens: 100_000,
+        rawMetric: 100_000,
+        rawMetricName: 'cache_read_input_tokens',
+      });
+      expect(reflectorRun).not.toHaveBeenCalled();
+
+      // Now lower the threshold to 5K — the same observations exceed it,
+      // so the reflector MUST fire.
+      const observerRun2 = vi.fn().mockResolvedValueOnce(ok({
+        summary: 'noop',
+        data: {
+          observations: [{ date: '2026-04-19', time: '11:00', priority: 'low', text: 'tick' }],
+          taskComplete: true,
+          memoryUpdates: [],
+        },
+      }));
+      (deps.resolveSummarizerRun as any).mockImplementation((name: string) => {
+        if (name === 'session-observer') return observerRun2;
+        if (name === 'session-reflector') return reflectorRun;
+        return null;
+      });
+
+      await roller.checkAndRotateOM(
+        'thread-1',
+        'persona-1',
+        {
+          ratio: 0.5,
+          inputTokens: 100_000,
+          rawMetric: 100_000,
+          rawMetricName: 'cache_read_input_tokens',
+        },
+        undefined,
+        'session-observer',
+        'session-reflector',
+        5_000,
+      );
+      expect(reflectorRun).toHaveBeenCalledTimes(1);
+    });
+
     it('persists currentTask/suggestedContinuation when taskComplete=false', async () => {
       const observerRun = vi.fn().mockResolvedValueOnce(ok({
         summary: 'Observations recorded',

--- a/tests/unit/providers/openai-compatible-usage.test.ts
+++ b/tests/unit/providers/openai-compatible-usage.test.ts
@@ -1,58 +1,103 @@
 import { describe, expect, it } from 'vitest';
 import {
   chooseUsage,
+  extractCumulativeUsage,
+  extractPerStepUsage,
   extractUsage,
   mergeUsage,
   normalizeUsage,
 } from '../../../src/providers/openai-compatible/agent-cli/usage.js';
 
 describe('openai-compatible wrapper usage extraction', () => {
-  describe('extractUsage', () => {
-    it('reads usage from a step-finish-style totalUsage payload', () => {
-      // Shape emitted by Mastra on step-finish chunks.
-      const usage = extractUsage({
-        totalUsage: { inputTokens: 120, outputTokens: 24, cachedInputTokens: 48 },
+  describe('extractPerStepUsage', () => {
+    it('reads the top-level payload.usage shape (step-finish per-step)', () => {
+      const usage = extractPerStepUsage({
+        usage: { inputTokens: 30, outputTokens: 10 },
       });
-      expect(usage).toEqual({ inputTokens: 120, outputTokens: 24, cachedInputTokens: 48 });
+      expect(usage).toEqual({ inputTokens: 30, outputTokens: 10 });
     });
 
-    it('reads usage from a finish-style output.usage payload', () => {
-      // Shape emitted by Mastra on finish chunks (FinishPayload.output.usage).
-      const usage = extractUsage({
-        output: { usage: { inputTokens: 42, outputTokens: 7 } },
-      });
-      expect(usage).toEqual({ inputTokens: 42, outputTokens: 7 });
-    });
-
-    it('reads usage from a flat payload.usage shape', () => {
-      // Some providers / older Mastra versions place it at the top level.
-      const usage = extractUsage({
-        usage: { inputTokens: 10, outputTokens: 3 },
-      });
-      expect(usage).toEqual({ inputTokens: 10, outputTokens: 3 });
-    });
-
-    it('reads usage from stepResult.totalUsage when that is the only location', () => {
-      // Mastra's own step-result schema includes stepResult.totalUsage;
-      // some provider pipelines surface usage only there.
-      const usage = extractUsage({
-        stepResult: {
-          totalUsage: { inputTokens: 200, outputTokens: 80 },
-        },
-      });
-      expect(usage).toEqual({ inputTokens: 200, outputTokens: 80 });
-    });
-
-    it('prefers stepResult.usage over stepResult.totalUsage when both exist', () => {
-      // The per-step usage (stepResult.usage) is scanned first because it
-      // is the more specific, per-chunk value; totalUsage is the accumulator.
-      const usage = extractUsage({
-        stepResult: {
-          usage: { inputTokens: 50, outputTokens: 20 },
-          totalUsage: { inputTokens: 200, outputTokens: 80 },
-        },
+    it('reads stepResult.usage (Mastra step-finish per-step)', () => {
+      const usage = extractPerStepUsage({
+        stepResult: { usage: { inputTokens: 50, outputTokens: 20 } },
       });
       expect(usage).toEqual({ inputTokens: 50, outputTokens: 20 });
+    });
+
+    it('prefers payload.usage over stepResult.usage when both exist', () => {
+      // Both are per-step but we still need a deterministic order. Top-level
+      // wins because Mastra's outer chunk typically carries the freshest data.
+      const usage = extractPerStepUsage({
+        usage: { inputTokens: 30, outputTokens: 10 },
+        stepResult: { usage: { inputTokens: 999, outputTokens: 999 } },
+      });
+      expect(usage).toEqual({ inputTokens: 30, outputTokens: 10 });
+    });
+
+    it('returns undefined when only cumulative shapes are present', () => {
+      // Cumulative `totalUsage` / `output.usage` must NOT leak into per-step.
+      // This is the core invariant that prevents the inflated-ratio bug.
+      expect(
+        extractPerStepUsage({ totalUsage: { inputTokens: 540, outputTokens: 90 } }),
+      ).toBeUndefined();
+      expect(
+        extractPerStepUsage({ output: { usage: { inputTokens: 540, outputTokens: 90 } } }),
+      ).toBeUndefined();
+      expect(
+        extractPerStepUsage({
+          stepResult: { totalUsage: { inputTokens: 540, outputTokens: 90 } },
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('extractCumulativeUsage', () => {
+    it('reads the top-level payload.totalUsage shape (step-finish cumulative)', () => {
+      const usage = extractCumulativeUsage({
+        totalUsage: { inputTokens: 540, outputTokens: 90, cachedInputTokens: 48 },
+      });
+      expect(usage).toEqual({ inputTokens: 540, outputTokens: 90, cachedInputTokens: 48 });
+    });
+
+    it('reads output.usage (Mastra finish-chunk cumulative)', () => {
+      const usage = extractCumulativeUsage({
+        output: { usage: { inputTokens: 540, outputTokens: 90 } },
+      });
+      expect(usage).toEqual({ inputTokens: 540, outputTokens: 90 });
+    });
+
+    it('reads stepResult.totalUsage when nothing else is present', () => {
+      const usage = extractCumulativeUsage({
+        stepResult: { totalUsage: { inputTokens: 540, outputTokens: 90 } },
+      });
+      expect(usage).toEqual({ inputTokens: 540, outputTokens: 90 });
+    });
+
+    it('returns undefined when only per-step shapes are present', () => {
+      // Symmetric guarantee: per-step values must NOT leak into cumulative.
+      expect(
+        extractCumulativeUsage({ usage: { inputTokens: 30, outputTokens: 10 } }),
+      ).toBeUndefined();
+      expect(
+        extractCumulativeUsage({ stepResult: { usage: { inputTokens: 30, outputTokens: 10 } } }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('extractUsage (legacy combined)', () => {
+    it('prefers per-step over cumulative when both are present', () => {
+      const usage = extractUsage({
+        usage: { inputTokens: 30, outputTokens: 10 },
+        totalUsage: { inputTokens: 540, outputTokens: 90 },
+      });
+      expect(usage).toEqual({ inputTokens: 30, outputTokens: 10 });
+    });
+
+    it('falls back to cumulative when only cumulative is present', () => {
+      const usage = extractUsage({
+        totalUsage: { inputTokens: 540, outputTokens: 90 },
+      });
+      expect(usage).toEqual({ inputTokens: 540, outputTokens: 90 });
     });
 
     it('returns undefined for chunks without any recognised usage shape', () => {
@@ -63,7 +108,6 @@ describe('openai-compatible wrapper usage extraction', () => {
     });
 
     it('ignores non-numeric token fields', () => {
-      // Defensive: some providers send string counts.
       const usage = extractUsage({
         usage: { inputTokens: '42' as unknown as number, outputTokens: 7 },
       });
@@ -71,10 +115,93 @@ describe('openai-compatible wrapper usage extraction', () => {
     });
   });
 
+  describe('two-accumulator streaming semantics', () => {
+    // These guard the wrapper-CLI streaming loop's invariant: per-step and
+    // cumulative are accumulated in SEPARATE variables so a later cumulative
+    // chunk can never clobber the freshest per-step value (and vice versa).
+    // We simulate the streaming loop here to lock in behavior.
+
+    function simulate(chunks: Array<Record<string, unknown>>): {
+      perStep: ReturnType<typeof mergeUsage> | undefined;
+      cumulative: ReturnType<typeof mergeUsage> | undefined;
+    } {
+      let perStep: ReturnType<typeof mergeUsage> | undefined;
+      let cumulative: ReturnType<typeof mergeUsage> | undefined;
+      for (const chunk of chunks) {
+        const ps = extractPerStepUsage(chunk);
+        if (ps) perStep = mergeUsage(perStep, ps);
+        const cu = extractCumulativeUsage(chunk);
+        if (cu) cumulative = mergeUsage(cumulative, cu);
+      }
+      return { perStep, cumulative };
+    }
+
+    it('per-step value survives a trailing cumulative finish chunk', () => {
+      // Mastra emits per-step on step-finish, then a finish chunk with the
+      // cumulative total in output.usage. The per-step value must NOT be
+      // overwritten — this is the inflated-ratio regression guard.
+      const { perStep, cumulative } = simulate([
+        // First step-finish: per-step 20K, cumulative 20K.
+        { usage: { inputTokens: 20_000, outputTokens: 500 }, totalUsage: { inputTokens: 20_000, outputTokens: 500 } },
+        // Second step-finish: per-step 30K, cumulative 50K.
+        { usage: { inputTokens: 30_000, outputTokens: 800 }, totalUsage: { inputTokens: 50_000, outputTokens: 1_300 } },
+        // Trailing finish chunk: only cumulative (546K) present, no per-step.
+        { output: { usage: { inputTokens: 546_000, outputTokens: 1_500 } } },
+      ]);
+      expect(perStep?.inputTokens).toBe(30_000);
+      expect(cumulative?.inputTokens).toBe(546_000);
+    });
+
+    it('cumulative value survives partial per-step-only chunks', () => {
+      // Symmetric guarantee: a chunk with only per-step data does not
+      // overwrite the running cumulative total.
+      const { perStep, cumulative } = simulate([
+        { totalUsage: { inputTokens: 100_000, outputTokens: 2_000 } },
+        // Partial per-step chunk (no totalUsage) — must not clobber cumulative.
+        { usage: { inputTokens: 15_000, outputTokens: 400 } },
+      ]);
+      expect(perStep?.inputTokens).toBe(15_000);
+      expect(cumulative?.inputTokens).toBe(100_000);
+    });
+
+    it('cachedInputTokens stays within its own accumulator', () => {
+      // Field-level provenance check: cumulative cache tokens never leak
+      // into the per-step accumulator and vice versa.
+      const { perStep, cumulative } = simulate([
+        { totalUsage: { inputTokens: 200_000, cachedInputTokens: 80_000 } },
+        { usage: { inputTokens: 25_000, cachedInputTokens: 1_000 } },
+      ]);
+      expect(perStep?.cachedInputTokens).toBe(1_000);
+      expect(cumulative?.cachedInputTokens).toBe(80_000);
+    });
+
+    it('summed per-step is a faithful cumulative fallback', () => {
+      // For providers that only emit per-step shapes (no native cumulative
+      // chunk), summing per-step inputs across the loop equals what
+      // `totalUsage` would have reported. The wrapper uses this as a
+      // billing-accurate fallback so Langfuse / `runs.input_tokens` do not
+      // silently under-report. Simulate the loop's third accumulator here.
+      let summedInput = 0;
+      let summedOutput = 0;
+      const chunks = [
+        { usage: { inputTokens: 20_000, outputTokens: 500 } },
+        { usage: { inputTokens: 30_000, outputTokens: 800 } },
+        { usage: { inputTokens: 25_000, outputTokens: 600 } },
+      ];
+      for (const c of chunks) {
+        const ps = extractPerStepUsage(c);
+        if (ps) {
+          summedInput += ps.inputTokens ?? 0;
+          summedOutput += ps.outputTokens ?? 0;
+        }
+      }
+      expect(summedInput).toBe(75_000);
+      expect(summedOutput).toBe(1_900);
+    });
+  });
+
   describe('mergeUsage', () => {
-    it('lets later chunks overwrite earlier ones', () => {
-      // OpenAI-compatible servers emit the final counts on the last stream
-      // event, so newer values must win.
+    it('lets later snapshots overwrite earlier ones', () => {
       const merged = mergeUsage(
         { inputTokens: 10, outputTokens: 5 },
         { inputTokens: 120, outputTokens: 24 },
@@ -110,9 +237,6 @@ describe('openai-compatible wrapper usage extraction', () => {
 
   describe('chooseUsage', () => {
     it('prefers chunk-derived usage when it has non-zero counts', () => {
-      // This is the regression guard for the bug where `stream.usage` settles
-      // with zeros after fullStream is externally drained — the chunk-derived
-      // counts must win.
       const chunk = { inputTokens: 120, outputTokens: 24 };
       const fromPromise = { inputTokens: 0, outputTokens: 0 };
       expect(chooseUsage(chunk, fromPromise)).toEqual(chunk);
@@ -134,9 +258,6 @@ describe('openai-compatible wrapper usage extraction', () => {
     });
 
     it('treats a chunk with only cache tokens as authoritative', () => {
-      // Regression guard: if a provider emits a chunk that carries only
-      // cachedInputTokens (and the promise resolves with zeros), the chunk
-      // must still win so we do not drop the cache signal.
       const chunk = { inputTokens: 0, outputTokens: 0, cachedInputTokens: 42 };
       const fromPromise = { inputTokens: 0, outputTokens: 0 };
       expect(chooseUsage(chunk, fromPromise)).toEqual(chunk);


### PR DESCRIPTION
## Summary

- **Stops spurious session rotations on openai-compatible.** The wrapper CLI was reporting `totalUsage` (cumulative across the agent's tool-call loop) as the run's input_tokens. With `contextWindowTokens: 256000` and `thresholdRatio: 0.75`, that ratio crossed the threshold on almost every braintoss run (Langfuse traces showed 342K and 546K input — well above the 192K trigger). Telemetry was correct; rotation gating was reading the wrong number.
- **Adds `contextManagement.reflectionThresholdChars`** (default 40000, min 1000) so the observation-log consolidation threshold (previously a hardcoded `MAX_OBSERVATION_CHARS` constant in `context-roller.ts`) is now operator-tunable.

## What changed

**Per-step vs cumulative split** (openai-compatible provider):
- `usage.ts`: `extractUsage` split into `extractPerStepUsage` + `extractCumulativeUsage`. No cross-kind mixing.
- Wrapper streaming loop maintains three accumulators:
  - `perStepUsage` (last model turn) → emitted as `lastStepUsage`.
  - `cumulativeUsage` (from native `totalUsage` / `output.usage`) → emitted as `usage`.
  - `summedPerStep` (running sum of per-step inputs) → fallback for `usage` when the provider only emits per-step shapes, preserving billing accuracy.
- `ProviderResult` and `AgentRunResult` get an optional `lastStepUsage?: AgentUsage` field.
- `agent-runner` captures `lastStepUsage` alongside `usage` and uses `lastStepUsage ?? usage` for rotation gating only. Telemetry (`runs.input_tokens`, Langfuse `usageDetails`) still uses cumulative `usage`.

**Configurable reflector threshold**:
- New `agentRunner.providers.<name>.contextManagement.reflectionThresholdChars` zod field (default 40000, min 1000).
- Threaded through `agent-runner` → `checkAndRotateOM(..., reflectionThresholdChars)` → `maybeReflect`.
- `MAX_OBSERVATION_CHARS` renamed to `DEFAULT_MAX_OBSERVATION_CHARS` and used only as the default.

## Verification

- 1000 unit tests passing across `tests/unit/providers`, `tests/unit/daemon`, `tests/unit/core`.
- New tests cover: per-step extractor, cumulative extractor, legacy combined extractor, two-accumulator streaming invariants (per-step survives trailing cumulative finish chunk; cumulative survives partial per-step-only chunks; cachedInputTokens stays in its own accumulator; summed-per-step fallback semantics), and configurable reflector threshold behavior (default 40K skips, override 5K triggers).
- `npm run build` clean.
- Reviewed by Codex (gpt-5.4, high reasoning): no critical/high/medium issues remaining.

## Test plan

- [ ] Pull, `npm run build`, restart daemon.
- [ ] Watch a few braintoss runs in Langfuse — rotation should stop firing on every run; `runs.input_tokens` should remain the cumulative number (not under-reported).
- [ ] Confirm `lastStepUsage` appears on openai-compatible result envelopes (or in agent-runner logs) — claude-code and codex-cli traces should be unaffected.
- [ ] Optionally lower `openai-compatible.contextManagement.reflectionThresholdChars` to ~15000 and watch for earlier reflector consolidation on the assistant thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)