### PR TITLE
fix(openai-compatible): kill MCP subprocess descendants on wrapper exit

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -121,7 +121,26 @@ export class TalondDaemon {
     injectSiblingBotIds(this.ctx.channelRegistry, this.logger);
 
     // 5. Start queue processing.
-    this.ctx.queueManager.startProcessing((item) => this.agentRunner!.run(item));
+    //
+    // Wrap the runner in a per-item finally that sweeps any orphaned MCP
+    // subprocesses left behind by this run. Long-lived daemons accumulate
+    // orphans between runs when the provider's CLI (`claude`, `gemini`,
+    // `codex`) exits and its `mcp-remote`-style grandchildren reparent to
+    // PID 1 while still holding their resources (e.g. port 8787). The
+    // boot-time reaper from cleanupOrphanedMcpChildren only fires on
+    // restart; this hook makes it fire after every queue item so the next
+    // run on the same persona doesn't hit a port collision. See #210.
+    this.ctx.queueManager.startProcessing(async (item) => {
+      try {
+        return await this.agentRunner!.run(item);
+      } finally {
+        try {
+          cleanupOrphanedMcpChildren(this.logger);
+        } catch (cause) {
+          this.logger.warn({ cause }, 'daemon: post-run MCP orphan sweep failed');
+        }
+      }
+    });
 
     // 6. Start scheduler.
     this.ctx.scheduler.start();

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -134,6 +134,25 @@ export class TalondDaemon {
       try {
         return await this.agentRunner!.run(item);
       } finally {
+        // The Anthropic Agent SDK's `query()` can resolve a beat ahead of
+        // the underlying `claude` process's kernel-side exit. During that
+        // window the spawned MCP grandchildren (e.g. mcp-remote) still
+        // have `claude` as their parent in /proc, so the reaper's
+        // PPID==1 filter skips them and the orphan is left behind to
+        // collide with the next agent run's MCP spawn (issue #210, the
+        // cross-run race).
+        //
+        // Give the kernel a moment to reap `claude` and re-parent its
+        // descendants to PID 1 before we sweep. 500 ms is generous; on a
+        // healthy host the exit completes within a few ms. Tests can set
+        // TALON_MCP_SWEEP_SETTLE_MS=0 to skip the delay.
+        const settleMs = Number.parseInt(
+          process.env.TALON_MCP_SWEEP_SETTLE_MS ?? '500',
+          10,
+        );
+        if (Number.isFinite(settleMs) && settleMs > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, settleMs));
+        }
         try {
           cleanupOrphanedMcpChildren(this.logger);
         } catch (cause) {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -24,6 +24,7 @@ import { AgentRunner } from './agent-runner.js';
 import { writePidFile, removePidFile } from './lifecycle.js';
 import { WatchdogNotifier } from './watchdog.js';
 import { registerChannels, injectSiblingBotIds } from '../channels/channel-setup.js';
+import { cleanupOrphanedMcpChildren } from './mcp-orphan-cleanup.js';
 
 import type { DaemonContext } from './daemon-context.js';
 import type { DaemonState, DaemonHealth } from './daemon-types.js';
@@ -64,6 +65,14 @@ export class TalondDaemon {
 
     this._state = 'starting';
     this.logger.info({ configPath }, 'daemon: starting');
+
+    // 0. Sweep orphaned MCP subprocesses left behind by previous runs. The
+    // openai-compatible wrapper's per-run cleanup is the primary fix for
+    // issue #210; this catches the case where the wrapper itself died
+    // before its `finally` block could run (e.g. SIGKILL on timeout) and
+    // a marked grandchild is still holding a port (e.g. mcp-remote's
+    // OAuth callback). No-op on non-Linux.
+    cleanupOrphanedMcpChildren(this.logger);
 
     // 1. Bootstrap — builds the full DaemonContext or fails.
     const ctxResult = await bootstrap(configPath, this.logger);

--- a/src/daemon/mcp-orphan-cleanup.ts
+++ b/src/daemon/mcp-orphan-cleanup.ts
@@ -1,16 +1,27 @@
 /**
- * Daemon-boot defensive cleanup for orphaned MCP subprocesses.
+ * Reaper for orphaned MCP subprocesses identified by the
+ * `TALON_MCP_CHILD=1` env marker that every Talon provider stamps onto
+ * its stdio MCP children.
  *
- * The openai-compatible wrapper stamps `TALON_MCP_CHILD=1` on every stdio
- * MCP child it spawns and sweeps its descendant tree on exit. That covers
- * the normal exit path, but if the wrapper itself dies abruptly (e.g.
- * SIGKILL on a parent timeout), the stamped grandchildren can still
- * reparent to PID 1 and survive across daemon restarts.
+ * The function runs in two places:
  *
- * This module runs once at daemon boot and SIGKILLs any process whose
- * environment carries the marker and whose parent is PID 1. It is a
- * defensive net for past leaks only — the normal exit path is the
- * primary fix (see openai-compatible/agent-cli/process-cleanup.ts).
+ *   1. Daemon boot — cleans up orphans left by a previous daemon
+ *      process. The openai-compatible wrapper sweeps its own descendant
+ *      tree on exit, but if the wrapper itself dies abruptly (e.g.
+ *      SIGKILL on parent timeout) the stamped grandchildren can still
+ *      reparent to PID 1 and survive across a restart.
+ *
+ *   2. After every queue item — closes the cross-run gap inside a
+ *      single daemon session. The CLI providers (`claude`, `gemini`,
+ *      `codex`) spawn MCPs as their own descendants and Talon has no
+ *      per-process `finally` block to clean them up. When the CLI exits
+ *      its MCP grandchildren reparent to PID 1 still holding their
+ *      ports (e.g. `mcp-remote`'s OAuth callback on 8787), and the next
+ *      agent run on the same persona collides. Reaping right after each
+ *      run keeps that from accumulating.
+ *
+ * Either invocation SIGKILLs every process whose environment carries
+ * the marker and whose parent is PID 1.
  *
  * Linux is the supported scanning target (uses `/proc/<pid>/environ`,
  * `/proc/<pid>/stat`). On other platforms the function is a no-op since

--- a/src/daemon/mcp-orphan-cleanup.ts
+++ b/src/daemon/mcp-orphan-cleanup.ts
@@ -1,0 +1,150 @@
+/**
+ * Daemon-boot defensive cleanup for orphaned MCP subprocesses.
+ *
+ * The openai-compatible wrapper stamps `TALON_MCP_CHILD=1` on every stdio
+ * MCP child it spawns and sweeps its descendant tree on exit. That covers
+ * the normal exit path, but if the wrapper itself dies abruptly (e.g.
+ * SIGKILL on a parent timeout), the stamped grandchildren can still
+ * reparent to PID 1 and survive across daemon restarts.
+ *
+ * This module runs once at daemon boot and SIGKILLs any process whose
+ * environment carries the marker and whose parent is PID 1. It is a
+ * defensive net for past leaks only — the normal exit path is the
+ * primary fix (see openai-compatible/agent-cli/process-cleanup.ts).
+ *
+ * Linux is the supported scanning target (uses `/proc/<pid>/environ`,
+ * `/proc/<pid>/stat`). On other platforms the function is a no-op since
+ * the process environment of an arbitrary PID is not portably readable.
+ *
+ * See https://github.com/ivo-toby/talon/issues/210.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import type { Logger } from 'pino';
+import { MCP_CHILD_MARKER_ENV } from '../providers/openai-compatible/agent-cli/process-cleanup.js';
+
+export interface OrphanCleanupResult {
+  scanned: number;
+  candidates: number[];
+  killed: number[];
+}
+
+export interface OrphanCleanupOptions {
+  /** Override for tests. Defaults to scanning `/proc` on Linux. */
+  findCandidates?: () => number[];
+  /** Override for tests. Defaults to `process.kill`. */
+  kill?: (pid: number, signal: NodeJS.Signals) => boolean;
+}
+
+/**
+ * Scan for orphaned MCP subprocesses and SIGKILL them.
+ *
+ * No-op on non-Linux platforms. Errors from individual /proc reads are
+ * swallowed — entries disappear as processes exit, which is expected.
+ */
+export function cleanupOrphanedMcpChildren(
+  logger: Logger,
+  options: OrphanCleanupOptions = {},
+): OrphanCleanupResult {
+  if (process.platform !== 'linux') {
+    return { scanned: 0, candidates: [], killed: [] };
+  }
+
+  const findCandidates = options.findCandidates ?? findOrphanedMarkedPids;
+  const kill =
+    options.kill
+    ?? ((pid: number, signal: NodeJS.Signals): boolean => {
+      try {
+        process.kill(pid, signal);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+  let candidates: number[];
+  try {
+    candidates = findCandidates();
+  } catch (cause) {
+    logger.warn({ cause }, 'mcp-orphan-cleanup: scan failed, skipping');
+    return { scanned: 0, candidates: [], killed: [] };
+  }
+
+  const killed: number[] = [];
+  for (const pid of candidates) {
+    if (kill(pid, 'SIGKILL')) {
+      killed.push(pid);
+    }
+  }
+
+  if (killed.length > 0) {
+    logger.warn(
+      { killed },
+      'mcp-orphan-cleanup: killed orphaned MCP subprocesses left over from a previous run',
+    );
+  } else {
+    logger.debug({ candidates }, 'mcp-orphan-cleanup: no orphans found');
+  }
+
+  return { scanned: candidates.length, candidates, killed };
+}
+
+/**
+ * Walk /proc for processes that (a) are reparented to PID 1 and (b) have
+ * the MCP marker env var set. Returns the matching PIDs.
+ */
+function findOrphanedMarkedPids(): number[] {
+  const orphaned: number[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync('/proc');
+  } catch {
+    return orphaned;
+  }
+
+  const selfPid = process.pid;
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+    const pid = Number.parseInt(entry, 10);
+    if (pid === selfPid || pid === 1) continue;
+
+    const ppid = readPpid(pid);
+    if (ppid !== 1) continue;
+
+    if (!hasMarkerEnv(pid)) continue;
+
+    orphaned.push(pid);
+  }
+  return orphaned;
+}
+
+function readPpid(pid: number): number | undefined {
+  let stat: string;
+  try {
+    stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+  } catch {
+    return undefined;
+  }
+  // /proc/<pid>/stat format: pid (comm) state ppid ...
+  // The `comm` field may contain spaces/parens; locate the LAST ')' so we
+  // parse the fields that follow it reliably.
+  const close = stat.lastIndexOf(')');
+  if (close < 0) return undefined;
+  const fields = stat.slice(close + 2).split(' ');
+  if (fields.length < 2) return undefined;
+  const ppid = Number.parseInt(fields[1], 10);
+  return Number.isInteger(ppid) ? ppid : undefined;
+}
+
+function hasMarkerEnv(pid: number): boolean {
+  let raw: Buffer;
+  try {
+    raw = readFileSync(`/proc/${pid}/environ`);
+  } catch {
+    return false;
+  }
+  const needle = `${MCP_CHILD_MARKER_ENV}=`;
+  for (const entry of raw.toString('utf8').split('\0')) {
+    if (entry.startsWith(needle)) return true;
+  }
+  return false;
+}

--- a/src/daemon/mcp-orphan-cleanup.ts
+++ b/src/daemon/mcp-orphan-cleanup.ts
@@ -20,7 +20,7 @@
  */
 import { readFileSync, readdirSync } from 'node:fs';
 import type { Logger } from 'pino';
-import { MCP_CHILD_MARKER_ENV } from '../providers/openai-compatible/agent-cli/process-cleanup.js';
+import { MCP_CHILD_MARKER_ENV } from '../providers/mcp-child-marker.js';
 
 export interface OrphanCleanupResult {
   scanned: number;

--- a/src/providers/claude-code-provider.ts
+++ b/src/providers/claude-code-provider.ts
@@ -14,6 +14,7 @@ import type {
   ProviderSpawnInput,
 } from './provider-types.js';
 import type { ProviderConfig } from '../core/config/config-types.js';
+import { stampMcpChildMarker } from './mcp-child-marker.js';
 
 export class ClaudeCodeProvider implements AgentProvider {
   readonly name = 'claude-code';
@@ -280,11 +281,14 @@ export class ClaudeCodeProvider implements AgentProvider {
       }
 
       if (server.transport === 'stdio') {
+        // Stamp the TALON_MCP_CHILD marker so the daemon-boot orphan
+        // reaper can clean up any subprocess that leaks past the SDK or
+        // the `claude` CLI (see daemon/mcp-orphan-cleanup.ts, issue #210).
         nativeServers[name] = {
           type: 'stdio',
           command: server.command,
           args: server.args,
-          ...(server.env ? { env: server.env } : {}),
+          env: stampMcpChildMarker(server.env),
         };
         continue;
       }

--- a/src/providers/codex-cli-provider.ts
+++ b/src/providers/codex-cli-provider.ts
@@ -25,6 +25,7 @@ import type {
   ProviderResult,
   ProviderSpawnInput,
 } from './provider-types.js';
+import { stampMcpChildMarker } from './mcp-child-marker.js';
 
 interface CodexCliProviderRuntime {
   dataDir: string;
@@ -199,13 +200,16 @@ export class CodexCliProvider implements AgentProvider {
         lines.push(`args = [${server.args.map((arg) => JSON.stringify(arg)).join(', ')}]`);
         lines.push('');
 
-        if (server.env && Object.keys(server.env).length > 0) {
-          lines.push(`[${tableName}.env]`);
-          for (const [key, value] of Object.entries(server.env)) {
-            lines.push(`${key} = ${JSON.stringify(value)}`);
-          }
-          lines.push('');
+        // Always emit the env table so the TALON_MCP_CHILD marker is
+        // present even when the user did not configure any MCP env vars.
+        // The marker lets the daemon-boot orphan reaper identify and clean
+        // up subprocesses that leak past the `codex` CLI (issue #210).
+        const stampedEnv = stampMcpChildMarker(server.env);
+        lines.push(`[${tableName}.env]`);
+        for (const [key, value] of Object.entries(stampedEnv)) {
+          lines.push(`${key} = ${JSON.stringify(value)}`);
         }
+        lines.push('');
         continue;
       }
 

--- a/src/providers/gemini-cli-provider.ts
+++ b/src/providers/gemini-cli-provider.ts
@@ -15,6 +15,7 @@ import type {
   ProviderResult,
   ProviderSpawnInput,
 } from './provider-types.js';
+import { stampMcpChildMarker } from './mcp-child-marker.js';
 
 interface GeminiTokens {
   input?: number;
@@ -239,10 +240,13 @@ export class GeminiCliProvider implements AgentProvider {
       }
 
       if (server.transport === 'stdio') {
+        // Stamp the TALON_MCP_CHILD marker so the daemon-boot orphan
+        // reaper can clean up any subprocess that leaks past the
+        // `gemini` CLI (see daemon/mcp-orphan-cleanup.ts, issue #210).
         nativeServers[name] = {
           command: server.command,
           args: server.args,
-          ...(server.env ? { env: server.env } : {}),
+          env: stampMcpChildMarker(server.env),
         };
         continue;
       }

--- a/src/providers/mcp-child-marker.ts
+++ b/src/providers/mcp-child-marker.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared env marker stamped on every stdio MCP child Talon spawns.
+ *
+ * Lives in its own tiny module so every provider (and the daemon-boot
+ * orphan reaper) can reference the same string without pulling in the
+ * openai-compatible wrapper or the daemon-side cleanup logic.
+ *
+ * See https://github.com/ivo-toby/talon/issues/210.
+ */
+
+/** Env var name set to "1" on every stdio MCP subprocess. */
+export const MCP_CHILD_MARKER_ENV = 'TALON_MCP_CHILD';
+
+/**
+ * Merge the marker into an MCP server's env block. Always returns a new
+ * object — callers should pass the existing env unchanged.
+ */
+export function stampMcpChildMarker(
+  env: Record<string, string> | undefined,
+): Record<string, string> {
+  return { ...(env ?? {}), [MCP_CHILD_MARKER_ENV]: '1' };
+}

--- a/src/providers/openai-compatible/agent-cli/index.ts
+++ b/src/providers/openai-compatible/agent-cli/index.ts
@@ -19,7 +19,7 @@ import {
   DEFAULT_TOOL_OUTPUT_CAP,
   DEFAULT_FETCH_SLICE_CAP,
 } from './tool-output-excerpter.js';
-import { killDescendantTree } from './process-cleanup.js';
+import { snapshotDescendantPids, terminateProcesses } from './process-cleanup.js';
 import { stampMcpChildMarker } from '../../mcp-child-marker.js';
 
 interface WrapperInput {
@@ -424,15 +424,29 @@ async function main(): Promise<void> {
     });
     process.exitCode = 1;
   } finally {
+    // Issue #210 race-safe teardown: Mastra's MCPClient.disconnect() only
+    // SIGTERMs the direct stdio child. When that child is an `npx`/shell
+    // shim, the real MCP `node` process gets reparented to PID 1 the
+    // instant the shim dies — at which point a "find descendants of
+    // wrapper" walk finds nothing.
+    //
+    // Snapshot the descendant tree FIRST, then run disconnect, then
+    // signal the snapshotted PIDs. Pids that disconnect already cleaned
+    // up are filtered out by the alive-check in terminateProcesses.
+    let descendantsSnapshot: number[] = [];
+    try {
+      descendantsSnapshot = snapshotDescendantPids(process.pid);
+    } catch (cause) {
+      process.stderr.write(
+        `openai-compatible wrapper: descendant snapshot failed: ${cause instanceof Error ? cause.message : String(cause)}\n`,
+      );
+    }
+
     await mcpClient?.disconnect().catch(() => {});
     await workspace?.destroy().catch(() => {});
-    // Safety net for issue #210: Mastra's MCPClient.disconnect() only kills
-    // the direct stdio child. When that child is an `npx`/shell shim, the
-    // real MCP `node` process gets reparented to PID 1 and keeps holding
-    // its resources (ports, sockets) — silently breaking subsequent runs.
-    // Sweep the wrapper's descendant tree ourselves so nothing survives us.
+
     try {
-      const survivors = await killDescendantTree(process.pid, {
+      const survivors = await terminateProcesses(descendantsSnapshot, {
         onSurvivor: (pid) => {
           process.stderr.write(
             `openai-compatible wrapper: SIGKILL escalation on surviving descendant pid=${pid}\n`,

--- a/src/providers/openai-compatible/agent-cli/index.ts
+++ b/src/providers/openai-compatible/agent-cli/index.ts
@@ -19,7 +19,8 @@ import {
   DEFAULT_TOOL_OUTPUT_CAP,
   DEFAULT_FETCH_SLICE_CAP,
 } from './tool-output-excerpter.js';
-import { killDescendantTree, MCP_CHILD_MARKER_ENV } from './process-cleanup.js';
+import { killDescendantTree } from './process-cleanup.js';
+import { stampMcpChildMarker } from '../../mcp-child-marker.js';
 
 interface WrapperInput {
   prompt: string;
@@ -625,15 +626,13 @@ function toMastraMcpServers(
 
   for (const [name, server] of Object.entries(mcpServers)) {
     if (server.transport === 'stdio') {
-      // Stamp a marker env var on every stdio MCP child. The wrapper uses
-      // its descendant process tree to clean up survivors on exit; the
-      // marker lets a defensive daemon-boot pass identify any process that
-      // still leaks past the wrapper (e.g. wrapper killed with SIGKILL by
-      // the parent timeout). See process-cleanup.ts and issue #210.
+      // Stamp the shared TALON_MCP_CHILD marker so the daemon-boot orphan
+      // reaper can identify and clean up any subprocess that leaks past
+      // this wrapper (see process-cleanup.ts + mcp-orphan-cleanup.ts).
       servers[name] = {
         command: server.command,
         args: server.args,
-        env: { ...(server.env ?? {}), [MCP_CHILD_MARKER_ENV]: '1' },
+        env: stampMcpChildMarker(server.env),
         cwd: process.cwd(),
       };
       continue;

--- a/src/providers/openai-compatible/agent-cli/index.ts
+++ b/src/providers/openai-compatible/agent-cli/index.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_TOOL_OUTPUT_CAP,
   DEFAULT_FETCH_SLICE_CAP,
 } from './tool-output-excerpter.js';
+import { killDescendantTree, MCP_CHILD_MARKER_ENV } from './process-cleanup.js';
 
 interface WrapperInput {
   prompt: string;
@@ -424,6 +425,29 @@ async function main(): Promise<void> {
   } finally {
     await mcpClient?.disconnect().catch(() => {});
     await workspace?.destroy().catch(() => {});
+    // Safety net for issue #210: Mastra's MCPClient.disconnect() only kills
+    // the direct stdio child. When that child is an `npx`/shell shim, the
+    // real MCP `node` process gets reparented to PID 1 and keeps holding
+    // its resources (ports, sockets) — silently breaking subsequent runs.
+    // Sweep the wrapper's descendant tree ourselves so nothing survives us.
+    try {
+      const survivors = await killDescendantTree(process.pid, {
+        onSurvivor: (pid) => {
+          process.stderr.write(
+            `openai-compatible wrapper: SIGKILL escalation on surviving descendant pid=${pid}\n`,
+          );
+        },
+      });
+      if (survivors.length > 0) {
+        process.stderr.write(
+          `openai-compatible wrapper: cleaned up ${survivors.length} descendant process(es) after MCP disconnect\n`,
+        );
+      }
+    } catch (cause) {
+      process.stderr.write(
+        `openai-compatible wrapper: descendant cleanup failed: ${cause instanceof Error ? cause.message : String(cause)}\n`,
+      );
+    }
   }
 }
 
@@ -601,10 +625,15 @@ function toMastraMcpServers(
 
   for (const [name, server] of Object.entries(mcpServers)) {
     if (server.transport === 'stdio') {
+      // Stamp a marker env var on every stdio MCP child. The wrapper uses
+      // its descendant process tree to clean up survivors on exit; the
+      // marker lets a defensive daemon-boot pass identify any process that
+      // still leaks past the wrapper (e.g. wrapper killed with SIGKILL by
+      // the parent timeout). See process-cleanup.ts and issue #210.
       servers[name] = {
         command: server.command,
         args: server.args,
-        ...(server.env ? { env: server.env } : {}),
+        env: { ...(server.env ?? {}), [MCP_CHILD_MARKER_ENV]: '1' },
         cwd: process.cwd(),
       };
       continue;

--- a/src/providers/openai-compatible/agent-cli/process-cleanup.ts
+++ b/src/providers/openai-compatible/agent-cli/process-cleanup.ts
@@ -9,9 +9,15 @@
  * `mcp-remote`). The next wrapper run then fails to bind the port and
  * Mastra silently drops the MCP from the toolset.
  *
- * This module provides a wrapper-level safety net that walks the wrapper's
- * descendant process tree at teardown and signals every surviving descendant
- * directly, regardless of what the upstream library did.
+ * This module provides a wrapper-level safety net. Critically the API is
+ * split into a *snapshot* step and a *terminate* step, so callers can
+ * record the descendant tree BEFORE asking the upstream library to
+ * disconnect. Otherwise the race below defeats the whole point:
+ *
+ *   1. snapshot → Mastra disconnect kills npx
+ *   2. sh / node reparent to PID 1
+ *   3. tree walk run AFTER disconnect would find nothing — the orphans are
+ *      no longer descendants of the wrapper.
  *
  * See https://github.com/ivo-toby/talon/issues/210.
  */
@@ -94,6 +100,21 @@ export function collectDescendantPids(rootPid: number, processes: ProcessInfo[])
 }
 
 /**
+ * Snapshot the descendant PIDs of `rootPid` from the live process table.
+ *
+ * Call this BEFORE the upstream library tears down its direct child. If
+ * you snapshot afterwards, grandchildren that have already been reparented
+ * to PID 1 will not appear in the tree and you will not be able to kill
+ * them.
+ */
+export function snapshotDescendantPids(
+  rootPid: number,
+  readProcesses: () => ProcessInfo[] = readProcessTable,
+): number[] {
+  return collectDescendantPids(rootPid, readProcesses());
+}
+
+/**
  * Best-effort signal delivery. Returns true on success, false when the
  * process no longer exists or the signal could not be delivered.
  */
@@ -118,31 +139,71 @@ export function isPidAlive(pid: number): boolean {
   }
 }
 
-export interface KillDescendantsOptions {
+export interface TerminateOptions {
   /** How long to wait after SIGTERM before escalating to SIGKILL. */
   gracePeriodMs?: number;
-  /**
-   * Optional injection point for tests. Defaults to `readProcessTable`.
-   */
-  readProcesses?: () => ProcessInfo[];
   /** Optional sleep override for tests. */
   sleep?: (ms: number) => Promise<void>;
   /** Optional liveness check override for tests. */
   isAlive?: (pid: number) => boolean;
   /** Optional signal override for tests. Should match `process.kill` semantics. */
   signal?: (pid: number, sig: NodeJS.Signals) => boolean;
-  /** Optional callback for diagnostic logging. */
+  /** Optional callback invoked for each pid escalated to SIGKILL. */
   onSurvivor?: (pid: number) => void;
 }
 
 /**
- * Walk the wrapper's descendant process tree and signal every survivor.
+ * Send SIGTERM to every pid, wait `gracePeriodMs`, then SIGKILL anything
+ * still alive. Best-effort: individual signal failures are swallowed.
  *
- * Sends SIGTERM first so processes get a chance to clean up (close ports,
- * release sockets), then escalates to SIGKILL after `gracePeriodMs`. The
- * function is best-effort: errors from individual `process.kill` calls are
- * swallowed since the target may legitimately be gone by the time the
- * signal lands.
+ * Skips pids that are already dead at call time so we don't accidentally
+ * race against PID reuse on busy hosts.
+ *
+ * @returns the pids that received at least one signal attempt.
+ */
+export async function terminateProcesses(
+  pids: readonly number[],
+  options: TerminateOptions = {},
+): Promise<number[]> {
+  if (pids.length === 0) return [];
+
+  const sleep = options.sleep ?? defaultSleep;
+  const aliveCheck = options.isAlive ?? isPidAlive;
+  const signal = options.signal ?? trySignal;
+  const gracePeriodMs = options.gracePeriodMs ?? 500;
+
+  const targets = pids.filter((pid) => aliveCheck(pid));
+  if (targets.length === 0) return [];
+
+  for (const pid of targets) {
+    signal(pid, 'SIGTERM');
+  }
+
+  await sleep(gracePeriodMs);
+
+  for (const pid of targets) {
+    if (aliveCheck(pid)) {
+      options.onSurvivor?.(pid);
+      signal(pid, 'SIGKILL');
+    }
+  }
+
+  return targets;
+}
+
+export interface KillDescendantsOptions extends TerminateOptions {
+  /** Optional injection point for tests. Defaults to `readProcessTable`. */
+  readProcesses?: () => ProcessInfo[];
+}
+
+/**
+ * Convenience: snapshot descendants and terminate them in one call.
+ *
+ * NOT appropriate when an upstream `disconnect`/`destroy` step runs
+ * between the snapshot and the terminate — for that case, call
+ * `snapshotDescendantPids` first, run the disconnect, then
+ * `terminateProcesses` on the snapshot. See the wrapper's `finally`
+ * block for the canonical example.
  *
  * @returns the PIDs we attempted to terminate (does not imply success).
  */
@@ -151,29 +212,8 @@ export async function killDescendantTree(
   options: KillDescendantsOptions = {},
 ): Promise<number[]> {
   const readProcesses = options.readProcesses ?? readProcessTable;
-  const sleep = options.sleep ?? defaultSleep;
-  const aliveCheck = options.isAlive ?? isPidAlive;
-  const signal = options.signal ?? trySignal;
-  const gracePeriodMs = options.gracePeriodMs ?? 500;
-
-  const processes = readProcesses();
-  const descendants = collectDescendantPids(rootPid, processes);
-  if (descendants.length === 0) return [];
-
-  for (const pid of descendants) {
-    signal(pid, 'SIGTERM');
-  }
-
-  await sleep(gracePeriodMs);
-
-  for (const pid of descendants) {
-    if (aliveCheck(pid)) {
-      options.onSurvivor?.(pid);
-      signal(pid, 'SIGKILL');
-    }
-  }
-
-  return descendants;
+  const descendants = snapshotDescendantPids(rootPid, readProcesses);
+  return terminateProcesses(descendants, options);
 }
 
 function defaultSleep(ms: number): Promise<void> {
@@ -181,3 +221,4 @@ function defaultSleep(ms: number): Promise<void> {
     setTimeout(resolve, ms).unref();
   });
 }
+

--- a/src/providers/openai-compatible/agent-cli/process-cleanup.ts
+++ b/src/providers/openai-compatible/agent-cli/process-cleanup.ts
@@ -17,8 +17,7 @@
  */
 import { execFileSync } from 'node:child_process';
 
-/** Env marker stamped on every stdio MCP child spawned by the wrapper. */
-export const MCP_CHILD_MARKER_ENV = 'TALON_MCP_CHILD';
+export { MCP_CHILD_MARKER_ENV } from '../../mcp-child-marker.js';
 
 export interface ProcessInfo {
   pid: number;

--- a/src/providers/openai-compatible/agent-cli/process-cleanup.ts
+++ b/src/providers/openai-compatible/agent-cli/process-cleanup.ts
@@ -1,0 +1,184 @@
+/**
+ * Process-tree cleanup utilities for the openai-compatible wrapper.
+ *
+ * Background: Mastra's `MCPClient.disconnect()` ultimately calls
+ * `child.kill('SIGTERM')` on the direct stdio child only. When that child is
+ * an `npx` shim it spawns a `sh` shim that spawns the real MCP `node`
+ * process. Killing the npx shim leaves `sh` and `node` reparented to PID 1,
+ * still holding their resources (e.g. the OAuth callback port of
+ * `mcp-remote`). The next wrapper run then fails to bind the port and
+ * Mastra silently drops the MCP from the toolset.
+ *
+ * This module provides a wrapper-level safety net that walks the wrapper's
+ * descendant process tree at teardown and signals every surviving descendant
+ * directly, regardless of what the upstream library did.
+ *
+ * See https://github.com/ivo-toby/talon/issues/210.
+ */
+import { execFileSync } from 'node:child_process';
+
+/** Env marker stamped on every stdio MCP child spawned by the wrapper. */
+export const MCP_CHILD_MARKER_ENV = 'TALON_MCP_CHILD';
+
+export interface ProcessInfo {
+  pid: number;
+  ppid: number;
+}
+
+/**
+ * Read the full process table as (pid, ppid) pairs.
+ *
+ * Uses `ps -A -o pid=,ppid=` which is supported on both Linux and macOS.
+ * Returns an empty list when `ps` is unavailable or fails — callers must
+ * treat cleanup as best-effort.
+ */
+export function readProcessTable(): ProcessInfo[] {
+  let output: string;
+  try {
+    output = execFileSync('ps', ['-A', '-o', 'pid=,ppid='], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000,
+    });
+  } catch {
+    return [];
+  }
+
+  const processes: ProcessInfo[] = [];
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 2) continue;
+    const pid = Number.parseInt(parts[0], 10);
+    const ppid = Number.parseInt(parts[1], 10);
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+    processes.push({ pid, ppid });
+  }
+  return processes;
+}
+
+/**
+ * Collect every descendant PID of `rootPid`, given a process table.
+ *
+ * The root itself is excluded from the result. Walks the tree iteratively
+ * (BFS) so deeply-nested chains (wrapper → npx → sh → node) are all
+ * captured.
+ */
+export function collectDescendantPids(rootPid: number, processes: ProcessInfo[]): number[] {
+  const childrenByParent = new Map<number, number[]>();
+  for (const proc of processes) {
+    const siblings = childrenByParent.get(proc.ppid);
+    if (siblings) {
+      siblings.push(proc.pid);
+    } else {
+      childrenByParent.set(proc.ppid, [proc.pid]);
+    }
+  }
+
+  const descendants: number[] = [];
+  const queue: number[] = [rootPid];
+  const seen = new Set<number>([rootPid]);
+  while (queue.length > 0) {
+    const next = queue.shift();
+    if (next === undefined) break;
+    const children = childrenByParent.get(next);
+    if (!children) continue;
+    for (const child of children) {
+      if (seen.has(child)) continue;
+      seen.add(child);
+      descendants.push(child);
+      queue.push(child);
+    }
+  }
+  return descendants;
+}
+
+/**
+ * Best-effort signal delivery. Returns true on success, false when the
+ * process no longer exists or the signal could not be delivered.
+ */
+function trySignal(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether the given PID is still alive.
+ */
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface KillDescendantsOptions {
+  /** How long to wait after SIGTERM before escalating to SIGKILL. */
+  gracePeriodMs?: number;
+  /**
+   * Optional injection point for tests. Defaults to `readProcessTable`.
+   */
+  readProcesses?: () => ProcessInfo[];
+  /** Optional sleep override for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Optional liveness check override for tests. */
+  isAlive?: (pid: number) => boolean;
+  /** Optional signal override for tests. Should match `process.kill` semantics. */
+  signal?: (pid: number, sig: NodeJS.Signals) => boolean;
+  /** Optional callback for diagnostic logging. */
+  onSurvivor?: (pid: number) => void;
+}
+
+/**
+ * Walk the wrapper's descendant process tree and signal every survivor.
+ *
+ * Sends SIGTERM first so processes get a chance to clean up (close ports,
+ * release sockets), then escalates to SIGKILL after `gracePeriodMs`. The
+ * function is best-effort: errors from individual `process.kill` calls are
+ * swallowed since the target may legitimately be gone by the time the
+ * signal lands.
+ *
+ * @returns the PIDs we attempted to terminate (does not imply success).
+ */
+export async function killDescendantTree(
+  rootPid: number,
+  options: KillDescendantsOptions = {},
+): Promise<number[]> {
+  const readProcesses = options.readProcesses ?? readProcessTable;
+  const sleep = options.sleep ?? defaultSleep;
+  const aliveCheck = options.isAlive ?? isPidAlive;
+  const signal = options.signal ?? trySignal;
+  const gracePeriodMs = options.gracePeriodMs ?? 500;
+
+  const processes = readProcesses();
+  const descendants = collectDescendantPids(rootPid, processes);
+  if (descendants.length === 0) return [];
+
+  for (const pid of descendants) {
+    signal(pid, 'SIGTERM');
+  }
+
+  await sleep(gracePeriodMs);
+
+  for (const pid of descendants) {
+    if (aliveCheck(pid)) {
+      options.onSurvivor?.(pid);
+      signal(pid, 'SIGKILL');
+    }
+  }
+
+  return descendants;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms).unref();
+  });
+}

--- a/tests/unit/daemon/daemon.test.ts
+++ b/tests/unit/daemon/daemon.test.ts
@@ -184,9 +184,14 @@ describe('TalondDaemon', () => {
   beforeEach(() => {
     daemon = new TalondDaemon(createSilentLogger());
     vi.clearAllMocks();
+    // The production code adds a 500ms settle delay before the post-run
+    // MCP sweep so the kernel can reap the just-exited CLI subprocess and
+    // re-parent its MCP descendants to PID 1. Skip the delay in tests.
+    process.env.TALON_MCP_SWEEP_SETTLE_MS = '0';
   });
 
   afterEach(async () => {
+    delete process.env.TALON_MCP_SWEEP_SETTLE_MS;
     if (daemon.state !== 'stopped') {
       await daemon.stop();
     }
@@ -291,6 +296,34 @@ describe('TalondDaemon', () => {
       void result;
 
       expect(cleanupOrphanedMcpChildren).toHaveBeenCalledTimes(1);
+    });
+
+    it('settles for TALON_MCP_SWEEP_SETTLE_MS before sweeping (race fix for #210)', async () => {
+      // Reproduces the cross-run race: the SDK's query() can resolve a
+      // beat ahead of the underlying claude process's kernel-side exit,
+      // so the post-run sweep must wait for descendants to re-parent to
+      // PID 1 before walking /proc. The delay is read from
+      // TALON_MCP_SWEEP_SETTLE_MS so tests can opt out.
+      process.env.TALON_MCP_SWEEP_SETTLE_MS = '120';
+      try {
+        const ctx = setupSuccessfulBootstrap();
+        await daemon.start('/config.yaml');
+
+        const handler = (ctx.queueManager.startProcessing as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+        expect(typeof handler).toBe('function');
+        vi.mocked(cleanupOrphanedMcpChildren).mockClear();
+
+        const start = Date.now();
+        await handler!({ id: 'q1', threadId: 't1', payload: {} } as unknown);
+        const elapsed = Date.now() - start;
+
+        expect(cleanupOrphanedMcpChildren).toHaveBeenCalledTimes(1);
+        // Within a tolerance — the handler resolves AFTER the settle
+        // delay completes, so elapsed must be at least the configured ms.
+        expect(elapsed).toBeGreaterThanOrEqual(100);
+      } finally {
+        process.env.TALON_MCP_SWEEP_SETTLE_MS = '0';
+      }
     });
 
     it('runs the post-run MCP orphan sweep even when the runner throws', async () => {

--- a/tests/unit/daemon/daemon.test.ts
+++ b/tests/unit/daemon/daemon.test.ts
@@ -39,6 +39,14 @@ vi.mock('../../../src/skills/skill-loader.js', () => ({
   })),
 }));
 
+vi.mock('../../../src/daemon/mcp-orphan-cleanup.js', () => ({
+  cleanupOrphanedMcpChildren: vi.fn().mockReturnValue({
+    scanned: 0,
+    candidates: [],
+    killed: [],
+  }),
+}));
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -48,6 +56,7 @@ import { bootstrap } from '../../../src/daemon/daemon-bootstrap.js';
 import { loadConfig } from '../../../src/core/config/config-loader.js';
 import { writePidFile, removePidFile } from '../../../src/daemon/lifecycle.js';
 import { injectSiblingBotIds } from '../../../src/channels/channel-setup.js';
+import { cleanupOrphanedMcpChildren } from '../../../src/daemon/mcp-orphan-cleanup.js';
 import { DaemonError } from '../../../src/core/errors/index.js';
 import type { DaemonContext } from '../../../src/daemon/daemon-context.js';
 import { createDiscardLogger } from './helpers.js';
@@ -258,6 +267,43 @@ describe('TalondDaemon', () => {
       await daemon.start('/config.yaml');
 
       expect(ctx.queueManager.startProcessing).toHaveBeenCalledOnce();
+    });
+
+    it('sweeps orphaned MCP subprocesses after every queue item (cross-run gap, issue #210)', async () => {
+      const ctx = setupSuccessfulBootstrap();
+
+      await daemon.start('/config.yaml');
+
+      // Capture the handler the daemon wired into queueManager.startProcessing.
+      const handler = (ctx.queueManager.startProcessing as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(typeof handler).toBe('function');
+
+      const runnerOk = ok(undefined);
+      // The wrapper calls the runner first, then runs the sweep in finally.
+      vi.mocked(cleanupOrphanedMcpChildren).mockClear();
+
+      const result = await handler!({ id: 'q1', threadId: 't1', payload: {} } as unknown);
+      // The handler should return whatever the underlying runner returned. We
+      // are not asserting on result.shape here — the relevant assertion is
+      // that the sweep ran. AgentRunner is not stubbed in these mocks, so
+      // the handler may resolve to an err; that is fine because the sweep
+      // runs in finally.
+      void result;
+
+      expect(cleanupOrphanedMcpChildren).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs the post-run MCP orphan sweep even when the runner throws', async () => {
+      const ctx = setupSuccessfulBootstrap();
+      await daemon.start('/config.yaml');
+
+      const handler = (ctx.queueManager.startProcessing as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(typeof handler).toBe('function');
+      vi.mocked(cleanupOrphanedMcpChildren).mockClear();
+
+      await handler!(null as unknown).catch(() => {});
+
+      expect(cleanupOrphanedMcpChildren).toHaveBeenCalledTimes(1);
     });
 
     it('starts scheduler after bootstrap', async () => {

--- a/tests/unit/daemon/mcp-orphan-cleanup.test.ts
+++ b/tests/unit/daemon/mcp-orphan-cleanup.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { cleanupOrphanedMcpChildren } from '../../../src/daemon/mcp-orphan-cleanup.js';
+
+const stubLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+} as unknown as Parameters<typeof cleanupOrphanedMcpChildren>[0];
+
+describe('cleanupOrphanedMcpChildren', () => {
+  it('is a no-op on non-Linux platforms', () => {
+    if (process.platform === 'linux') {
+      // Skip on Linux — the early-return guard is not exercised.
+      return;
+    }
+    const findCandidates = vi.fn(() => [123]);
+    const kill = vi.fn(() => true);
+    const result = cleanupOrphanedMcpChildren(stubLogger, { findCandidates, kill });
+    expect(result).toEqual({ scanned: 0, candidates: [], killed: [] });
+    expect(findCandidates).not.toHaveBeenCalled();
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('SIGKILLs every candidate returned by the scanner', () => {
+    if (process.platform !== 'linux') return;
+    const kill = vi.fn(() => true);
+    const result = cleanupOrphanedMcpChildren(stubLogger, {
+      findCandidates: () => [101, 202, 303],
+      kill,
+    });
+    expect(result.scanned).toBe(3);
+    expect(result.candidates).toEqual([101, 202, 303]);
+    expect(result.killed).toEqual([101, 202, 303]);
+    expect(kill.mock.calls).toEqual([
+      [101, 'SIGKILL'],
+      [202, 'SIGKILL'],
+      [303, 'SIGKILL'],
+    ]);
+  });
+
+  it('reports zero kills when no orphans match', () => {
+    if (process.platform !== 'linux') return;
+    const kill = vi.fn(() => true);
+    const result = cleanupOrphanedMcpChildren(stubLogger, {
+      findCandidates: () => [],
+      kill,
+    });
+    expect(result).toEqual({ scanned: 0, candidates: [], killed: [] });
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('skips PIDs whose kill call fails (process already gone)', () => {
+    if (process.platform !== 'linux') return;
+    const result = cleanupOrphanedMcpChildren(stubLogger, {
+      findCandidates: () => [10, 20],
+      kill: (pid) => pid === 10, // only 10 succeeds
+    });
+    expect(result.killed).toEqual([10]);
+    expect(result.candidates).toEqual([10, 20]);
+  });
+
+  it('survives a scanner that throws and returns an empty result', () => {
+    if (process.platform !== 'linux') return;
+    const result = cleanupOrphanedMcpChildren(stubLogger, {
+      findCandidates: () => {
+        throw new Error('boom');
+      },
+    });
+    expect(result).toEqual({ scanned: 0, candidates: [], killed: [] });
+  });
+});

--- a/tests/unit/providers/claude-code-provider.test.ts
+++ b/tests/unit/providers/claude-code-provider.test.ts
@@ -66,7 +66,10 @@ describe('ClaudeCodeProvider', () => {
           type: 'stdio',
           command: 'node',
           args: ['dist/tools/host-tools-mcp-server.js'],
-          env: { TALOND_SOCKET: '/tmp/talond.sock' },
+          // TALON_MCP_CHILD marker is stamped on every stdio MCP child so
+          // the daemon-boot orphan reaper can recognize subprocesses we
+          // spawned. See providers/mcp-child-marker.ts and issue #210.
+          env: { TALOND_SOCKET: '/tmp/talond.sock', TALON_MCP_CHILD: '1' },
         },
         remoteBrowser: {
           type: 'http',

--- a/tests/unit/providers/gemini-cli-provider.test.ts
+++ b/tests/unit/providers/gemini-cli-provider.test.ts
@@ -100,7 +100,10 @@ describe('GeminiCliProvider', () => {
         hostTools: {
           command: 'node',
           args: ['dist/tools/host-tools-mcp-server.js'],
-          env: { TALOND_SOCKET: '/tmp/talond.sock' },
+          // TALON_MCP_CHILD marker is stamped on every stdio MCP child
+          // so the daemon-boot orphan reaper can recognize subprocesses
+          // we spawned. See providers/mcp-child-marker.ts and issue #210.
+          env: { TALOND_SOCKET: '/tmp/talond.sock', TALON_MCP_CHILD: '1' },
         },
         remoteBrowser: {
           httpUrl: 'https://mcp.example.test',

--- a/tests/unit/providers/mcp-child-marker.test.ts
+++ b/tests/unit/providers/mcp-child-marker.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MCP_CHILD_MARKER_ENV,
+  stampMcpChildMarker,
+} from '../../../src/providers/mcp-child-marker.js';
+
+describe('stampMcpChildMarker', () => {
+  it('exposes the canonical env var name', () => {
+    expect(MCP_CHILD_MARKER_ENV).toBe('TALON_MCP_CHILD');
+  });
+
+  it('adds the marker to an undefined env', () => {
+    expect(stampMcpChildMarker(undefined)).toEqual({ TALON_MCP_CHILD: '1' });
+  });
+
+  it('adds the marker to an empty env', () => {
+    expect(stampMcpChildMarker({})).toEqual({ TALON_MCP_CHILD: '1' });
+  });
+
+  it('preserves existing env entries', () => {
+    expect(stampMcpChildMarker({ FOO: 'bar', BAZ: 'qux' })).toEqual({
+      FOO: 'bar',
+      BAZ: 'qux',
+      TALON_MCP_CHILD: '1',
+    });
+  });
+
+  it('overrides any pre-existing marker value', () => {
+    expect(stampMcpChildMarker({ TALON_MCP_CHILD: '0' })).toEqual({
+      TALON_MCP_CHILD: '1',
+    });
+  });
+
+  it('returns a new object — does not mutate the input', () => {
+    const input = { FOO: 'bar' };
+    const result = stampMcpChildMarker(input);
+    expect(input).toEqual({ FOO: 'bar' });
+    expect(result).not.toBe(input);
+  });
+});

--- a/tests/unit/providers/openai-compatible-process-cleanup.test.ts
+++ b/tests/unit/providers/openai-compatible-process-cleanup.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  collectDescendantPids,
+  killDescendantTree,
+  MCP_CHILD_MARKER_ENV,
+  type ProcessInfo,
+} from '../../../src/providers/openai-compatible/agent-cli/process-cleanup.js';
+
+describe('collectDescendantPids', () => {
+  it('returns an empty list when the root has no children', () => {
+    const table: ProcessInfo[] = [
+      { pid: 100, ppid: 1 },
+      { pid: 200, ppid: 1 },
+    ];
+    expect(collectDescendantPids(100, table)).toEqual([]);
+  });
+
+  it('walks the full chain (wrapper → npx → sh → node)', () => {
+    const table: ProcessInfo[] = [
+      { pid: 100, ppid: 1 }, // wrapper
+      { pid: 200, ppid: 100 }, // npx
+      { pid: 300, ppid: 200 }, // sh
+      { pid: 400, ppid: 300 }, // node mcp-remote
+      { pid: 999, ppid: 1 }, // unrelated
+    ];
+    const descendants = collectDescendantPids(100, table);
+    expect(descendants).toEqual(expect.arrayContaining([200, 300, 400]));
+    expect(descendants).not.toContain(100);
+    expect(descendants).not.toContain(999);
+    expect(descendants).toHaveLength(3);
+  });
+
+  it('handles multiple branches under the root', () => {
+    const table: ProcessInfo[] = [
+      { pid: 100, ppid: 1 },
+      { pid: 200, ppid: 100 },
+      { pid: 201, ppid: 100 },
+      { pid: 300, ppid: 200 },
+      { pid: 301, ppid: 201 },
+    ];
+    const descendants = collectDescendantPids(100, table).sort((a, b) => a - b);
+    expect(descendants).toEqual([200, 201, 300, 301]);
+  });
+
+  it('ignores cycles defensively (does not loop forever)', () => {
+    // Pathological table — ppid points back at the descendant.
+    const table: ProcessInfo[] = [
+      { pid: 100, ppid: 1 },
+      { pid: 200, ppid: 100 },
+      { pid: 100, ppid: 200 },
+    ];
+    const descendants = collectDescendantPids(100, table);
+    expect(descendants).toEqual([200]);
+  });
+});
+
+describe('killDescendantTree', () => {
+  it('signals every descendant with SIGTERM and escalates to SIGKILL on survivors', async () => {
+    const table: ProcessInfo[] = [
+      { pid: 100, ppid: 1 }, // wrapper (self)
+      { pid: 200, ppid: 100 },
+      { pid: 300, ppid: 200 }, // this one "survives" SIGTERM
+    ];
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+
+    const result = await killDescendantTree(100, {
+      readProcesses: () => table,
+      sleep: async () => {},
+      isAlive: (pid) => pid === 300, // 200 dies on SIGTERM, 300 survives
+      signal: (pid, sig) => {
+        signals.push({ pid, signal: sig });
+        return true;
+      },
+      gracePeriodMs: 0,
+    });
+
+    expect(result.sort((a, b) => a - b)).toEqual([200, 300]);
+    expect(signals).toEqual([
+      { pid: 200, signal: 'SIGTERM' },
+      { pid: 300, signal: 'SIGTERM' },
+      { pid: 300, signal: 'SIGKILL' },
+    ]);
+  });
+
+  it('is a no-op when no descendants exist', async () => {
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const result = await killDescendantTree(100, {
+      readProcesses: () => [{ pid: 100, ppid: 1 }],
+      sleep: async () => {},
+      isAlive: () => false,
+      signal: (pid, sig) => {
+        signals.push({ pid, signal: sig });
+        return true;
+      },
+    });
+    expect(result).toEqual([]);
+    expect(signals).toEqual([]);
+  });
+
+  it('does not SIGKILL processes that exited during the grace period', async () => {
+    const table: ProcessInfo[] = [
+      { pid: 100, ppid: 1 },
+      { pid: 200, ppid: 100 },
+    ];
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    await killDescendantTree(100, {
+      readProcesses: () => table,
+      sleep: async () => {},
+      isAlive: () => false,
+      signal: (pid, sig) => {
+        signals.push({ pid, signal: sig });
+        return true;
+      },
+    });
+    expect(signals).toEqual([{ pid: 200, signal: 'SIGTERM' }]);
+  });
+
+  it('invokes onSurvivor for each pid escalated to SIGKILL', async () => {
+    const table: ProcessInfo[] = [
+      { pid: 100, ppid: 1 },
+      { pid: 200, ppid: 100 },
+      { pid: 300, ppid: 100 },
+    ];
+    const survivors: number[] = [];
+    await killDescendantTree(100, {
+      readProcesses: () => table,
+      sleep: async () => {},
+      isAlive: () => true,
+      signal: () => true,
+      onSurvivor: (pid) => survivors.push(pid),
+    });
+    expect(survivors.sort((a, b) => a - b)).toEqual([200, 300]);
+  });
+});
+
+describe('MCP_CHILD_MARKER_ENV', () => {
+  it('is the documented env var name', () => {
+    expect(MCP_CHILD_MARKER_ENV).toBe('TALON_MCP_CHILD');
+  });
+});

--- a/tests/unit/providers/openai-compatible-process-cleanup.test.ts
+++ b/tests/unit/providers/openai-compatible-process-cleanup.test.ts
@@ -4,6 +4,8 @@ import {
   collectDescendantPids,
   killDescendantTree,
   MCP_CHILD_MARKER_ENV,
+  snapshotDescendantPids,
+  terminateProcesses,
   type ProcessInfo,
 } from '../../../src/providers/openai-compatible/agent-cli/process-cleanup.js';
 
@@ -44,7 +46,6 @@ describe('collectDescendantPids', () => {
   });
 
   it('ignores cycles defensively (does not loop forever)', () => {
-    // Pathological table — ppid points back at the descendant.
     const table: ProcessInfo[] = [
       { pid: 100, ppid: 1 },
       { pid: 200, ppid: 100 },
@@ -55,19 +56,25 @@ describe('collectDescendantPids', () => {
   });
 });
 
-describe('killDescendantTree', () => {
-  it('signals every descendant with SIGTERM and escalates to SIGKILL on survivors', async () => {
+describe('snapshotDescendantPids', () => {
+  it('captures the descendant tree from the live process table', () => {
     const table: ProcessInfo[] = [
-      { pid: 100, ppid: 1 }, // wrapper (self)
+      { pid: 100, ppid: 1 },
       { pid: 200, ppid: 100 },
-      { pid: 300, ppid: 200 }, // this one "survives" SIGTERM
+      { pid: 300, ppid: 200 },
     ];
-    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    expect(snapshotDescendantPids(100, () => table).sort((a, b) => a - b)).toEqual([
+      200, 300,
+    ]);
+  });
+});
 
-    const result = await killDescendantTree(100, {
-      readProcesses: () => table,
+describe('terminateProcesses', () => {
+  it('SIGTERMs every alive pid then SIGKILLs survivors after the grace period', async () => {
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const result = await terminateProcesses([200, 300], {
       sleep: async () => {},
-      isAlive: (pid) => pid === 300, // 200 dies on SIGTERM, 300 survives
+      isAlive: () => true,
       signal: (pid, sig) => {
         signals.push({ pid, signal: sig });
         return true;
@@ -79,16 +86,58 @@ describe('killDescendantTree', () => {
     expect(signals).toEqual([
       { pid: 200, signal: 'SIGTERM' },
       { pid: 300, signal: 'SIGTERM' },
+      { pid: 200, signal: 'SIGKILL' },
       { pid: 300, signal: 'SIGKILL' },
     ]);
   });
 
-  it('is a no-op when no descendants exist', async () => {
+  it('does not SIGKILL processes that died during the grace period', async () => {
+    const aliveCalls: number[] = [];
+    let phase: 'before' | 'after' = 'before';
     const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
-    const result = await killDescendantTree(100, {
-      readProcesses: () => [{ pid: 100, ppid: 1 }],
+
+    await terminateProcesses([200], {
+      sleep: async () => {
+        phase = 'after';
+      },
+      isAlive: (pid) => {
+        aliveCalls.push(pid);
+        return phase === 'before';
+      },
+      signal: (pid, sig) => {
+        signals.push({ pid, signal: sig });
+        return true;
+      },
+      gracePeriodMs: 0,
+    });
+
+    expect(signals).toEqual([{ pid: 200, signal: 'SIGTERM' }]);
+  });
+
+  it('skips pids that are already dead at the start (no useless SIGTERM)', async () => {
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const result = await terminateProcesses([200, 300], {
       sleep: async () => {},
-      isAlive: () => false,
+      isAlive: (pid) => pid === 300, // 200 was already cleaned up by upstream disconnect
+      signal: (pid, sig) => {
+        signals.push({ pid, signal: sig });
+        return true;
+      },
+      gracePeriodMs: 0,
+    });
+
+    expect(result).toEqual([300]);
+    expect(signals).toEqual([
+      { pid: 300, signal: 'SIGTERM' },
+      { pid: 300, signal: 'SIGKILL' },
+    ]);
+  });
+
+  it('is a no-op when called with an empty pid list', async () => {
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const result = await terminateProcesses([], {
+      sleep: async () => {},
+      isAlive: () => true,
       signal: (pid, sig) => {
         signals.push({ pid, signal: sig });
         return true;
@@ -98,39 +147,126 @@ describe('killDescendantTree', () => {
     expect(signals).toEqual([]);
   });
 
-  it('does not SIGKILL processes that exited during the grace period', async () => {
+  it('invokes onSurvivor for each pid escalated to SIGKILL', async () => {
+    const survivors: number[] = [];
+    await terminateProcesses([200, 300], {
+      sleep: async () => {},
+      isAlive: () => true,
+      signal: () => true,
+      onSurvivor: (pid) => survivors.push(pid),
+      gracePeriodMs: 0,
+    });
+    expect(survivors.sort((a, b) => a - b)).toEqual([200, 300]);
+  });
+});
+
+describe('snapshot-then-terminate race', () => {
+  it('still kills grandchildren that get reparented to PID 1 during the upstream disconnect', async () => {
+    // BEFORE disconnect: full wrapper → npx → sh → node chain.
+    const beforeDisconnect: ProcessInfo[] = [
+      { pid: 100, ppid: 1 }, // wrapper (self)
+      { pid: 200, ppid: 100 }, // npx
+      { pid: 300, ppid: 200 }, // sh
+      { pid: 400, ppid: 300 }, // node mcp-remote (the leaker)
+    ];
+    // AFTER disconnect: Mastra killed 200, then 300/400 reparent to PID 1.
+    // A "find descendants of 100" walk done at this point would return [].
+    // The whole point of snapshot-first is to have already captured them.
+    const afterDisconnect: ProcessInfo[] = [
+      { pid: 100, ppid: 1 },
+      { pid: 300, ppid: 1 },
+      { pid: 400, ppid: 1 },
+    ];
+
+    // Step 1: snapshot BEFORE disconnect.
+    const snapshot = snapshotDescendantPids(100, () => beforeDisconnect).sort(
+      (a, b) => a - b,
+    );
+    expect(snapshot).toEqual([200, 300, 400]);
+
+    // Sanity check: a snapshot taken AFTER disconnect would miss the orphans
+    // entirely. This is precisely what the P1 review flagged in the
+    // pre-refactor wrapper code path.
+    const stalePostDisconnectSnapshot = snapshotDescendantPids(
+      100,
+      () => afterDisconnect,
+    );
+    expect(stalePostDisconnectSnapshot).toEqual([]);
+
+    // Step 2: terminate the snapshotted PIDs. 200 is gone (Mastra got it),
+    // 300 dies on SIGTERM, 400 hangs onto its port and needs SIGKILL.
+    const sigkilledSurvivors: number[] = [];
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let phase: 'before' | 'after' = 'before';
+
+    await terminateProcesses(snapshot, {
+      sleep: async () => {
+        phase = 'after';
+      },
+      isAlive: (pid) => {
+        if (pid === 200) return false; // killed by upstream
+        if (pid === 300) return phase === 'before'; // SIGTERM works
+        if (pid === 400) return true; // survives SIGTERM, needs SIGKILL
+        return false;
+      },
+      signal: (pid, sig) => {
+        signals.push({ pid, signal: sig });
+        return true;
+      },
+      onSurvivor: (pid) => sigkilledSurvivors.push(pid),
+      gracePeriodMs: 0,
+    });
+
+    expect(signals).toEqual([
+      { pid: 300, signal: 'SIGTERM' },
+      { pid: 400, signal: 'SIGTERM' },
+      { pid: 400, signal: 'SIGKILL' },
+    ]);
+    expect(sigkilledSurvivors).toEqual([400]);
+  });
+});
+
+describe('killDescendantTree (convenience wrapper)', () => {
+  it('snapshots then terminates in one call', async () => {
     const table: ProcessInfo[] = [
       { pid: 100, ppid: 1 },
       { pid: 200, ppid: 100 },
+      { pid: 300, ppid: 200 },
     ];
     const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
-    await killDescendantTree(100, {
+    const result = await killDescendantTree(100, {
       readProcesses: () => table,
       sleep: async () => {},
-      isAlive: () => false,
+      isAlive: () => true,
+      signal: (pid, sig) => {
+        signals.push({ pid, signal: sig });
+        return true;
+      },
+      gracePeriodMs: 0,
+    });
+
+    expect(result.sort((a, b) => a - b)).toEqual([200, 300]);
+    expect(signals).toEqual([
+      { pid: 200, signal: 'SIGTERM' },
+      { pid: 300, signal: 'SIGTERM' },
+      { pid: 200, signal: 'SIGKILL' },
+      { pid: 300, signal: 'SIGKILL' },
+    ]);
+  });
+
+  it('is a no-op when no descendants exist', async () => {
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const result = await killDescendantTree(100, {
+      readProcesses: () => [{ pid: 100, ppid: 1 }],
+      sleep: async () => {},
+      isAlive: () => true,
       signal: (pid, sig) => {
         signals.push({ pid, signal: sig });
         return true;
       },
     });
-    expect(signals).toEqual([{ pid: 200, signal: 'SIGTERM' }]);
-  });
-
-  it('invokes onSurvivor for each pid escalated to SIGKILL', async () => {
-    const table: ProcessInfo[] = [
-      { pid: 100, ppid: 1 },
-      { pid: 200, ppid: 100 },
-      { pid: 300, ppid: 100 },
-    ];
-    const survivors: number[] = [];
-    await killDescendantTree(100, {
-      readProcesses: () => table,
-      sleep: async () => {},
-      isAlive: () => true,
-      signal: () => true,
-      onSurvivor: (pid) => survivors.push(pid),
-    });
-    expect(survivors.sort((a, b) => a - b)).toEqual([200, 300]);
+    expect(result).toEqual([]);
+    expect(signals).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #210 — the openai-compatible wrapper was leaking MCP subprocesses across runs because Mastra's `MCPClient.disconnect()` only SIGTERMs the direct stdio child. When the child is an `npx` shim, the real MCP `node` process gets reparented to PID 1 and keeps holding its resources (e.g. `mcp-remote`'s OAuth callback port on 8787). The next wrapper run can't bind the port, Mastra silently drops the MCP from the toolset, and the agent sees the gap with no signal why.

## Fix

Three layers, smallest blast radius first:

1. **Wrapper-level descendant sweep** (primary fix, `process-cleanup.ts`). After `mcpClient.disconnect()` in the wrapper's `finally`, walk the wrapper's descendant process tree via `ps -A -o pid=,ppid=` and signal every survivor with SIGTERM, escalating to SIGKILL after a 500ms grace window. Works regardless of what Mastra or the MCP SDK do upstream — kills `npx → sh → node` chains in their entirety.

2. **Marker env var** (`TALON_MCP_CHILD=1`). Stamped on every stdio MCP child the wrapper hands to Mastra. Lets a defensive scanner positively identify processes Talon spawned without having to enumerate skill configs.

3. **Daemon-boot orphan cleanup** (`mcp-orphan-cleanup.ts`). Runs once at the start of `TalondDaemon.start()`. Scans `/proc/*/environ` on Linux for processes that (a) carry the marker and (b) have PPID=1, and SIGKILLs them. Catches the case where the wrapper itself died before its `finally` could run (e.g. SIGKILL on parent timeout). No-op on non-Linux.

The wrapper-level cleanup alone is sufficient to stop new leaks; the daemon-boot pass is a defensive net for leaks already in flight when the fix is deployed.

## Notes

- Tests added: 14 new unit tests covering descendant traversal, SIGTERM → SIGKILL escalation, grace-period exits, marker constant, scanner errors, and the non-Linux no-op path. Full suite for `tests/unit/providers/` and `tests/unit/daemon/` passes (449 tests).
- The "surface MCP startup failures to the agent" point from the issue (suggestion #4) is intentionally out of scope here — it's an observability concern that survives or fails independently of this lifecycle bug.
- `codex` skill / CLI not available in this environment, so the project's pre-commit codex review step was skipped.

## Test plan

- [x] `npx vitest run tests/unit/providers/openai-compatible-process-cleanup.test.ts tests/unit/daemon/mcp-orphan-cleanup.test.ts` — new tests
- [x] `npx vitest run tests/unit/providers/ tests/unit/daemon/` — no regressions in adjacent suites
- [x] `npm run build` — TypeScript clean
- [x] `npx eslint` on touched files — clean (project-wide lint errors are pre-existing)
- [ ] Manual repro on a persona with the Glean (`mcp-remote`) MCP: verify `node mcp-remote` no longer accumulates under PPID=1 across multiple wrapper runs, and port 8787 is released between runs.

Fixes #210.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Avxv2vQJjwLBang8g9ccma)_