### PR TITLE
feat(mcp): HTTP transport + Talon-managed OAuth for remote MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,61 @@ granted = persona.capabilities ∩ skill.requiredCapabilities
 
 Skills with unmet capabilities produce a warning at startup and are skipped.
 
+### HTTP MCP Servers and OAuth
+
+For HTTP / SSE MCP servers that require OAuth (e.g. Glean, GitHub Enterprise),
+Talon owns the token lifecycle directly — no `mcp-remote` or other stdio
+bridge process at runtime.
+
+The interactive OAuth dance lives in `talonctl auth-mcp`, runs once per
+server, and writes a refreshable token bundle into Talon's data dir. The
+daemon reads + refreshes that bundle on every agent run and injects the
+resulting `Authorization: Bearer <token>` header into the MCP server config
+before the provider sees it. Providers (claude-code, gemini-cli, codex-cli,
+openai-compatible) stay completely unaware of the OAuth flow.
+
+**Skill config shape:**
+
+```json
+{
+  "name": "glean",
+  "config": {
+    "name": "glean",
+    "transport": "http",
+    "url": "https://contentful-be.glean.com/mcp/default",
+    "auth": { "kind": "oauth2" }
+  }
+}
+```
+
+The skill loader stamps `auth.tokenStore: "<skillName>/<serverName>"` when
+omitted. Token bundles live at `<dataDir>/mcp-auth/<tokenStore>.json` (mode
+0600, atomic temp+rename writes).
+
+**One-time authorisation:**
+
+```bash
+# Interactive (operator's desktop — opens local browser)
+npx talonctl auth-mcp glean:glean
+
+# Headless (operator on the daemon's host over SSH)
+npx talonctl auth-mcp glean:glean --headless
+# Prints the auth URL plus an `ssh -L <port>:localhost:<port> server`
+# command. Run the SSH forward from your local machine, then open the URL
+# in your local browser — the callback comes back over the forward.
+```
+
+The command performs Dynamic Client Registration (RFC 7591) when the
+server advertises a `registration_endpoint`, generates a PKCE challenge,
+runs the standard authorisation-code flow, and persists the resulting
+access + refresh tokens. After it completes, the daemon picks up the new
+bundle on the next agent run — no daemon restart required.
+
+**Refresh:** the daemon automatically refreshes access tokens that fall
+within 60 s of expiry, using the cached `refresh_token` and the OAuth
+provider's `token_endpoint`. If both access and refresh have expired,
+agent runs fail loudly with a "re-run `talonctl auth-mcp`" message.
+
 ---
 
 ## Sub-Agents
@@ -1636,6 +1691,21 @@ Whether you actually see non-zero cache counts depends entirely on the **upstrea
 | Groq / Together / Fireworks                  | ❌ no                       |
 
 If your upstream does not emit `prompt_tokens_details`, `cache_read_input_tokens` will stay at 0 and `cache_creation_input_tokens` will equal `input_tokens` — that is the expected degradation, not a bug. Use `triggerMetric: input_tokens` for those endpoints.
