### PR TITLE
fix(scheduler): support --prompt-file in CLI, defensively parse "file:" prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1652,8 +1652,11 @@ If your upstream does not emit `prompt_tokens_details`, `cache_read_input_tokens
 | `--channel <name>` | Channel to bind the schedule thread to (required) | — |
 | `--cron <expr>` | Cron expression, 5-field (required) | — |
 | `--label <label>` | Human-readable label (required) | — |
-| `--prompt <prompt>` | Prompt text for the agent (required) | — |
+| `--prompt <prompt>` | Inline prompt text. Mutually exclusive with `--prompt-file`. | — |
+| `--prompt-file <name>` | Prompt file basename (without `.md`) under `personas/<persona>/prompts/`. Resolved by the scheduler at fire time. Mutually exclusive with `--prompt`. | — |
 | `--config <path>` | Path to talond.yaml | `talond.yaml` |
+
+Exactly one of `--prompt` or `--prompt-file` must be provided. `--prompt-file` is preferred for reusable, long-form prompts (e.g. `--prompt-file braintoss` resolves to `personas/<persona>/prompts/braintoss.md` at fire time).
 
 **`list-schedules`** options:
 
@@ -1669,8 +1672,14 @@ If your upstream does not emit `prompt_tokens_details`, `cache_read_input_tokens
 | `--config <path>` | Path to talond.yaml | `talond.yaml` |
 
 ```bash
+# Inline prompt
 npx talonctl add-schedule --persona assistant --channel my-telegram \
   --cron "0 8 * * 1-5" --label "Morning briefing" --prompt "Give me a morning briefing"
+
+# Reusable prompt file (resolves to personas/assistant/prompts/braintoss.md)
+npx talonctl add-schedule --persona assistant --channel my-telegram \
+  --cron "*/15 6-23 * * *" --label "Braintoss inbox" --prompt-file braintoss
+
 npx talonctl list-schedules --persona assistant
 npx talonctl remove-schedule abc123
 ```

--- a/src/cli/commands/add-schedule.ts
+++ b/src/cli/commands/add-schedule.ts
@@ -28,7 +28,17 @@ export interface AddScheduleOptions {
   channel: string;
   cron: string;
   label: string;
-  prompt: string;
+  /**
+   * Inline prompt text. Mutually exclusive with `promptFile`. Exactly one
+   * of the two MUST be provided — `addSchedule()` throws otherwise.
+   */
+  prompt?: string;
+  /**
+   * Prompt file basename (no `.md`) in the persona's `prompts/` directory.
+   * The scheduler resolves this to file content at fire time via
+   * `personaLoader.resolveTaskPrompt`. Mutually exclusive with `prompt`.
+   */
+  promptFile?: string;
   db: Database.Database;
 }
 
@@ -54,7 +64,19 @@ export interface AddScheduleResult {
  * @throws Error with a descriptive message on any failure.
  */
 export function addSchedule(options: AddScheduleOptions): AddScheduleResult {
-  const { db, persona, channel, cron, label, prompt } = options;
+  const { db, persona, channel, cron, label, prompt, promptFile } = options;
+
+  // --- Validate prompt vs promptFile (exactly one required) ---------------
+  // Match the host-tool contract (schedule-manage.ts buildSchedulePayload):
+  // a schedule needs either inline prompt text OR a promptFile alias —
+  // never both, never neither. Catching this here keeps the DB clean even
+  // when addSchedule() is called programmatically (e.g. from a setup skill).
+  if (prompt !== undefined && promptFile !== undefined) {
+    throw new Error('addSchedule: prompt and promptFile are mutually exclusive');
+  }
+  if (prompt === undefined && promptFile === undefined) {
+    throw new Error('addSchedule: one of prompt or promptFile is required');
+  }
 
   // --- Validate cron expression (must be exactly 5 fields) ----------------
   const cronFields = cron.trim().split(/\s+/);
@@ -119,9 +141,15 @@ export function addSchedule(options: AddScheduleOptions): AddScheduleResult {
   const nextRunAt = nextRunResult.value;
 
   // --- Insert schedule row -----------------------------------------------
+  // Payload shape matches what the scheduler reads at fire time:
+  //   { label, prompt }      — inline text used as-is
+  //   { label, promptFile }  — basename resolved to prompts/<name>.md content
+  // The two are mutually exclusive (validated above).
   const scheduleId = uuidv4();
   const scheduleRepo = new ScheduleRepository(db);
-  const payload = JSON.stringify({ label, prompt });
+  const payload = JSON.stringify(
+    promptFile !== undefined ? { label, promptFile } : { label, prompt },
+  );
 
   const insertResult = scheduleRepo.insert({
     id: scheduleId,
@@ -244,7 +272,8 @@ export async function addScheduleCommand(options: {
   channel: string;
   cron: string;
   label: string;
-  prompt: string;
+  prompt?: string;
+  promptFile?: string;
   configPath?: string;
 }): Promise<void> {
   const { loadConfig } = await import('../../core/config/config-loader.js');
@@ -277,7 +306,8 @@ export async function addScheduleCommand(options: {
       channel: options.channel,
       cron: options.cron,
       label: options.label,
-      prompt: options.prompt,
+      ...(options.prompt !== undefined ? { prompt: options.prompt } : {}),
+      ...(options.promptFile !== undefined ? { promptFile: options.promptFile } : {}),
       db,
     });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -424,15 +424,38 @@ program
   .requiredOption('--channel <name>', 'Channel to bind the schedule thread to')
   .requiredOption('--cron <expr>', 'Cron expression (5-field)')
   .requiredOption('--label <label>', 'Human-readable label')
-  .requiredOption('--prompt <prompt>', 'Prompt text for the agent')
+  .option('--prompt <prompt>', 'Inline prompt text (mutually exclusive with --prompt-file)')
+  .option(
+    '--prompt-file <name>',
+    'Prompt file basename in the persona\'s prompts/ dir (without .md), resolved by the scheduler at fire time',
+  )
   .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
-  .action(async (opts: { persona: string; channel: string; cron: string; label: string; prompt: string; config: string }) => {
+  .action(async (opts: {
+    persona: string;
+    channel: string;
+    cron: string;
+    label: string;
+    prompt?: string;
+    promptFile?: string;
+    config: string;
+  }) => {
+    if (opts.prompt && opts.promptFile) {
+      console.error('Error: --prompt and --prompt-file are mutually exclusive');
+      process.exit(1);
+      return;
+    }
+    if (!opts.prompt && !opts.promptFile) {
+      console.error('Error: provide one of --prompt or --prompt-file');
+      process.exit(1);
+      return;
+    }
     await addScheduleCommand({
       persona: opts.persona,
       channel: opts.channel,
       cron: opts.cron,
       label: opts.label,
-      prompt: opts.prompt,
+      ...(opts.prompt !== undefined ? { prompt: opts.prompt } : {}),
+      ...(opts.promptFile !== undefined ? { promptFile: opts.promptFile } : {}),
       configPath: opts.config,
     });
   });

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -175,19 +175,27 @@ export class Scheduler {
       // Defensive: agents and humans sometimes invent `prompt: "file:NAME"`
       // as if it were a documented convention (it isn't). Without this
       // promotion, the literal string ships to the agent and it falls back
-      // to grepping/reading the file itself — expensive and non-deterministic.
-      // Promote the alias here and warn so the operator can fix the schedule
-      // row (or the agent that created it).
-      if (!promptFile && content.startsWith('file:')) {
-        const aliased = content.slice('file:'.length).trim();
-        if (aliased.length > 0) {
+      // to grepping for the file itself — expensive and non-deterministic.
+      //
+      // The pattern MUST be strict (`file:` followed by exactly one filename
+      // token and nothing else) to avoid hijacking a legitimate prompt that
+      // happens to start with the word "file:" — e.g.
+      // `"file: summarize the latest backup log"`. A loose match would
+      // discard such a prompt's body and call resolveTaskPrompt against an
+      // alias that does not exist, which fails and stalls the schedule
+      // (early return = no enqueue + no next-run advance).
+      const FILE_ALIAS_RE = /^file:([A-Za-z0-9._-]+)$/;
+      if (!promptFile) {
+        const match = FILE_ALIAS_RE.exec(content.trim());
+        if (match) {
+          const aliased = match[1];
           this.logger.warn(
             {
               scheduleId: schedule.id,
               personaId: schedule.persona_id,
               aliased,
             },
-            'scheduler: prompt starts with "file:" — treating as promptFile alias. Update the schedule payload to use {promptFile: "..."} explicitly.',
+            'scheduler: prompt matches "file:<name>" — treating as promptFile alias. Update the schedule payload to use {promptFile: "..."} explicitly.',
           );
           promptFile = aliased;
           content = '';

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -167,10 +167,32 @@ export class Scheduler {
       }
 
       const schedulePayload = rawPayload as SchedulePayload & Record<string, unknown>;
-      const promptFile =
+      let promptFile =
         typeof schedulePayload.promptFile === 'string' ? schedulePayload.promptFile : undefined;
       let content =
         typeof schedulePayload.prompt === 'string' ? schedulePayload.prompt : '';
+
+      // Defensive: agents and humans sometimes invent `prompt: "file:NAME"`
+      // as if it were a documented convention (it isn't). Without this
+      // promotion, the literal string ships to the agent and it falls back
+      // to grepping/reading the file itself — expensive and non-deterministic.
+      // Promote the alias here and warn so the operator can fix the schedule
+      // row (or the agent that created it).
+      if (!promptFile && content.startsWith('file:')) {
+        const aliased = content.slice('file:'.length).trim();
+        if (aliased.length > 0) {
+          this.logger.warn(
+            {
+              scheduleId: schedule.id,
+              personaId: schedule.persona_id,
+              aliased,
+            },
+            'scheduler: prompt starts with "file:" — treating as promptFile alias. Update the schedule payload to use {promptFile: "..."} explicitly.',
+          );
+          promptFile = aliased;
+          content = '';
+        }
+      }
 
       if (promptFile) {
         const promptResult = await this.personaLoader.resolveTaskPrompt(schedule.persona_id, promptFile);

--- a/tests/unit/cli/schedule-commands.test.ts
+++ b/tests/unit/cli/schedule-commands.test.ts
@@ -259,6 +259,58 @@ describe('addSchedule()', () => {
       }),
     ).toThrow('Expected exactly 5 fields');
   });
+
+  it('writes {label, promptFile} payload when --prompt-file is supplied', () => {
+    // The scheduler reads payload.promptFile and resolves it through
+    // personaLoader.resolveTaskPrompt at fire time. The CLI must write
+    // that exact field name so existing scheduler logic picks it up.
+    const { personaName, channelName } = seedPersonaAndChannel();
+
+    const result = addSchedule({
+      persona: personaName,
+      channel: channelName,
+      cron: '*/15 6-23 * * *',
+      label: 'braintoss',
+      promptFile: 'braintoss',
+      db,
+    });
+
+    const row = new ScheduleRepository(db).findById(result.id)._unsafeUnwrap();
+    const payload = JSON.parse(row!.payload);
+    expect(payload).toEqual({ label: 'braintoss', promptFile: 'braintoss' });
+    // Must NOT also write `prompt` — that would confuse the scheduler.
+    expect(payload.prompt).toBeUndefined();
+  });
+
+  it('throws when both prompt and promptFile are supplied', () => {
+    const { personaName, channelName } = seedPersonaAndChannel();
+
+    expect(() =>
+      addSchedule({
+        persona: personaName,
+        channel: channelName,
+        cron: '0 9 * * *',
+        label: 'mixed',
+        prompt: 'inline',
+        promptFile: 'something',
+        db,
+      }),
+    ).toThrow('mutually exclusive');
+  });
+
+  it('throws when neither prompt nor promptFile is supplied', () => {
+    const { personaName, channelName } = seedPersonaAndChannel();
+
+    expect(() =>
+      addSchedule({
+        persona: personaName,
+        channel: channelName,
+        cron: '0 9 * * *',
+        label: 'no-prompt',
+        db,
+      }),
+    ).toThrow('one of prompt or promptFile is required');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -262,6 +262,62 @@ describe('Scheduler', () => {
       expect(enqueued.content).not.toContain('file:braintoss');
     });
 
+    it('does NOT promote a prompt whose body legitimately starts with "file:"', async () => {
+      // Regression guard: a prompt like `"file: summarize the latest backup log"`
+      // is real prose, not a promptFile alias. A loose `startsWith("file:")`
+      // check would discard the body and call resolveTaskPrompt() with a
+      // nonexistent alias — leaving the schedule stuck (no enqueue, no
+      // next-run advance). The strict `^file:<name>$` pattern guarantees
+      // only the exact agent-invented shape is promoted.
+      const prose = 'file: summarize the latest backup log';
+      const payload = { label: 'Prose with colon', prompt: prose };
+      seedDueSchedule(db, personaId, threadId, {
+        type: 'one_shot',
+        payload: JSON.stringify(payload),
+      });
+
+      scheduler.start();
+      await wait(150);
+      scheduler.stop();
+
+      expect(personaLoader.resolveTaskPrompt).not.toHaveBeenCalled();
+      const enqueueCalls = (queueStub.enqueue as ReturnType<typeof vi.fn>).mock.calls;
+      expect(enqueueCalls).toHaveLength(1);
+      const enqueued = enqueueCalls[0][2] as Record<string, unknown>;
+      expect(enqueued.content).toBe(prose);
+    });
+
+    it('does NOT promote "file:" followed by content with spaces or special chars', async () => {
+      // A few near-miss patterns that must NOT be treated as aliases:
+      // file:name with space, file:name@host, file:/absolute/path, etc.
+      const nearMisses = [
+        'file:my name',
+        'file:user@host',
+        'file:/etc/passwd',
+        'file:name?query',
+      ];
+
+      for (const prompt of nearMisses) {
+        vi.mocked(personaLoader.resolveTaskPrompt).mockClear();
+        (queueStub.enqueue as ReturnType<typeof vi.fn>).mockClear();
+        const myThread = seedThread(db);
+        seedDueSchedule(db, personaId, myThread, {
+          type: 'one_shot',
+          payload: JSON.stringify({ label: 'near-miss', prompt }),
+        });
+
+        scheduler.start();
+        await wait(150);
+        scheduler.stop();
+
+        expect(personaLoader.resolveTaskPrompt).not.toHaveBeenCalled();
+        const calls = (queueStub.enqueue as ReturnType<typeof vi.fn>).mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(1);
+        const last = calls[calls.length - 1][2] as Record<string, unknown>;
+        expect(last.content).toBe(prompt);
+      }
+    });
+
     it('prefers explicit promptFile over a file:-prefixed prompt when both are set', async () => {
       // If a schedule somehow has BOTH `promptFile: "real"` and
       // `prompt: "file:other"`, the explicit promptFile wins — the

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -235,6 +235,55 @@ describe('Scheduler', () => {
       });
     });
 
+    it('promotes prompt:"file:NAME" to a promptFile alias and resolves it', async () => {
+      // Regression guard: an agent/human that creates a schedule with
+      // `prompt: "file:foo"` (a non-documented convention they invented)
+      // would otherwise ship the literal string to the agent, which then
+      // wastes turns greppingfor the file. The scheduler defensively
+      // recognises the prefix and routes through resolveTaskPrompt.
+      vi.mocked(personaLoader.resolveTaskPrompt).mockResolvedValue(ok('Resolved prompt body'));
+      const payload = { label: 'Braintoss', prompt: 'file:braintoss' };
+      seedDueSchedule(db, personaId, threadId, {
+        type: 'one_shot',
+        payload: JSON.stringify(payload),
+      });
+
+      scheduler.start();
+      await wait(150);
+      scheduler.stop();
+
+      expect(personaLoader.resolveTaskPrompt).toHaveBeenCalledWith(personaId, 'braintoss');
+      const enqueueCalls = (queueStub.enqueue as ReturnType<typeof vi.fn>).mock.calls;
+      expect(enqueueCalls).toHaveLength(1);
+      const enqueued = enqueueCalls[0][2] as Record<string, unknown>;
+      expect(enqueued.content).toBe('Resolved prompt body');
+      // The literal `file:braintoss` string must NOT survive into content
+      // — otherwise the agent would still see it and discover the file.
+      expect(enqueued.content).not.toContain('file:braintoss');
+    });
+
+    it('prefers explicit promptFile over a file:-prefixed prompt when both are set', async () => {
+      // If a schedule somehow has BOTH `promptFile: "real"` and
+      // `prompt: "file:other"`, the explicit promptFile wins — the
+      // defensive promotion is fallback-only, not an override.
+      vi.mocked(personaLoader.resolveTaskPrompt).mockResolvedValue(ok('Real body'));
+      const payload = {
+        label: 'Mixed',
+        promptFile: 'real',
+        prompt: 'file:other',
+      };
+      seedDueSchedule(db, personaId, threadId, {
+        type: 'one_shot',
+        payload: JSON.stringify(payload),
+      });
+
+      scheduler.start();
+      await wait(150);
+      scheduler.stop();
+
+      expect(personaLoader.resolveTaskPrompt).toHaveBeenCalledWith(personaId, 'real');
+    });
+
     it('uses the thread_id of the schedule when enqueuing', async () => {
       const anotherThread = seedThread(db);
       seedDueSchedule(db, personaId, anotherThread, { type: 'one_shot' });


### PR DESCRIPTION
## Summary

- **Adds `--prompt-file <name>` to `talonctl add-schedule`.** Previously the CLI only exposed `--prompt`, even though the scheduler and the `schedule_manage` host-tool both support `promptFile` (a basename in `personas/<persona>/prompts/` that the scheduler resolves to file content at fire time via `resolveTaskPrompt`). Users reaching for the file-resolved pattern via the CLI typically improvised `--prompt file:braintoss`, which shipped the literal string to the agent and forced it to grep/read the file itself (visible in Langfuse traces — many wasted `mastra_workspace_grep` / `mastra_workspace_read_file` turns per run).
- **Defensively promotes legacy `prompt: "file:NAME"` shape** in the scheduler with a strict regex (`^file:([A-Za-z0-9._-]+)$`) so existing broken schedule rows keep working — with a `warn` log pointing the operator at the fix.
- **One DB row repaired locally**: the live `braintoss` schedule (`173bb7f1-…`) had `prompt: "file:braintoss"`; updated in place to `promptFile: "braintoss"`.

## What changed

**CLI** (`src/cli/index.ts`, `src/cli/commands/add-schedule.ts`):
- `add-schedule` accepts `--prompt` OR `--prompt-file`, mutually exclusive, exactly one required.
- `addSchedule()` validates the same invariant programmatically.
- Writes `{label, prompt}` or `{label, promptFile}` (never both, never neither) into the schedule row.

**Scheduler** (`src/scheduler/scheduler.ts`):
- Strict pattern match (`^file:([A-Za-z0-9._-]+)$` against the trimmed prompt) promotes a legacy `prompt: "file:NAME"` payload to a `promptFile` alias when no explicit `promptFile` is set. Warns with the schedule ID + alias.
- Pattern is intentionally narrow:
  - Legitimate prose like `"file: summarize the latest backup log"` falls through unchanged (has a space).
  - `/` is excluded so the alias can't express path traversal.
  - Explicit `promptFile` always wins over a `file:`-prefixed prompt (fallback-only).

**Docs** (`README.md`): updated the `add-schedule` reference table + example to cover `--prompt-file`.

## Verification

- 822 unit tests pass across `tests/unit/scheduler`, `tests/unit/cli`, `tests/unit/providers`, `tests/unit/daemon`.
- New tests:
  - scheduler: `file:NAME` promotion happens and the literal content does NOT leak through; explicit `promptFile` wins; **prose starting with `"file:"` is NOT promoted**; four near-miss patterns (`file:my name`, `file:user@host`, `file:/etc/passwd`, `file:name?query`) are NOT promoted.
  - addSchedule: writes `{label, promptFile}` shape; throws on both `--prompt` and `--prompt-file`; throws on neither.
- Codex (gpt-5.4, high) reviewed in two passes. Initial Medium ("loose `startsWith` could hijack legitimate prose") was addressed by tightening to the regex. No critical/high/medium issues remain.

## Test plan

- [ ] Pull, `npm run build`, restart daemon.
- [ ] Watch the braintoss schedule fire — its payload was repaired locally, so this run should resolve `personas/assistant/prompts/braintoss.md` deterministically (no `mastra_workspace_grep` chasing in the trace).
- [ ] Try the new flag: `npx talonctl add-schedule --persona assistant --channel TalonMain --cron "*/15 6-23 * * *" --label braintoss-test --prompt-file braintoss` — inspect the DB row to confirm `{label, promptFile}` shape.
- [ ] Confirm legitimate prose like `--prompt "file: summarize today"` still works as a literal prompt (no promotion).
- [ ] Any pre-existing broken schedule rows on your machine (e.g. created by an agent during testing) will keep working via the defensive promotion, with a `scheduler: prompt matches "file:<name>"` warn log identifying them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)