+
+### MCP Authentication
+
+| Command | Description |
+|---------|-------------|
+| `auth-mcp <skill>:<server>` | One-time interactive OAuth flow for an HTTP MCP server. See [HTTP MCP Servers and OAuth](#http-mcp-servers-and-oauth). |
+
+**`auth-mcp`** options:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--headless` | Don't try to open a browser. Print the auth URL + suggested SSH forward command. Use this on remote daemons. | off |
+| `--port <port>` | Localhost callback port. Must match the SSH `-L` forward in headless mode. | `8788` |
+| `--config <path>` | Path to talond.yaml | `talond.yaml` |
+| `--skills-dir <path>` | Path to the skills directory | `skills` |
 
 ### Scheduling
 

--- a/src/auth/oauth-flow.ts
+++ b/src/auth/oauth-flow.ts
@@ -1,0 +1,506 @@
+/**
+ * Interactive OAuth 2.0 + PKCE flow for HTTP MCP servers.
+ *
+ * Owned by `talonctl auth-mcp`, not by the daemon. Performs:
+ *
+ *   1. Protected-resource discovery (RFC 9728) → authorization-server
+ *      metadata (RFC 8414). Either may be absent; we try both.
+ *   2. Dynamic Client Registration (RFC 7591) when supported.
+ *   3. PKCE-protected authorization code flow.
+ *   4. Code → token exchange.
+ *
+ * Result is a `CachedTokens` bundle the caller writes through
+ * `oauth-token-store.writeTokens()`.
+ *
+ * Two callback delivery modes:
+ *   - **interactive** (default): we attempt to open the user's local
+ *     browser. Suitable when the operator runs `talonctl auth-mcp` on
+ *     their desktop.
+ *   - **headless**: we print the authorization URL plus an SSH
+ *     port-forward example. The operator pastes the URL into their
+ *     local browser and the redirect comes back over the forwarded
+ *     port. This is the realistic mode for production daemons running
+ *     on remote servers.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { spawn } from 'node:child_process';
+import { createHash, randomBytes } from 'node:crypto';
+import { hostname } from 'node:os';
+import { URL } from 'node:url';
+import type { CachedTokens } from './oauth-token-store.js';
+
+/** Subset of RFC 8414 metadata we actually consume. */
+export interface AuthorizationServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint?: string;
+  /** Optional scope strings the server advertises. */
+  scopes_supported?: string[];
+  /** Code challenge methods the server accepts; we require S256. */
+  code_challenge_methods_supported?: string[];
+}
+
+/** Subset of RFC 9728 protected-resource metadata we look at. */
+export interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers?: string[];
+}
+
+export interface RunOAuthFlowOptions {
+  /** MCP resource URL — used as the OAuth `resource` parameter and discovery root. */
+  resourceUrl: string;
+  /** Suggested client name used during DCR. Defaults to `Talon (<hostname>)`. */
+  clientName?: string;
+  /**
+   * Localhost callback port. Must be reachable from the user's browser
+   * (or via SSH forward in headless mode). Defaults to 8788.
+   */
+  callbackPort?: number;
+  /**
+   * Headless mode prints the authorization URL and waits without trying
+   * to open a browser. The operator forwards the callback port
+   * themselves (e.g. `ssh -L 8788:localhost:8788 server`).
+   */
+  headless?: boolean;
+  /**
+   * How long to wait for the callback. Defaults to 5 minutes.
+   */
+  timeoutMs?: number;
+  /** Optional override fetch (tests). */
+  fetchImpl?: typeof fetch;
+  /** Where to print human-readable status. Defaults to `console.log`. */
+  printLine?: (line: string) => void;
+}
+
+export interface RunOAuthFlowResult {
+  tokens: CachedTokens;
+  authorizationServer: AuthorizationServerMetadata;
+}
+
+/**
+ * Drive the full OAuth dance and return a cached-token bundle.
+ *
+ * The caller is responsible for persisting the bundle via
+ * `writeTokens(dataDir, tokenStoreId, result.tokens)`.
+ */
+export async function runOAuthFlow(
+  options: RunOAuthFlowOptions,
+): Promise<RunOAuthFlowResult> {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const print = options.printLine ?? ((line) => process.stdout.write(`${line}\n`));
+  const callbackPort = options.callbackPort ?? 8788;
+  const clientName = options.clientName ?? `Talon (${hostname()})`;
+  const timeoutMs = options.timeoutMs ?? 5 * 60_000;
+
+  const asMeta = await discoverAuthorizationServer(options.resourceUrl, fetchImpl);
+  if (
+    asMeta.code_challenge_methods_supported
+    && !asMeta.code_challenge_methods_supported.includes('S256')
+  ) {
+    throw new Error(
+      `OAuth server at ${asMeta.issuer} does not advertise S256 PKCE support`,
+    );
+  }
+
+  const redirectUri = `http://localhost:${callbackPort}/callback`;
+  const { clientId, clientSecret } = await registerOrReuseClient(
+    asMeta,
+    redirectUri,
+    clientName,
+    fetchImpl,
+  );
+
+  const verifier = randomBase64Url(64);
+  const challenge = sha256Base64Url(verifier);
+  const state = randomBase64Url(16);
+  const scope = options.headless
+    ? asMeta.scopes_supported?.join(' ')
+    : asMeta.scopes_supported?.join(' ');
+
+  const authUrl = new URL(asMeta.authorization_endpoint);
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('code_challenge', challenge);
+  authUrl.searchParams.set('code_challenge_method', 'S256');
+  authUrl.searchParams.set('state', state);
+  authUrl.searchParams.set('resource', options.resourceUrl);
+  if (scope) authUrl.searchParams.set('scope', scope);
+
+  const callbackPromise = waitForCallback({
+    port: callbackPort,
+    expectedState: state,
+    timeoutMs,
+  });
+
+  if (options.headless) {
+    print('');
+    print('=== headless OAuth ===');
+    print('On your local machine, run:');
+    print(`  ssh -L ${callbackPort}:localhost:${callbackPort} <user@this-host>`);
+    print('');
+    print('Then open this URL in your local browser:');
+    print(`  ${authUrl.toString()}`);
+    print('');
+    print(`Waiting for callback on localhost:${callbackPort} (timeout ${Math.round(timeoutMs / 1000)}s)…`);
+    print('');
+  } else {
+    print(`Opening browser to authorise. If it does not open, visit: ${authUrl.toString()}`);
+    tryOpenBrowser(authUrl.toString());
+  }
+
+  const code = await callbackPromise;
+
+  const tokens = await exchangeCodeForTokens({
+    tokenEndpoint: asMeta.token_endpoint,
+    code,
+    redirectUri,
+    clientId,
+    clientSecret,
+    codeVerifier: verifier,
+    resource: options.resourceUrl,
+    fetchImpl,
+  });
+
+  return {
+    tokens: {
+      ...tokens,
+      tokenEndpoint: asMeta.token_endpoint,
+      ...(clientId ? { clientId } : {}),
+      ...(clientSecret ? { clientSecret } : {}),
+    },
+    authorizationServer: asMeta,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+async function discoverAuthorizationServer(
+  resourceUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<AuthorizationServerMetadata> {
+  // 1. RFC 9728 protected-resource metadata at the resource itself.
+  const prMeta = await fetchProtectedResourceMetadata(resourceUrl, fetchImpl);
+  if (prMeta?.authorization_servers && prMeta.authorization_servers.length > 0) {
+    const asUrl = prMeta.authorization_servers[0];
+    const asMeta = await fetchAuthorizationServerMetadata(asUrl, fetchImpl);
+    if (asMeta) return asMeta;
+  }
+
+  // 2. Fallback: try `.well-known/oauth-authorization-server` at the
+  //    resource's base URL. Many MCP servers (including Glean) co-locate
+  //    the AS metadata on the same origin as the resource.
+  const baseAsMeta = await fetchAuthorizationServerMetadata(resourceUrl, fetchImpl);
+  if (baseAsMeta) return baseAsMeta;
+
+  throw new Error(
+    `OAuth discovery failed for ${resourceUrl}: neither /.well-known/oauth-protected-resource nor /.well-known/oauth-authorization-server resolved a usable authorization server.`,
+  );
+}
+
+async function fetchProtectedResourceMetadata(
+  resourceUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<ProtectedResourceMetadata | undefined> {
+  const wellKnown = wellKnownUrl(resourceUrl, 'oauth-protected-resource');
+  return fetchJson<ProtectedResourceMetadata>(wellKnown, fetchImpl);
+}
+
+async function fetchAuthorizationServerMetadata(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<AuthorizationServerMetadata | undefined> {
+  const wellKnown = wellKnownUrl(baseUrl, 'oauth-authorization-server');
+  const meta = await fetchJson<AuthorizationServerMetadata>(wellKnown, fetchImpl);
+  if (!meta) return undefined;
+  if (typeof meta.authorization_endpoint !== 'string' || typeof meta.token_endpoint !== 'string') {
+    return undefined;
+  }
+  return meta;
+}
+
+/**
+ * RFC 8414 places `.well-known/` at the origin root. We try that first
+ * and fall back to a path-prefixed location so older non-conforming
+ * servers still work.
+ */
+function wellKnownUrl(input: string, suffix: string): string[] {
+  const url = new URL(input);
+  const origin = `${url.protocol}//${url.host}`;
+  const candidates = [`${origin}/.well-known/${suffix}`];
+  const path = url.pathname.replace(/\/$/, '');
+  if (path.length > 0) {
+    candidates.push(`${origin}/.well-known/${suffix}${path}`);
+  }
+  return candidates as unknown as string[];
+}
+
+async function fetchJson<T>(
+  candidates: string[] | string,
+  fetchImpl: typeof fetch,
+): Promise<T | undefined> {
+  const urls = Array.isArray(candidates) ? candidates : [candidates];
+  for (const url of urls) {
+    try {
+      const response = await fetchImpl(url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+      if (response.ok) {
+        return (await response.json()) as T;
+      }
+    } catch {
+      // try the next candidate
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic Client Registration
+// ---------------------------------------------------------------------------
+
+async function registerOrReuseClient(
+  asMeta: AuthorizationServerMetadata,
+  redirectUri: string,
+  clientName: string,
+  fetchImpl: typeof fetch,
+): Promise<{ clientId: string; clientSecret?: string }> {
+  if (!asMeta.registration_endpoint) {
+    throw new Error(
+      `OAuth server at ${asMeta.issuer} does not advertise a registration_endpoint; cannot complete dynamic client registration. Pre-register a client and add its ID to the skill config manually.`,
+    );
+  }
+
+  const body = {
+    redirect_uris: [redirectUri],
+    client_name: clientName,
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  };
+
+  let response: Response;
+  try {
+    response = await fetchImpl(asMeta.registration_endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (cause) {
+    throw new Error(
+      `dynamic client registration failed: ${stringify(cause)}`,
+    );
+  }
+
+  if (!response.ok) {
+    const text = await safeText(response);
+    throw new Error(
+      `dynamic client registration returned ${response.status} from ${asMeta.registration_endpoint}: ${text}`,
+    );
+  }
+
+  const payload = (await response.json()) as { client_id?: string; client_secret?: string };
+  if (typeof payload.client_id !== 'string') {
+    throw new Error('dynamic client registration response missing client_id');
+  }
+  return {
+    clientId: payload.client_id,
+    ...(typeof payload.client_secret === 'string' ? { clientSecret: payload.client_secret } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Callback listener + browser open
+// ---------------------------------------------------------------------------
+
+interface WaitForCallbackOptions {
+  port: number;
+  expectedState: string;
+  timeoutMs: number;
+}
+
+async function waitForCallback(options: WaitForCallbackOptions): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let settled = false;
+    const finish = (err: Error | null, code?: string): void => {
+      if (settled) return;
+      settled = true;
+      server.close();
+      clearTimeout(timer);
+      if (err) reject(err);
+      else if (code) resolve(code);
+      else reject(new Error('callback completed without a code'));
+    };
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      if (!req.url) {
+        res.writeHead(400).end();
+        return;
+      }
+      const url = new URL(req.url, `http://localhost:${options.port}`);
+      if (url.pathname !== '/callback') {
+        res.writeHead(404).end();
+        return;
+      }
+      const state = url.searchParams.get('state');
+      const code = url.searchParams.get('code');
+      const error = url.searchParams.get('error');
+
+      if (error) {
+        res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end(`OAuth error: ${error}\nYou can close this tab.`);
+        finish(new Error(`OAuth callback returned error: ${error}`));
+        return;
+      }
+      if (state !== options.expectedState) {
+        res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('OAuth state mismatch — possible CSRF. Aborted.');
+        finish(new Error('OAuth state mismatch'));
+        return;
+      }
+      if (!code) {
+        res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('OAuth callback missing code parameter.');
+        finish(new Error('OAuth callback missing code'));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Authorization received. You can close this tab.');
+      finish(null, code);
+    });
+
+    server.on('error', (err) => finish(err));
+    server.listen(options.port, '127.0.0.1');
+
+    const timer = setTimeout(
+      () => finish(new Error(`OAuth callback timed out after ${options.timeoutMs}ms`)),
+      options.timeoutMs,
+    );
+  });
+}
+
+function tryOpenBrowser(url: string): void {
+  const platform = process.platform;
+  let cmd: string;
+  let args: string[];
+  if (platform === 'darwin') {
+    cmd = 'open';
+    args = [url];
+  } else if (platform === 'win32') {
+    cmd = 'cmd';
+    args = ['/c', 'start', '""', url];
+  } else {
+    cmd = 'xdg-open';
+    args = [url];
+  }
+  try {
+    const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    child.on('error', () => {
+      // best-effort: print already happened
+    });
+    child.unref();
+  } catch {
+    // best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Code → tokens
+// ---------------------------------------------------------------------------
+
+interface ExchangeOptions {
+  tokenEndpoint: string;
+  code: string;
+  redirectUri: string;
+  clientId: string;
+  clientSecret?: string;
+  codeVerifier: string;
+  resource: string;
+  fetchImpl: typeof fetch;
+}
+
+async function exchangeCodeForTokens(
+  options: ExchangeOptions,
+): Promise<Omit<CachedTokens, 'tokenEndpoint' | 'clientId' | 'clientSecret'>> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: options.code,
+    redirect_uri: options.redirectUri,
+    client_id: options.clientId,
+    code_verifier: options.codeVerifier,
+    resource: options.resource,
+  });
+  if (options.clientSecret) body.set('client_secret', options.clientSecret);
+
+  let response: Response;
+  try {
+    response = await options.fetchImpl(options.tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: body.toString(),
+    });
+  } catch (cause) {
+    throw new Error(
+      `token exchange request failed: ${stringify(cause)}`,
+    );
+  }
+
+  if (!response.ok) {
+    const text = await safeText(response);
+    throw new Error(
+      `token exchange returned ${response.status} from ${options.tokenEndpoint}: ${text}`,
+    );
+  }
+
+  const payload = (await response.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    scope?: string;
+  };
+  if (typeof payload.access_token !== 'string' || typeof payload.expires_in !== 'number') {
+    throw new Error('token exchange response missing access_token or expires_in');
+  }
+  return {
+    accessToken: payload.access_token,
+    expiresAt: Date.now() + payload.expires_in * 1000,
+    ...(payload.refresh_token ? { refreshToken: payload.refresh_token } : {}),
+    ...(payload.scope ? { scope: payload.scope } : {}),
+    refreshedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function randomBase64Url(bytes: number): string {
+  return randomBytes(bytes).toString('base64url');
+}
+
+function sha256Base64Url(input: string): string {
+  return createHash('sha256').update(input).digest('base64url');
+}
+
+function stringify(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  return String(value);
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500);
+  } catch {
+    return '<unreadable body>';
+  }
+}

--- a/src/auth/oauth-token-store.ts
+++ b/src/auth/oauth-token-store.ts
@@ -1,0 +1,327 @@
+/**
+ * OAuth 2.0 token cache for HTTP MCP servers.
+ *
+ * Each cache bundle is addressed by an opaque `tokenStoreId` — a
+ * filesystem-safe identifier the skill-loader stamps into the canonical
+ * MCP config (default `<skillName>/<serverName>`). The bundle lives at
+ * `<dataDir>/mcp-auth/<tokenStoreId>.json` and is the single source of
+ * truth for that server's tokens — there is no in-memory cache that
+ * outlives a single materialization round.
+ *
+ * Lifecycle:
+ *   1. `talonctl auth-mcp <skill>:<server>` writes the initial bundle
+ *      after the interactive OAuth dance.
+ *   2. The daemon's MCP-resolution layer calls `materializeBearer()`
+ *      every time it builds an agent's MCP config for a run. If the
+ *      access token is near expiry the helper refreshes in-place via
+ *      the cached refresh_token + token_endpoint.
+ *   3. Talon never starts an mcp-remote process. The HTTP MCP endpoint
+ *      consumes the Bearer header itself; no stdio bridge in the loop.
+ *
+ * Concurrent materializations for the same id share a single refresh
+ * promise so we don't burn the refresh_token by racing the IdP with
+ * parallel exchanges.
+ */
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join, normalize, sep } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+/** Persisted shape of a cached OAuth token bundle. */
+export interface CachedTokens {
+  /** Bearer access token. Always required. */
+  accessToken: string;
+  /** OAuth refresh token. Optional — some IdPs do not issue one. */
+  refreshToken?: string;
+  /** Absolute Unix milliseconds when `accessToken` stops being valid. */
+  expiresAt: number;
+  /** Space-separated scope string from the most recent grant. */
+  scope?: string;
+  /** Token endpoint URL — required for refresh. Captured at auth time. */
+  tokenEndpoint: string;
+  /** Optional client metadata captured during dynamic registration. */
+  clientId?: string;
+  clientSecret?: string;
+  /** ISO timestamp of the last refresh, for diagnostics only. */
+  refreshedAt?: string;
+}
+
+export interface TokenStoreOptions {
+  /** Root data directory; tokens live under `<dataDir>/mcp-auth/`. */
+  dataDir: string;
+  /**
+   * Refresh access tokens that expire within this many milliseconds.
+   * Default 60 s leaves a comfortable margin for clock skew + network
+   * latency without thrashing refresh.
+   */
+  refreshBufferMs?: number;
+  /** Injected fetch for tests. Defaults to `globalThis.fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Injected clock for tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Resolve a `tokenStoreId` to an absolute cache file path. Rejects
+ * absolute paths and any segment that contains `..` so a malicious or
+ * misconfigured skill cannot escape `<dataDir>/mcp-auth/`.
+ *
+ * Exported so the CLI and the daemon agree on exactly one location.
+ */
+export function tokenFilePath(dataDir: string, tokenStoreId: string): string {
+  const id = tokenStoreId.trim();
+  if (id.length === 0) {
+    throw new TokenStoreError('tokenStoreId must be non-empty');
+  }
+  if (isAbsolute(id) || id.startsWith(sep) || id.startsWith('/')) {
+    throw new TokenStoreError(
+      `tokenStoreId must be relative, got "${tokenStoreId}"`,
+    );
+  }
+  const normalized = normalize(id);
+  if (normalized.split(/[\\/]/).includes('..')) {
+    throw new TokenStoreError(
+      `tokenStoreId may not contain ".." segments, got "${tokenStoreId}"`,
+    );
+  }
+  return join(dataDir, 'mcp-auth', `${normalized}.json`);
+}
+
+/**
+ * Atomically write a token bundle to disk. Creates parents with 0700
+ * permissions and uses temp-file + rename to avoid partial reads while
+ * a refresh is in flight.
+ */
+export async function writeTokens(
+  dataDir: string,
+  tokenStoreId: string,
+  tokens: CachedTokens,
+): Promise<void> {
+  const path = tokenFilePath(dataDir, tokenStoreId);
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(tokens, null, 2), { encoding: 'utf8', mode: 0o600 });
+  await rename(tmp, path);
+}
+
+/**
+ * Read a token bundle from disk. Returns `undefined` when the file is
+ * missing — callers should map that to a clear "run talonctl auth-mcp"
+ * error rather than auto-initiating the OAuth dance from the daemon.
+ */
+export async function readTokens(
+  dataDir: string,
+  tokenStoreId: string,
+): Promise<CachedTokens | undefined> {
+  const path = tokenFilePath(dataDir, tokenStoreId);
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (cause) {
+    if (isNoEnt(cause)) return undefined;
+    throw new TokenStoreError(`failed to read ${path}: ${stringify(cause)}`, cause);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    throw new TokenStoreError(`invalid JSON in ${path}: ${stringify(cause)}`, cause);
+  }
+
+  if (!isCachedTokens(parsed)) {
+    throw new TokenStoreError(`malformed token bundle in ${path}`);
+  }
+  return parsed;
+}
+
+export class TokenStoreError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = 'TokenStoreError';
+  }
+}
+
+/**
+ * OAuthTokenStore — thin wrapper around the on-disk cache that knows how
+ * to refresh expiring tokens via the cached `tokenEndpoint`.
+ *
+ * Instances are cheap to construct; the daemon makes one per process.
+ */
+export class OAuthTokenStore {
+  private readonly dataDir: string;
+  private readonly refreshBufferMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => number;
+  /**
+   * Per-tokenStoreId in-flight refresh promise. Concurrent
+   * `materializeBearer()` calls coalesce so we never fire two parallel
+   * refresh_token exchanges (which would burn the refresh token).
+   */
+  private readonly inflight = new Map<string, Promise<CachedTokens>>();
+
+  constructor(options: TokenStoreOptions) {
+    this.dataDir = options.dataDir;
+    this.refreshBufferMs = options.refreshBufferMs ?? 60_000;
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Return a usable access token for `tokenStoreId`. Throws if no token
+   * bundle exists, the bundle lacks refresh material when needed, or
+   * the IdP rejects the refresh.
+   */
+  async materializeBearer(tokenStoreId: string): Promise<string> {
+    const tokens = await this.loadFresh(tokenStoreId);
+    return tokens.accessToken;
+  }
+
+  private async loadFresh(tokenStoreId: string): Promise<CachedTokens> {
+    const existing = this.inflight.get(tokenStoreId);
+    if (existing) return existing;
+
+    const pending = (async (): Promise<CachedTokens> => {
+      const tokens = await readTokens(this.dataDir, tokenStoreId);
+      if (!tokens) {
+        throw new TokenStoreError(
+          `no cached tokens for "${tokenStoreId}". Run \`talonctl auth-mcp\` to authorise this MCP server.`,
+        );
+      }
+
+      if (tokens.expiresAt - this.now() > this.refreshBufferMs) {
+        return tokens;
+      }
+      if (!tokens.refreshToken) {
+        throw new TokenStoreError(
+          `access token for "${tokenStoreId}" is expired and no refresh_token is cached. Re-run \`talonctl auth-mcp\`.`,
+        );
+      }
+      const refreshed = await this.exchangeRefresh(tokens);
+      await writeTokens(this.dataDir, tokenStoreId, refreshed);
+      return refreshed;
+    })();
+
+    this.inflight.set(tokenStoreId, pending);
+    try {
+      return await pending;
+    } finally {
+      this.inflight.delete(tokenStoreId);
+    }
+  }
+
+  /**
+   * Standard RFC 6749 §6 refresh_token exchange. Returns a new bundle,
+   * preserving the original refresh_token when the IdP did not rotate
+   * it.
+   */
+  private async exchangeRefresh(tokens: CachedTokens): Promise<CachedTokens> {
+    if (!tokens.refreshToken) {
+      throw new TokenStoreError('exchangeRefresh: no refresh_token available');
+    }
+
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: tokens.refreshToken,
+    });
+    if (tokens.clientId) body.set('client_id', tokens.clientId);
+    if (tokens.clientSecret) body.set('client_secret', tokens.clientSecret);
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(tokens.tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: body.toString(),
+      });
+    } catch (cause) {
+      throw new TokenStoreError(
+        `refresh request to ${tokens.tokenEndpoint} failed: ${stringify(cause)}`,
+        cause,
+      );
+    }
+
+    if (!response.ok) {
+      const text = await safeText(response);
+      throw new TokenStoreError(
+        `refresh returned ${response.status} from ${tokens.tokenEndpoint}: ${text}`,
+      );
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch (cause) {
+      throw new TokenStoreError(`refresh response not JSON: ${stringify(cause)}`, cause);
+    }
+
+    if (!isTokenResponse(payload)) {
+      throw new TokenStoreError(
+        'refresh response missing required fields (access_token, expires_in)',
+      );
+    }
+
+    return {
+      accessToken: payload.access_token,
+      refreshToken: payload.refresh_token ?? tokens.refreshToken,
+      expiresAt: this.now() + payload.expires_in * 1000,
+      scope: payload.scope ?? tokens.scope,
+      tokenEndpoint: tokens.tokenEndpoint,
+      ...(tokens.clientId ? { clientId: tokens.clientId } : {}),
+      ...(tokens.clientSecret ? { clientSecret: tokens.clientSecret } : {}),
+      refreshedAt: new Date(this.now()).toISOString(),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function isCachedTokens(value: unknown): value is CachedTokens {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.accessToken === 'string'
+    && typeof v.expiresAt === 'number'
+    && typeof v.tokenEndpoint === 'string'
+  );
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope?: string;
+  token_type?: string;
+}
+
+function isTokenResponse(value: unknown): value is TokenResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.access_token === 'string' && typeof v.expires_in === 'number';
+}
+
+function isNoEnt(value: unknown): boolean {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && (value as { code?: string }).code === 'ENOENT'
+  );
+}
+
+function stringify(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  return String(value);
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.slice(0, 500);
+  } catch {
+    return '<unreadable body>';
+  }
+}

--- a/src/cli/commands/auth-mcp.ts
+++ b/src/cli/commands/auth-mcp.ts
@@ -1,0 +1,143 @@
+/**
+ * `talonctl auth-mcp <skill>:<server>` — one-time interactive OAuth
+ * dance for HTTP MCP servers.
+ *
+ * Looks up `skills/<skill>/mcp/<server>.json`, reads the configured URL
+ * and tokenStore id (defaulting to `<skill>/<server>`), drives the
+ * OAuth flow (RFC 9728 discovery → DCR → PKCE → token exchange), and
+ * persists the resulting bundle at
+ * `<dataDir>/mcp-auth/<tokenStore>.json`. The daemon picks the cache
+ * up on the next agent run via `resolveMcpServers()` — no daemon
+ * restart required.
+ *
+ * Two modes:
+ *   - default: opens the local browser. Use when running talonctl on
+ *     the same desktop as the operator.
+ *   - `--headless`: prints the authorization URL and the SSH
+ *     port-forward command. Use when running talonctl on the daemon's
+ *     server over SSH.
+ */
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { runOAuthFlow } from '../../auth/oauth-flow.js';
+import { writeTokens, type CachedTokens } from '../../auth/oauth-token-store.js';
+
+export interface AuthMcpOptions {
+  /** Selector in `<skill>:<server>` form. */
+  selector: string;
+  /** Root data dir; tokens land under `<dataDir>/mcp-auth/`. */
+  dataDir: string;
+  /** Skills root (`skills/`). */
+  skillsDir: string;
+  /** Local callback port. Default 8788. */
+  callbackPort?: number;
+  /** Headless mode (no browser open). */
+  headless?: boolean;
+  /** Where to print human-readable progress. */
+  printLine?: (line: string) => void;
+}
+
+export interface AuthMcpResult {
+  /** Resolved tokenStore identifier (e.g. `glean/glean`). */
+  tokenStoreId: string;
+  /** Path of the token bundle written to disk. */
+  tokenFilePath: string;
+  /** Expiry of the access token just obtained (Unix ms). */
+  expiresAt: number;
+}
+
+/**
+ * Pure entry point — no console output, returns the result. The CLI
+ * wrapper in `cli/index.ts` handles config loading + exit codes.
+ */
+export async function authMcp(options: AuthMcpOptions): Promise<AuthMcpResult> {
+  const { skill, server } = parseSelector(options.selector);
+  const skillDir = join(options.skillsDir, skill);
+  const mcpFile = join(skillDir, 'mcp', `${server}.json`);
+
+  let raw: string;
+  try {
+    raw = await readFile(mcpFile, 'utf8');
+  } catch (cause) {
+    throw new AuthMcpError(
+      `MCP server definition not found at ${mcpFile}. Check that the skill name is "${skill}" and the file is named "${server}.json".`,
+      cause,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    throw new AuthMcpError(`failed to parse ${mcpFile} as JSON`, cause);
+  }
+
+  const serverDef = parsed as {
+    config?: {
+      transport?: string;
+      url?: string;
+      auth?: { kind?: string; tokenStore?: string };
+    };
+  };
+  const cfg = serverDef.config ?? {};
+  if (cfg.transport !== 'http' && cfg.transport !== 'sse') {
+    throw new AuthMcpError(
+      `${mcpFile}: auth-mcp only supports HTTP/SSE MCP servers; got transport "${cfg.transport ?? '<missing>'}".`,
+    );
+  }
+  if (typeof cfg.url !== 'string' || cfg.url.length === 0) {
+    throw new AuthMcpError(`${mcpFile}: HTTP MCP entry is missing a "url" field.`);
+  }
+  if (cfg.auth?.kind !== 'oauth2') {
+    throw new AuthMcpError(
+      `${mcpFile}: entry has no "auth.kind: oauth2" — add it to enable OAuth-managed credentials.`,
+    );
+  }
+  const tokenStoreId =
+    typeof cfg.auth.tokenStore === 'string' && cfg.auth.tokenStore.length > 0
+      ? cfg.auth.tokenStore
+      : `${skill}/${server}`;
+
+  const print = options.printLine ?? ((line) => process.stdout.write(`${line}\n`));
+  print(`auth-mcp: ${skill}:${server}`);
+  print(`  resource: ${cfg.url}`);
+  print(`  tokenStore: ${tokenStoreId}`);
+
+  const { tokens } = await runOAuthFlow({
+    resourceUrl: cfg.url,
+    callbackPort: options.callbackPort,
+    headless: options.headless,
+    printLine: print,
+  });
+
+  const bundle: CachedTokens = tokens;
+  await writeTokens(options.dataDir, tokenStoreId, bundle);
+
+  const filePath = resolve(options.dataDir, 'mcp-auth', `${tokenStoreId}.json`);
+  print('');
+  print('auth-mcp: success');
+  print(`  wrote ${filePath}`);
+  print(`  expires_at: ${new Date(bundle.expiresAt).toISOString()}`);
+  return { tokenStoreId, tokenFilePath: filePath, expiresAt: bundle.expiresAt };
+}
+
+export class AuthMcpError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = 'AuthMcpError';
+  }
+}
+
+function parseSelector(selector: string): { skill: string; server: string } {
+  const trimmed = selector.trim();
+  const colon = trimmed.indexOf(':');
+  if (colon <= 0 || colon === trimmed.length - 1) {
+    throw new AuthMcpError(
+      `invalid selector "${selector}". Expected "<skill>:<server>", e.g. "glean:glean".`,
+    );
+  }
+  return {
+    skill: trimmed.slice(0, colon),
+    server: trimmed.slice(colon + 1),
+  };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -504,12 +504,13 @@ program
       process.exit(1);
       return;
     }
-    // Anchor `dataDir` to the dir containing the SQLite path so
-    // `data/mcp-auth/` lives alongside other Talon-managed state.
-    const dbPath = configResult.value.storage.path;
-    const dataDir = dbPath.includes('/')
-      ? dbPath.replace(/\/+[^/]+$/, '')
-      : '.';
+    // Resolve `dataDir` from the exact same config field the daemon uses
+    // in daemon-bootstrap.ts (`resolve(config.dataDir)`). Using a
+    // different source (e.g. derived from `storage.path`) would cause
+    // talonctl to write tokens to one directory and the daemon to read
+    // from another, producing "no cached tokens" failures at runtime
+    // even after a successful auth flow.
+    const dataDir = resolve(configResult.value.dataDir);
     try {
       await authMcp({
         selector,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,6 +36,7 @@ import { removeChannelCommand } from './commands/remove-channel.js';
 import { removePersonaCommand } from './commands/remove-persona.js';
 import { configShowCommand } from './commands/config-show.js';
 import { addScheduleCommand } from './commands/add-schedule.js';
+import { authMcp, AuthMcpError } from './commands/auth-mcp.js';
 import { listSchedulesCommand } from './commands/list-schedules.js';
 import { removeScheduleCommand } from './commands/remove-schedule.js';
 import { runSubAgentCommand } from './commands/run-subagent.js';
@@ -467,6 +468,64 @@ program
   .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
   .action(async (opts: { config: string; persona?: string }) => {
     await listSchedulesCommand({ configPath: opts.config, persona: opts.persona });
+  });
+
+// ---------------------------------------------------------------------------
+// OAuth for HTTP MCP servers
+// ---------------------------------------------------------------------------
+
+program
+  .command('auth-mcp')
+  .description('One-time interactive OAuth dance for an HTTP MCP server')
+  .argument(
+    '<selector>',
+    'Skill + server in "<skill>:<server>" form (e.g. "glean:glean")',
+  )
+  .option(
+    '--headless',
+    'Headless mode: print the auth URL + SSH forward command; do not open a browser',
+    false,
+  )
+  .option(
+    '--port <port>',
+    'Localhost callback port (default 8788)',
+    (v) => Number.parseInt(v, 10),
+  )
+  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--skills-dir <path>', 'Path to the skills/ directory', 'skills')
+  .action(async (
+    selector: string,
+    opts: { headless: boolean; port?: number; config: string; skillsDir: string },
+  ) => {
+    const { loadConfig } = await import('../core/config/config-loader.js');
+    const configResult = loadConfig(opts.config);
+    if (configResult.isErr()) {
+      console.error(`Error loading config: ${configResult.error.message}`);
+      process.exit(1);
+      return;
+    }
+    // Anchor `dataDir` to the dir containing the SQLite path so
+    // `data/mcp-auth/` lives alongside other Talon-managed state.
+    const dbPath = configResult.value.storage.path;
+    const dataDir = dbPath.includes('/')
+      ? dbPath.replace(/\/+[^/]+$/, '')
+      : '.';
+    try {
+      await authMcp({
+        selector,
+        dataDir,
+        skillsDir: opts.skillsDir,
+        headless: opts.headless,
+        ...(opts.port !== undefined ? { callbackPort: opts.port } : {}),
+      });
+    } catch (cause) {
+      if (cause instanceof AuthMcpError) {
+        console.error(`auth-mcp: ${cause.message}`);
+      } else {
+        console.error(`auth-mcp: ${(cause as Error).message ?? String(cause)}`);
+      }
+      process.exit(1);
+    }
   });
 
 program

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -9,6 +9,7 @@ import type { AssembledContext } from './context-assembler.js';
 import type { QueueItem } from '../queue/queue-types.js';
 import { filterAllowedMcpTools } from '../tools/tool-filter.js';
 import { resolveToolInstructions } from '../tools/tool-instructions.js';
+import { resolveMcpServers } from '../mcp/resolve-mcp-servers.js';
 import { buildPersonaRuntimeContext } from '../personas/persona-runtime-context.js';
 import {
   TALON_SKILL_LOAD_TOOL_DESCRIPTION,
@@ -649,11 +650,21 @@ export class AgentRunner {
                   // streaming events). Events are sequential so FIFO order correctly pairs starts with ends.
                   const pendingNoIdToolObservations: StartedObservationHandle[] = [];
 
+                  // Materialize dynamic auth (OAuth bearers) on HTTP MCP
+                  // entries before handing them to the provider. Providers
+                  // stay completely unaware of `auth` — the resolver
+                  // strips the field and merges Authorization into headers.
+                  // Failure here surfaces with a "run talonctl auth-mcp …"
+                  // message so the operator can fix it without restarting.
+                  const resolvedMcpServers = await resolveMcpServers(mcpServers, {
+                    tokenStore: this.ctx.oauthTokenStore,
+                  });
+
                   const queryInput = {
                     threadId: item.threadId,
                     prompt: content,
                     systemPrompt,
-                    mcpServers,
+                    mcpServers: resolvedMcpServers,
                     cwd: workspaceResult.value,
                     model,
                     maxTurns: 25,

--- a/src/daemon/daemon-bootstrap.ts
+++ b/src/daemon/daemon-bootstrap.ts
@@ -73,6 +73,7 @@ import { createObservabilityService } from '../observability/langfuse/index.js';
 import { NoopObservabilityService } from '../observability/langfuse/noop-observability.js';
 import type { ObservabilityService } from '../observability/langfuse/observability-types.js';
 import { wrapProviderOptions } from '../subagents/provider-options.js';
+import { OAuthTokenStore } from '../auth/oauth-token-store.js';
 
 // ---------------------------------------------------------------------------
 // Bootstrap
@@ -644,6 +645,12 @@ export async function bootstrap(
   // We build the context object first, then create the bridge and attach it.
   // Two-phase init: HostToolsBridge needs ctx, but ctx needs hostToolsBridge.
   // Build a partial context first, then fill in the bridge field.
+  // OAuth token store for HTTP MCP servers — backed by
+  // <dataDir>/mcp-auth/<tokenStore>.json files. The CLI command
+  // `talonctl auth-mcp` writes those files; the daemon reads + refreshes
+  // them on the way to materializing Authorization headers.
+  const oauthTokenStore = new OAuthTokenStore({ dataDir });
+
   const partialCtx = {
     db,
     config,
@@ -668,6 +675,7 @@ export async function bootstrap(
     executionEnvManager,
     contextRoller,
     contextAssembler,
+    oauthTokenStore,
     logger,
     a2aServer,
     a2aTaskMapper,

--- a/src/daemon/daemon-bootstrap.ts
+++ b/src/daemon/daemon-bootstrap.ts
@@ -111,6 +111,14 @@ export async function bootstrap(
 
   logger.info({ logLevel: config.logLevel }, 'bootstrap: config loaded');
 
+  // OAuth token store for HTTP MCP servers. Created early so it can be
+  // handed to both the foreground agent-runner path (via DaemonContext)
+  // and the background agent manager. `talonctl auth-mcp` writes
+  // bundles into <dataDir>/mcp-auth/; the daemon reads + refreshes
+  // them from the same path here, so foreground and background runs
+  // see identical materialized Bearer headers.
+  const oauthTokenStore = new OAuthTokenStore({ dataDir });
+
   // 2. Open database
   const dbResult = createDatabase(config.storage.path);
   if (dbResult.isErr()) {
@@ -588,6 +596,11 @@ export async function bootstrap(
       providerRegistry: backgroundProviderRegistry,
       executionEnvManager,
       hostToolsSocketPath: resolve(join(dataDir, 'host-tools.sock')),
+      // Share the same token store the foreground path uses so an
+      // `talonctl auth-mcp` run unlocks Glean (etc.) for both run
+      // types — without this, background runs receive raw
+      // `auth: { kind: 'oauth2' }` entries and the MCP server 401s.
+      oauthTokenStore,
       logger,
       observability,
     });
@@ -645,12 +658,6 @@ export async function bootstrap(
   // We build the context object first, then create the bridge and attach it.
   // Two-phase init: HostToolsBridge needs ctx, but ctx needs hostToolsBridge.
   // Build a partial context first, then fill in the bridge field.
-  // OAuth token store for HTTP MCP servers — backed by
-  // <dataDir>/mcp-auth/<tokenStore>.json files. The CLI command
-  // `talonctl auth-mcp` writes those files; the daemon reads + refreshes
-  // them on the way to materializing Authorization headers.
-  const oauthTokenStore = new OAuthTokenStore({ dataDir });
-
   const partialCtx = {
     db,
     config,

--- a/src/daemon/daemon-context.ts
+++ b/src/daemon/daemon-context.ts
@@ -48,6 +48,7 @@ import type { ContextAssembler } from './context-assembler.js';
 import type { ObservabilityService } from '../observability/langfuse/observability-types.js';
 import type { A2AServer } from '../a2a/a2a-server.js';
 import type { A2ATaskMapper } from '../a2a/a2a-task-mapper.js';
+import type { OAuthTokenStore } from '../auth/oauth-token-store.js';
 
 // ---------------------------------------------------------------------------
 // Repository bundle
@@ -103,6 +104,7 @@ export interface DaemonContext {
   readonly messagePipeline: MessagePipeline;
   readonly observability: ObservabilityService;
   readonly hostToolsBridge: HostToolsBridge;
+  readonly oauthTokenStore: OAuthTokenStore;
   readonly providerRegistry: ProviderRegistry<AgentRunnerProviderConfig>;
   readonly subAgentRunner: SubAgentRunner | null;
   readonly backgroundAgentManager: BackgroundAgentManager | null;

--- a/src/mcp/mcp-types.ts
+++ b/src/mcp/mcp-types.ts
@@ -45,6 +45,13 @@ export interface McpServerConfig {
   /** Custom headers sent with HTTP/SSE transport requests (e.g. Authorization). */
   headers?: Record<string, string>;
 
+  /**
+   * Dynamic auth resolved by `resolveMcpServers()` before the server entry
+   * reaches a provider. The resolver materializes the credential into a
+   * header on `headers` and strips this field, so providers never see it.
+   */
+  auth?: McpAuthConfig;
+
   // --- common optional fields -----------------------------------------------
 
   /**
@@ -74,6 +81,29 @@ export interface McpServerConfig {
    * Defaults to 60 tokens per minute if not specified.
    */
   rateLimit?: McpRateLimitConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Auth configuration (dynamic, resolved per run)
+// ---------------------------------------------------------------------------
+
+/**
+ * Auth specifications recognised by `resolveMcpServers()`. Keep the
+ * discriminator on `kind` so future schemes (`basic`, `mtls`, …) land
+ * without breaking existing entries.
+ */
+export type McpAuthConfig = McpOAuth2AuthConfig;
+
+export interface McpOAuth2AuthConfig {
+  kind: 'oauth2';
+  /**
+   * Opaque, filesystem-safe identifier for the cached token bundle.
+   * Resolves to `<dataDir>/mcp-auth/<tokenStore>.json`. Skill-loader
+   * defaults this to `<skill>/<server>` when the skill author omits it,
+   * so the on-disk layout follows the same shape the CLI uses
+   * (`talonctl auth-mcp <skill>:<server>`).
+   */
+  tokenStore: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/resolve-mcp-servers.ts
+++ b/src/mcp/resolve-mcp-servers.ts
@@ -1,0 +1,73 @@
+/**
+ * Resolve dynamic auth on MCP server entries before they reach a
+ * provider. Providers stay pure — they never inspect `auth`, never call
+ * the token store, never know an Authorization header was added.
+ *
+ * One-pass transform on the canonical shape: take a
+ * `Record<name, CanonicalMcpServer>`, for any HTTP/SSE entry with
+ * `auth.kind === 'oauth2'` look up a fresh access token from the store,
+ * merge `Authorization: Bearer <token>` into `headers`, and strip the
+ * `auth` field. stdio/sdk entries pass through unchanged.
+ *
+ * Centralising the materialization here keeps token handling testable
+ * in isolation and means new auth schemes land in one place, not
+ * stamped across every provider serializer.
+ */
+import type {
+  CanonicalMcpServer,
+  CanonicalMcpHttpServer,
+} from '../providers/provider-types.js';
+import type { OAuthTokenStore } from '../auth/oauth-token-store.js';
+
+export interface ResolveMcpServersOptions {
+  /** Concrete token store the daemon hands in. */
+  tokenStore: OAuthTokenStore;
+}
+
+/**
+ * Return a new map with auth resolved on HTTP entries. The input is
+ * never mutated. Throws if any oauth2 entry has no cached tokens — the
+ * caller (typically agent-runner) should surface that to the operator
+ * with a "run talonctl auth-mcp …" pointer.
+ */
+export async function resolveMcpServers(
+  servers: Record<string, CanonicalMcpServer>,
+  options: ResolveMcpServersOptions,
+): Promise<Record<string, CanonicalMcpServer>> {
+  const resolved: Record<string, CanonicalMcpServer> = {};
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (server.transport === 'stdio' || server.transport === 'sdk') {
+      resolved[name] = server;
+      continue;
+    }
+    resolved[name] = await resolveHttp(server, name, options);
+  }
+
+  return resolved;
+}
+
+async function resolveHttp(
+  server: CanonicalMcpHttpServer,
+  name: string,
+  options: ResolveMcpServersOptions,
+): Promise<CanonicalMcpHttpServer> {
+  if (!server.auth) {
+    return server;
+  }
+  if (server.auth.kind === 'oauth2') {
+    const bearer = await options.tokenStore.materializeBearer(server.auth.tokenStore);
+    // Preserve caller-set Authorization by writing Bearer LAST; skills
+    // that want a different scheme should not declare `auth` and set
+    // their own header instead.
+    const headers = {
+      ...(server.headers ?? {}),
+      Authorization: `Bearer ${bearer}`,
+    };
+    // Strip `auth` so providers never see a half-resolved entry.
+    const { auth: _drop, ...rest } = server;
+    void _drop;
+    return { ...rest, headers };
+  }
+  throw new Error(`resolveMcpServers: unsupported auth.kind for server "${name}"`);
+}

--- a/src/personas/persona-runtime-context.ts
+++ b/src/personas/persona-runtime-context.ts
@@ -153,6 +153,12 @@ export function buildPersonaRuntimeContext(
       transport: cfg.transport,
       url: cfg.url,
       ...(Object.keys(resolvedHeaders).length > 0 ? { headers: resolvedHeaders } : {}),
+      // Forward dynamic auth verbatim. `resolveMcpServers()` runs in the
+      // agent-runner and turns this into a materialized Bearer header
+      // before the entry reaches a provider — domain `McpAuthConfig`
+      // and canonical `McpAuthSpec` are structurally identical (same
+      // discriminator + same `tokenStore` field) so a flat copy is safe.
+      ...(cfg.auth ? { auth: cfg.auth } : {}),
     };
   }
 

--- a/src/providers/provider-types.ts
+++ b/src/providers/provider-types.ts
@@ -37,6 +37,32 @@ export interface CanonicalMcpHttpServer {
   transport: 'http' | 'sse';
   url: string;
   headers?: Record<string, string>;
+  /**
+   * Optional dynamic auth resolved by `resolveMcpServers()` before the
+   * server entry is handed to a provider. Once resolved, the materialized
+   * credential is merged into `headers` and `auth` is stripped — providers
+   * never see this field. Stays simple so adding new auth kinds doesn't
+   * require touching every provider.
+   */
+  auth?: McpAuthSpec;
+}
+
+/**
+ * Auth specifications recognised by `resolveMcpServers()`. Keep the
+ * discriminator on `kind` so future schemes (e.g. `basic`, `mtls`) can
+ * be added without breaking existing entries.
+ */
+export type McpAuthSpec = McpOAuth2AuthSpec;
+
+export interface McpOAuth2AuthSpec {
+  kind: 'oauth2';
+  /**
+   * Identifier for the cached token bundle, scoped per skill at runtime.
+   * Resolves to `data/mcp-auth/<skill>/<tokenStore>.json`. The cache is
+   * written by `talonctl auth-mcp` and refreshed in-place by the daemon's
+   * token store helper when the access token nears expiry.
+   */
+  tokenStore: string;
 }
 
 export interface CanonicalMcpSdkServer {

--- a/src/skills/skill-loader.ts
+++ b/src/skills/skill-loader.ts
@@ -89,6 +89,23 @@ const McpRateLimitSchema = z.object({
   callsPerMinute: z.number().int().positive(),
 });
 
+/**
+ * Auth specification for HTTP/SSE MCP servers. The resolver
+ * (`resolveMcpServers()`) materializes the configured credential into
+ * an `Authorization` header at runtime; providers never see this field.
+ *
+ * `tokenStore` is an opaque, filesystem-safe identifier resolved to
+ * `<dataDir>/mcp-auth/<tokenStore>.json`. When omitted, the loader
+ * stamps a default of `<skillName>/<serverName>` so the on-disk path
+ * matches `talonctl auth-mcp <skill>:<server>`.
+ */
+const McpOAuth2AuthSchema = z.object({
+  kind: z.literal('oauth2'),
+  tokenStore: z.string().trim().min(1).optional(),
+});
+
+const McpAuthSchema = z.discriminatedUnion('kind', [McpOAuth2AuthSchema]);
+
 const McpServerConfigSchema = z.object({
   name: z.string().min(1).optional(),
   transport: z.enum(['stdio', 'sse', 'http']),
@@ -96,6 +113,7 @@ const McpServerConfigSchema = z.object({
   args: z.array(z.string()).optional(),
   url: z.string().optional(),
   headers: z.record(z.string(), z.string()).optional(),
+  auth: McpAuthSchema.optional(),
   env: z.record(z.string(), z.string()).optional(),
   allowedTools: z.array(z.string()).optional(),
   credentialScope: z.string().optional(),
@@ -107,7 +125,10 @@ const McpServerDefFileSchema = z.object({
   config: McpServerConfigSchema,
 }).transform((def) => ({
   ...def,
-  config: { ...def.config, name: def.config.name ?? def.name },
+  config: {
+    ...def.config,
+    name: def.config.name ?? def.name,
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -570,7 +591,23 @@ export class SkillLoader {
         );
       }
 
-      defs.push(parseResult.data as McpServerDef);
+      const def = parseResult.data as McpServerDef;
+      // Stamp the default OAuth tokenStore identifier so skill authors
+      // can declare `auth: { kind: 'oauth2' }` without repeating the
+      // skill/server name. The on-disk cache for this server then
+      // lives at `<dataDir>/mcp-auth/<skill>/<server>.json`, which
+      // matches the CLI command shape `talonctl auth-mcp <skill>:<server>`.
+      if (
+        (def.config.transport === 'http' || def.config.transport === 'sse')
+        && def.config.auth?.kind === 'oauth2'
+        && (def.config.auth.tokenStore === undefined || def.config.auth.tokenStore === '')
+      ) {
+        def.config.auth = {
+          ...def.config.auth,
+          tokenStore: `${skillName}/${def.config.name}`,
+        };
+      }
+      defs.push(def);
       this.logger.debug({ skill: skillName, file }, 'MCP server definition loaded');
     }
 

--- a/src/subagents/background/background-agent-manager.ts
+++ b/src/subagents/background/background-agent-manager.ts
@@ -19,6 +19,8 @@ import type { AgentProvider } from '../../providers/provider.js';
 import type { ProviderRegistry } from '../../providers/provider-registry.js';
 import type { ObservabilityService, StartedObservationHandle } from '../../observability/langfuse/observability-types.js';
 import type { ExecutionEnvManager } from '../../execution-env/execution-env-manager.js';
+import type { OAuthTokenStore } from '../../auth/oauth-token-store.js';
+import { resolveMcpServers } from '../../mcp/resolve-mcp-servers.js';
 
 export interface SpawnBackgroundAgentInput {
   prompt: string;
@@ -66,6 +68,14 @@ interface BackgroundAgentManagerDeps {
   observability?: ObservabilityService;
   executionEnvManager?: Pick<ExecutionEnvManager, 'create' | 'upload' | 'destroyOwnedByTask'> | null;
   hostToolsSocketPath?: string;
+  /**
+   * Token store used to materialize `Authorization: Bearer …` headers on
+   * HTTP MCP servers that declare `auth: { kind: 'oauth2' }`. Optional so
+   * existing test scaffolds that don't construct one keep working — when
+   * absent, server entries with `auth` set are passed through unresolved
+   * (and the MCP server is expected to 401 loudly).
+   */
+  oauthTokenStore?: OAuthTokenStore;
 }
 
 interface ManagedProcess {
@@ -214,10 +224,24 @@ export class BackgroundAgentManager {
       hasSkills: input.hasSkills ?? false,
     });
 
+    // Materialize dynamic auth (OAuth bearers) on HTTP MCP entries the
+    // same way the foreground agent-runner path does in
+    // src/daemon/agent-runner.ts. Without this step a background run
+    // would receive raw `auth: { kind: 'oauth2' }` entries and the
+    // remote MCP would 401 because the Authorization header is never
+    // injected (issue surfaced in PR #212 codex review). When no token
+    // store is provided we pass through unresolved — the MCP server
+    // will surface the failure clearly.
+    const resolvedWorkerMcpServers = this.deps.oauthTokenStore
+      ? await resolveMcpServers(workerMcpServers, {
+          tokenStore: this.deps.oauthTokenStore,
+        })
+      : workerMcpServers;
+
     const invocationResult = providerEntry.provider.prepareBackgroundInvocation({
       prompt: input.prompt,
       systemPrompt,
-      mcpServers: workerMcpServers,
+      mcpServers: resolvedWorkerMcpServers,
       cwd: sandboxContext?.controlDirectory ?? input.workingDirectory ?? process.cwd(),
       timeoutMs: timeoutMinutes * 60 * 1000,
       traceparent: childTraceparent,

--- a/tests/unit/auth/oauth-token-store.test.ts
+++ b/tests/unit/auth/oauth-token-store.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  OAuthTokenStore,
+  TokenStoreError,
+  readTokens,
+  tokenFilePath,
+  writeTokens,
+  type CachedTokens,
+} from '../../../src/auth/oauth-token-store.js';
+
+function mkTokens(overrides: Partial<CachedTokens> = {}): CachedTokens {
+  return {
+    accessToken: 'access-original',
+    refreshToken: 'refresh-original',
+    expiresAt: Date.now() + 60 * 60 * 1000,
+    tokenEndpoint: 'https://idp.example.com/token',
+    clientId: 'client-abc',
+    ...overrides,
+  };
+}
+
+describe('tokenFilePath', () => {
+  it('resolves to <dataDir>/mcp-auth/<id>.json', () => {
+    expect(tokenFilePath('/tmp/data', 'glean/glean')).toBe(
+      '/tmp/data/mcp-auth/glean/glean.json',
+    );
+  });
+
+  it('rejects absolute identifiers', () => {
+    expect(() => tokenFilePath('/tmp/data', '/etc/passwd')).toThrow(/must be relative/);
+    expect(() => tokenFilePath('/tmp/data', '/foo')).toThrow(/must be relative/);
+  });
+
+  it('rejects path-traversal that would escape the mcp-auth dir', () => {
+    expect(() => tokenFilePath('/tmp/data', '../escape')).toThrow(/\.\./);
+    expect(() => tokenFilePath('/tmp/data', '..//escape')).toThrow(/\.\./);
+    // `glean/../escape` normalizes to `escape` and stays inside
+    // mcp-auth/, so it isn't an escape per se — the assertion is that
+    // we don't crash and the resolved file is still under mcp-auth.
+    expect(tokenFilePath('/tmp/data', 'glean/../escape')).toBe(
+      '/tmp/data/mcp-auth/escape.json',
+    );
+  });
+
+  it('rejects empty identifiers', () => {
+    expect(() => tokenFilePath('/tmp/data', '')).toThrow(/non-empty/);
+    expect(() => tokenFilePath('/tmp/data', '   ')).toThrow(/non-empty/);
+  });
+});
+
+describe('writeTokens / readTokens', () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'talon-token-store-'));
+  });
+
+  it('round-trips a bundle on disk', async () => {
+    const tokens = mkTokens();
+    await writeTokens(dataDir, 'glean/glean', tokens);
+    const read = await readTokens(dataDir, 'glean/glean');
+    expect(read).toEqual(tokens);
+  });
+
+  it('returns undefined for missing files (not an error)', async () => {
+    const read = await readTokens(dataDir, 'absent/absent');
+    expect(read).toBeUndefined();
+  });
+
+  it('writes with restricted mode (operator-only readable)', async () => {
+    const tokens = mkTokens();
+    await writeTokens(dataDir, 'glean/glean', tokens);
+    const { stat } = await import('node:fs/promises');
+    const s = await stat(join(dataDir, 'mcp-auth/glean/glean.json'));
+    // tmpfs/CI may not preserve mode exactly; assert no world bits at minimum.
+    expect(s.mode & 0o077).toBe(0);
+  });
+
+  it('rejects malformed bundles with a clear error', async () => {
+    const path = tokenFilePath(dataDir, 'broken/broken');
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(join(dataDir, 'mcp-auth/broken'), { recursive: true });
+    writeFileSync(path, JSON.stringify({ notATokenBundle: true }));
+    await expect(readTokens(dataDir, 'broken/broken')).rejects.toThrow(/malformed/);
+  });
+});
+
+describe('OAuthTokenStore.materializeBearer', () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'talon-token-store-'));
+  });
+
+  it('returns the cached access token when it is well within expiry', async () => {
+    const tokens = mkTokens({ expiresAt: 2_000_000_000_000 }); // far future
+    await writeTokens(dataDir, 'glean/glean', tokens);
+    const store = new OAuthTokenStore({ dataDir, now: () => 1_000_000_000_000 });
+    const bearer = await store.materializeBearer('glean/glean');
+    expect(bearer).toBe('access-original');
+  });
+
+  it('refreshes when the access token is within the refresh buffer', async () => {
+    const now = 1_000_000;
+    const tokens = mkTokens({ expiresAt: now + 1000 }); // 1s left — under default 60s buffer
+    await writeTokens(dataDir, 'glean/glean', tokens);
+
+    const fetchImpl = (async (_url: string, _init?: RequestInit) => {
+      return new Response(
+        JSON.stringify({ access_token: 'access-NEW', refresh_token: 'refresh-NEW', expires_in: 3600 }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as typeof fetch;
+
+    const store = new OAuthTokenStore({ dataDir, now: () => now, fetchImpl });
+    const bearer = await store.materializeBearer('glean/glean');
+    expect(bearer).toBe('access-NEW');
+
+    // Persisted refreshed bundle so the next run picks it up.
+    const persisted = await readTokens(dataDir, 'glean/glean');
+    expect(persisted?.accessToken).toBe('access-NEW');
+    expect(persisted?.refreshToken).toBe('refresh-NEW');
+    expect(persisted?.expiresAt).toBe(now + 3600 * 1000);
+  });
+
+  it('preserves the original refresh_token when IdP omits it', async () => {
+    const now = 1_000_000;
+    const tokens = mkTokens({ expiresAt: now + 1000 });
+    await writeTokens(dataDir, 'glean/glean', tokens);
+
+    const fetchImpl = (async () => {
+      return new Response(
+        // Note: no refresh_token in response
+        JSON.stringify({ access_token: 'access-NEW', expires_in: 3600 }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as typeof fetch;
+
+    const store = new OAuthTokenStore({ dataDir, now: () => now, fetchImpl });
+    await store.materializeBearer('glean/glean');
+    const persisted = await readTokens(dataDir, 'glean/glean');
+    expect(persisted?.refreshToken).toBe('refresh-original');
+  });
+
+  it('throws TokenStoreError with a helpful message when no bundle exists', async () => {
+    const store = new OAuthTokenStore({ dataDir });
+    await expect(store.materializeBearer('absent/absent')).rejects.toThrow(
+      /no cached tokens.*talonctl auth-mcp/,
+    );
+  });
+
+  it('throws when the cached token is expired and there is no refresh_token', async () => {
+    const now = 1_000_000;
+    const tokens = mkTokens({ expiresAt: now - 1000, refreshToken: undefined });
+    await writeTokens(dataDir, 'glean/glean', tokens);
+    const store = new OAuthTokenStore({ dataDir, now: () => now });
+    await expect(store.materializeBearer('glean/glean')).rejects.toThrow(
+      /expired and no refresh_token/,
+    );
+  });
+
+  it('coalesces concurrent materializations so refresh runs only once', async () => {
+    const now = 1_000_000;
+    const tokens = mkTokens({ expiresAt: now + 1000 });
+    await writeTokens(dataDir, 'glean/glean', tokens);
+
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls++;
+      // Simulate latency so parallel callers pile up.
+      await new Promise((r) => setTimeout(r, 10));
+      return new Response(
+        JSON.stringify({ access_token: 'access-NEW', expires_in: 3600 }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as typeof fetch;
+
+    const store = new OAuthTokenStore({ dataDir, now: () => now, fetchImpl });
+    const [a, b, c] = await Promise.all([
+      store.materializeBearer('glean/glean'),
+      store.materializeBearer('glean/glean'),
+      store.materializeBearer('glean/glean'),
+    ]);
+    expect(a).toBe('access-NEW');
+    expect(b).toBe('access-NEW');
+    expect(c).toBe('access-NEW');
+    expect(calls).toBe(1);
+  });
+
+  it('surfaces a TokenStoreError when the IdP rejects the refresh', async () => {
+    const now = 1_000_000;
+    const tokens = mkTokens({ expiresAt: now + 1000 });
+    await writeTokens(dataDir, 'glean/glean', tokens);
+
+    const fetchImpl = (async () => {
+      return new Response('invalid_grant', { status: 400 });
+    }) as typeof fetch;
+
+    const store = new OAuthTokenStore({ dataDir, now: () => now, fetchImpl });
+    await expect(store.materializeBearer('glean/glean')).rejects.toBeInstanceOf(TokenStoreError);
+  });
+
+  it('writeTokens followed by external read sees the new bundle (atomic via rename)', async () => {
+    const tokens = mkTokens({ accessToken: 'first' });
+    await writeTokens(dataDir, 'glean/glean', tokens);
+    await writeTokens(dataDir, 'glean/glean', { ...tokens, accessToken: 'second' });
+    const raw = readFileSync(join(dataDir, 'mcp-auth/glean/glean.json'), 'utf8');
+    expect(JSON.parse(raw).accessToken).toBe('second');
+  });
+});

--- a/tests/unit/mcp/resolve-mcp-servers.test.ts
+++ b/tests/unit/mcp/resolve-mcp-servers.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMcpServers } from '../../../src/mcp/resolve-mcp-servers.js';
+import type { CanonicalMcpServer } from '../../../src/providers/provider-types.js';
+
+function fakeTokenStore(bearer: string) {
+  return {
+    materializeBearer: async (id: string) => `${bearer}:${id}`,
+  } as unknown as import('../../../src/auth/oauth-token-store.js').OAuthTokenStore;
+}
+
+describe('resolveMcpServers', () => {
+  it('passes stdio entries through unchanged', async () => {
+    const servers: Record<string, CanonicalMcpServer> = {
+      filesystem: {
+        transport: 'stdio',
+        command: 'node',
+        args: ['fs-server.js'],
+        env: { FOO: 'bar' },
+      },
+    };
+    const resolved = await resolveMcpServers(servers, {
+      tokenStore: fakeTokenStore('NEVER'),
+    });
+    expect(resolved.filesystem).toEqual(servers.filesystem);
+  });
+
+  it('passes HTTP entries without auth through unchanged', async () => {
+    const servers: Record<string, CanonicalMcpServer> = {
+      github: {
+        transport: 'http',
+        url: 'https://api.github.com/mcp',
+        headers: { 'X-API-Key': 'static' },
+      },
+    };
+    const resolved = await resolveMcpServers(servers, {
+      tokenStore: fakeTokenStore('NEVER'),
+    });
+    expect(resolved.github).toEqual(servers.github);
+  });
+
+  it('materializes Bearer header for HTTP+oauth2 entries and strips `auth`', async () => {
+    const servers: Record<string, CanonicalMcpServer> = {
+      glean: {
+        transport: 'http',
+        url: 'https://contentful-be.glean.com/mcp/default',
+        auth: { kind: 'oauth2', tokenStore: 'glean/glean' },
+      },
+    };
+
+    const resolved = await resolveMcpServers(servers, {
+      tokenStore: fakeTokenStore('access'),
+    });
+
+    expect(resolved.glean).toEqual({
+      transport: 'http',
+      url: 'https://contentful-be.glean.com/mcp/default',
+      headers: { Authorization: 'Bearer access:glean/glean' },
+    });
+    // Provider never sees the auth field.
+    expect((resolved.glean as Record<string, unknown>).auth).toBeUndefined();
+  });
+
+  it('merges Bearer alongside any caller-set headers and lets Bearer win on collision', async () => {
+    const servers: Record<string, CanonicalMcpServer> = {
+      glean: {
+        transport: 'http',
+        url: 'https://glean.example.com/mcp',
+        headers: { 'X-Trace': 't1', Authorization: 'should-be-replaced' },
+        auth: { kind: 'oauth2', tokenStore: 'glean/glean' },
+      },
+    };
+    const resolved = await resolveMcpServers(servers, {
+      tokenStore: fakeTokenStore('NEW'),
+    });
+    const out = resolved.glean as { headers: Record<string, string> };
+    expect(out.headers['X-Trace']).toBe('t1');
+    expect(out.headers.Authorization).toBe('Bearer NEW:glean/glean');
+  });
+
+  it('throws when an HTTP entry declares an unsupported auth kind', async () => {
+    const servers: Record<string, CanonicalMcpServer> = {
+      odd: {
+        transport: 'http',
+        url: 'https://example.com',
+        // @ts-expect-error future kind not yet supported
+        auth: { kind: 'mtls' },
+      },
+    };
+    await expect(
+      resolveMcpServers(servers, { tokenStore: fakeTokenStore('NEVER') }),
+    ).rejects.toThrow(/unsupported auth.kind/);
+  });
+});

--- a/tests/unit/subagents/background/background-agent-manager.test.ts
+++ b/tests/unit/subagents/background/background-agent-manager.test.ts
@@ -175,6 +175,70 @@ describe('BackgroundAgentManager', () => {
     allowedMcpTools: [],
   };
 
+  it('materializes OAuth bearers on HTTP MCP entries before invoking the provider (#212 review)', async () => {
+    // Regression guard: the foreground path resolves auth in
+    // agent-runner; the background path was missing that step, so a
+    // background run on the Glean MCP would receive an unresolved
+    // `auth: { kind: "oauth2" }` entry and the server would 401.
+    const tokenStore = {
+      materializeBearer: vi.fn().mockResolvedValue('shiny-access-token'),
+    } as unknown as import('../../../../src/auth/oauth-token-store.js').OAuthTokenStore;
+
+    const manager = createManager({ oauthTokenStore: tokenStore });
+
+    await manager.spawn({
+      ...spawnInput,
+      mcpServers: {
+        glean: {
+          transport: 'http',
+          url: 'https://contentful-be.glean.com/mcp/default',
+          auth: { kind: 'oauth2', tokenStore: 'glean/glean' },
+        },
+      },
+    });
+
+    expect(tokenStore.materializeBearer).toHaveBeenCalledWith('glean/glean');
+    expect(prepareBackgroundInvocation).toHaveBeenCalledTimes(1);
+    const passed = (prepareBackgroundInvocation.mock.calls[0][0] as {
+      mcpServers: Record<string, unknown>;
+    }).mcpServers;
+    expect(passed.glean).toEqual({
+      transport: 'http',
+      url: 'https://contentful-be.glean.com/mcp/default',
+      headers: { Authorization: 'Bearer shiny-access-token' },
+    });
+    // The auth field must be stripped — providers never see it.
+    expect((passed.glean as Record<string, unknown>).auth).toBeUndefined();
+  });
+
+  it('passes server entries through unchanged when no oauthTokenStore is wired', async () => {
+    // The token store is optional so existing test scaffolds + setups
+    // without it keep working. Entries with `auth` still get forwarded;
+    // the provider/MCP server will surface the resulting 401 loudly.
+    const manager = createManager();
+
+    await manager.spawn({
+      ...spawnInput,
+      mcpServers: {
+        glean: {
+          transport: 'http',
+          url: 'https://contentful-be.glean.com/mcp/default',
+          auth: { kind: 'oauth2', tokenStore: 'glean/glean' },
+        },
+      },
+    });
+
+    const passed = (prepareBackgroundInvocation.mock.calls[0][0] as {
+      mcpServers: Record<string, unknown>;
+    }).mcpServers;
+    // Field preserved so the operator sees the MCP fail loudly with a
+    // missing Authorization header — better than silently passing.
+    expect((passed.glean as Record<string, unknown>).auth).toEqual({
+      kind: 'oauth2',
+      tokenStore: 'glean/glean',
+    });
+  });
+
   it('creates a running task and returns its id', async () => {
     const manager = createManager();
     const result = await manager.spawn(spawnInput);


### PR DESCRIPTION
Closes #210. Supersedes the orphan-reaper approach from PR #211 (closed).

## Why

The previous attempt at #210 (env marker stamping across providers, /proc-based orphan reaper, settle delays, descendant-tree expansion) was symptom-treatment for a fundamental design issue: Talon didn't own the MCP subprocess lifecycle. Each provider CLI spawned its own `mcp-remote` per agent run, the `npx → sh → node` chain leaked descendants that held ports across runs, and we resorted to host-level cleanup because we couldn't control the spawn.

This branch makes the lifecycle issue impossible by removing the stdio bridge from the runtime for HTTP-capable MCP servers.

## What changes

**1. HTTP transport for OAuth-protected MCP servers.** Talon's `CanonicalMcpHttpServer` already supported `headers`. New optional `auth?: McpAuthSpec` (with `kind: 'oauth2'`, `tokenStore: string`) declares dynamic credential materialization.

**2. `talonctl auth-mcp <skill>:<server>`.** One-time interactive OAuth dance:
- RFC 9728 protected-resource metadata discovery, with fallback to RFC 8414 authorization-server metadata at the resource origin
- RFC 7591 Dynamic Client Registration when the server advertises `registration_endpoint`
- PKCE (S256) authorization code flow
- Localhost callback listener on 127.0.0.1 (configurable port, default 8788)
- Code → token exchange, persist to `<dataDir>/mcp-auth/<tokenStore>.json` (mode 0600, atomic temp+rename writes)

Two modes:
- **default**: opens the operator's local browser (best-effort via `xdg-open`/`open`/`start`)
- `--headless`: prints the auth URL + suggested `ssh -L <port>:localhost:<port>` command; operator forwards the callback port from their local box. This is the realistic mode for production daemons.

**3. Token refresh.** `OAuthTokenStore.materializeBearer()` reads the cached bundle, exchanges `refresh_token` if within 60 s of `expires_at`, persists the new bundle, returns the access token. Concurrent materializations for the same `tokenStore` are coalesced via in-flight Promise dedup so we never burn the refresh token with parallel exchanges.

**4. Single-point Bearer materialization.** `resolveMcpServers()` runs once in `agent-runner` just before `mcpServers` reaches a provider. It strips `auth` from each entry and merges `Authorization: Bearer <token>` into `headers`. Providers (claude-code, gemini-cli, codex-cli, openai-compatible) stay completely unaware of OAuth — no per-provider plumbing, no env markers, no /proc walking, no settle delays, no process killing.

**5. Glean migration.** `skills/glean/mcp/glean.json` switched from stdio (`mcp-remote` shim binding port 8787) to HTTP transport with `auth: { kind: 'oauth2' }`. The daemon hits `https://contentful-be.glean.com/mcp/default` directly per run; no subprocess spawned at any layer.

## Files

| Area | New / changed |
|---|---|
| `src/auth/oauth-token-store.ts` | new — token cache + lazy refresh + path-traversal guard |
| `src/auth/oauth-flow.ts` | new — discovery, DCR, PKCE, callback listener, browser open |
| `src/mcp/resolve-mcp-servers.ts` | new — one-pass canonical→canonical transform |
| `src/cli/commands/auth-mcp.ts` | new — CLI command logic |
| `src/cli/index.ts` | wires `auth-mcp` |
| `src/skills/skill-loader.ts` | zod schema for `auth` + default `tokenStore` stamping |
| `src/providers/provider-types.ts` | `CanonicalMcpHttpServer.auth?: McpAuthSpec` |
| `src/mcp/mcp-types.ts` | `McpServerConfig.auth?: McpAuthConfig` (parallel domain type) |
| `src/personas/persona-runtime-context.ts` | forwards `cfg.auth` through canonical translation |
| `src/daemon/agent-runner.ts` | calls `resolveMcpServers` before passing to provider |
| `src/daemon/{daemon-context,daemon-bootstrap}.ts` | `OAuthTokenStore` wired into `DaemonContext`, anchored to `dataDir` |
| `skills/glean/mcp/glean.json` | migrated from stdio mcp-remote to HTTP + OAuth |
| `tests/unit/auth/oauth-token-store.test.ts` | 18 tests |
| `tests/unit/mcp/resolve-mcp-servers.test.ts` | 5 tests |
| `README.md` | new "HTTP MCP Servers and OAuth" section + CLI reference entry |

**Total: +1604 / -3 lines.** 969 unit tests pass (auth, mcp, providers, daemon, skills, personas, cli) — no regressions.

## Migration for existing operators

After merge:

```bash
# One-time: run the OAuth dance and persist tokens to the new location.
# For headless servers, pass --headless and follow the ssh -L instructions.
npx talonctl auth-mcp glean:glean

# Restart the daemon. From this point on:
# - No mcp-remote process spawned anywhere
# - Daemon hits Glean directly per agent run with a fresh Bearer
# - Token auto-refreshes within 60s of expiry
```

The old `~/.mcp-auth/mcp-remote-0.1.37/...` cache is no longer consulted and can be deleted.

## Test plan

- [ ] `npm run build` clean
- [ ] `npx vitest run` — verify all tests pass on CI
- [ ] On the daemon host: `npx talonctl auth-mcp glean:glean --headless`, complete the dance from your local browser via SSH forward, confirm `data/mcp-auth/glean/glean.json` exists with mode 0600
- [ ] Restart daemon. Send work-context-manager a Glean question; verify the agent's response shows real calendar/meeting data (no "still connecting", no port collisions)
- [ ] Send TWO consecutive Glean questions in the same daemon lifetime — should both succeed without any host-side mcp-remote process lingering (issue #210 acceptance criterion)
- [ ] Verify no `mcp-remote` process appears in `ps -eo cmd | grep mcp-remote` at any point

## Notes for reviewers

- Codex CLI was unavailable locally (its own refresh token expired). Per @ivo-toby's call, this PR ships without a pre-commit codex review — please run the GitHub-side codex review on the PR if you want a second opinion.
- The headless OAuth flow assumes the operator has shell access to the daemon's host. That's the realistic case for talond deployments.
- For non-OAuth HTTP MCPs (static API keys etc.) keep using `headers` directly — `auth` is opt-in and only triggered when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)