### PR TITLE
Talon starter bundle (v0.2.0)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,91 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write       # create GitHub Release + attach artifacts
+  packages: write       # push container image to GHCR
+
+jobs:
+  build-and-push-image:
+    name: Build & push container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/talond
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-and-attach-bundle:
+    name: Build & attach starter bundle
+    runs-on: ubuntu-latest
+    needs: build-and-push-image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync skills into starter/
+        run: |
+          chmod +x scripts/sync-starter-skills.sh
+          scripts/sync-starter-skills.sh
+
+      - name: Ensure starter/data exists in tarball
+        run: mkdir -p starter/data
+
+      - name: Create tarball
+        run: |
+          # Rename top-level dir from `starter/` to `talon-starter/` so users
+          # get a friendlier name when they extract. Done via a copy (portable
+          # across BSD and GNU tar) rather than --transform.
+          #
+          # The artifact filename is unversioned (`talon-starter.tar.gz`) so the
+          # GitHub `/releases/latest/download/talon-starter.tar.gz` URL — what
+          # the starter README documents — resolves correctly. The release tag
+          # itself carries the version.
+          rm -rf build && mkdir build
+          cp -R starter build/talon-starter
+          tar -czf talon-starter.tar.gz -C build talon-starter
+
+      - name: Attach to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: talon-starter.tar.gz
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/talond
           tags: |
@@ -42,7 +42,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build & push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: deploy/Dockerfile
@@ -59,7 +59,7 @@ jobs:
     needs: build-and-push-image
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync skills into starter/
         run: |
@@ -84,8 +84,25 @@ jobs:
           tar -czf talon-starter.tar.gz -C build talon-starter
 
       - name: Attach to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: talon-starter.tar.gz
           fail_on_unmatched_files: true
-          generate_release_notes: true
+          generate_release_notes: false
+          body: |
+            ## Talon ${{ github.ref_name }}
+
+            **Container image:** `ghcr.io/ivo-toby/talond:${{ github.ref_name }}` (also tagged `:latest`)
+            **Starter bundle:** `talon-starter.tar.gz` attached below
+
+            ### Quick start
+
+            ```bash
+            curl -fsSL https://github.com/ivo-toby/talon/releases/download/${{ github.ref_name }}/talon-starter.tar.gz | tar xz
+            cd talon-starter
+            ./install.sh
+            # edit .env + config/talond.yaml, then:
+            docker compose up -d
+            ```
+
+            See the [starter README](https://github.com/ivo-toby/talon/blob/main/starter/README.md) for full setup.

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ baileys-auth*
 
 # Ad-hoc UI screenshots from local testing
 chat-ui-*.png
+
+# Starter bundle — synced skill dirs are regenerated from .claude/skills/ via
+# scripts/sync-starter-skills.sh. INCLUDED.txt stays tracked.
+starter/.claude/skills/*/

--- a/config/talond.example.yaml
+++ b/config/talond.example.yaml
@@ -28,10 +28,10 @@ channels:
     name: personal-telegram
     enabled: true
     config:
-      token: ${TELEGRAM_BOT_TOKEN}
-      allowedUserIds:
-        - 123456789
-      pollIntervalMs: 1000
+      botToken: ${TELEGRAM_BOT_TOKEN}
+      allowedChatIds:
+        - "123456789"
+      pollingTimeoutSec: 30
 
   # WhatsApp Web bridge via Baileys — no Meta Business account required.
   # Authenticate first: npx talonctl whatsapp-auth --auth-dir ./baileys-auth

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,36 @@
+# .env.example
+# Copy this file to .env in the project root and fill in your secrets.
+# This file is loaded by docker-compose.yaml.
+
+# AI Provider API Keys
+# ---------------------------------------------------------------------------
+# If you use Claude Code (Anthropic API):
+SUBAGENT_ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# If you use Gemini CLI (Google AI API):
+# Note: Gemini CLI usually uses OAuth tokens in ~/.gemini/ but can also use API keys.
+GOOGLE_AI_API_KEY=your_google_ai_api_key_here
+
+# If you use OpenAI:
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Channel Tokens
+# ---------------------------------------------------------------------------
+# Telegram Bot Token (from @BotFather)
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
+
+# Slack Bot Token (xoxb-...)
+SLACK_BOT_TOKEN=your_slack_bot_token_here
+
+# Discord Bot Token
+DISCORD_BOT_TOKEN=your_discord_bot_token_here
+
+# WhatsApp (Twilio/360dialog) credentials
+WHATSAPP_API_KEY=your_whatsapp_api_key_here
+
+# Terminal Channel Token (for talonctl chat)
+TERMINAL_TOKEN=your_secret_terminal_token_here
+
+# Daemon Configuration Overrides
+# ---------------------------------------------------------------------------
+# LOG_LEVEL=debug

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -46,8 +46,11 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user/group with a fixed UID so host bind-mount
-# permissions are predictable.
-RUN groupadd --gid 1000 talond && \
+# permissions are predictable. node:slim ships with a `node` user at
+# UID/GID 1000 already, so remove it first to free the slot.
+RUN userdel node && \
+    (getent group node >/dev/null && groupdel node || true) && \
+    groupadd --gid 1000 talond && \
     useradd --uid 1000 --gid talond --no-create-home --shell /usr/sbin/nologin talond
 
 # Application directory
@@ -67,23 +70,33 @@ COPY config/talond.example.yaml ./config/
 # Volume mount points:
 #   /data    — SQLite database file, PID file, IPC sockets
 #   /config  — talond.yaml (bind-mount your config here at runtime)
+# Optional bind mounts (not declared as VOLUME to avoid anonymous volume surprises):
+#   /personas — persona directories
+#   /skills   — custom skills
+#   /subagents — custom sub-agents
 VOLUME ["/data", "/config"]
 
-# Ensure the daemon user can write to the data directory at runtime.
-# The directory is created here so Docker creates it as root; at startup
-# the container can chown it if needed, or the host pre-creates it.
-RUN mkdir -p /data /config && chown talond:talond /data /config
+# Ensure the daemon user can write to the volumes at runtime.
+RUN mkdir -p /data /config /personas /skills /subagents && \
+    chown talond:talond /data /config /personas /skills /subagents
+
+# Create symlinks from /opt/talond/<dir> to /<dir> so that relative paths
+# in the config (e.g. personas/assistant) resolve to the volume mounts.
+RUN ln -s /data /opt/talond/data && \
+    ln -s /personas /opt/talond/personas && \
+    ln -s /skills /opt/talond/skills && \
+    ln -s /subagents /opt/talond/subagents
 
 # Switch to the non-root user for all subsequent commands
 USER talond
 
 # Health check: verify the process is alive by checking the PID file.
-# Falls back to a simple node sanity check when no PID file is present yet.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+# Exits non-zero if the PID file is missing (daemon not started) or the process is dead.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD node -e "const fs=require('fs'); \
         const pid=process.env.TALON_PID_FILE||'/data/talond.pid'; \
-        if(fs.existsSync(pid)){const p=parseInt(fs.readFileSync(pid,'utf8').trim()); \
-        try{process.kill(p,0);process.exit(0);}catch{process.exit(1);}} \
-        process.exit(0);"
+        if(!fs.existsSync(pid)){process.exit(1);} \
+        const p=parseInt(fs.readFileSync(pid,'utf8').trim()); \
+        try{process.kill(p,0);process.exit(0);}catch{process.exit(1);}"
 
-ENTRYPOINT ["/usr/bin/tini", "--", "node", "/opt/talond/dist/daemon/main.js", "--config", "/config/talond.yaml"]
+ENTRYPOINT ["/usr/bin/tini", "--", "node", "/opt/talond/dist/index.js", "--config", "/config/talond.yaml"]

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -5,7 +5,8 @@
 #   1. cp config/talond.example.yaml config/talond.yaml
 #   2. Edit config/talond.yaml with your API keys and channel settings
 #   3. cp deploy/.env.example .env  (and fill in secrets)
-#   4. docker compose up -d
+#   4. mkdir -p personas data
+#   5. docker compose up -d
 # =============================================================================
 
 services:
@@ -28,9 +29,14 @@ services:
     environment:
       # Force production mode regardless of what the .env file says
       NODE_ENV: production
+      # Point the daemon to the correct in-container paths
+      TALOND_DATA_DIR: /data
+      TALOND_CONFIG_PATH: /config/talond.yaml
 
     volumes:
       # Persistent data: SQLite database, PID file, IPC sockets
+      # Recommendation: Use a bind mount (e.g. ./data:/data) if you want to
+      # use 'talonctl' from the host machine without 'docker exec'.
       - talond-data:/data
 
       # Configuration: bind-mount your edited talond.yaml here
@@ -38,6 +44,21 @@ services:
         source: ../config/talond.yaml
         target: /config/talond.yaml
         read_only: true
+
+      # Personas: bind-mount so you can edit prompts from the host
+      # and so Claude Code skills can manage personas.
+      # Create the directory first: mkdir -p personas
+      - type: bind
+        source: ../personas
+        target: /personas
+
+      # Optional: Custom skills or sub-agents — uncomment if used
+      # - type: bind
+      #   source: ../skills
+      #   target: /skills
+      # - type: bind
+      #   source: ../subagents
+      #   target: /subagents
 
       # -----------------------------------------------------------------------
       # Docker socket (optional — only needed for sandbox container spawning)
@@ -60,10 +81,10 @@ services:
     # ports:
     #   - "127.0.0.1:5173:5173"  # MCP server (if enabled in talond.yaml)
 
-    # Health check mirrors the HEALTHCHECK in the Dockerfile but is also
-    # expressed here so Compose restarts unhealthy containers.
+    # Health check: verify the daemon process is alive via PID file.
+    # Reports unhealthy if the PID file is missing or the process is dead.
     healthcheck:
-      test: ["CMD", "node", "-e", "process.exit(0)"]
+      test: ["CMD", "node", "-e", "const fs=require('fs');const p=process.env.TALON_PID_FILE||'/data/talond.pid';if(!fs.existsSync(p)){process.exit(1);}try{process.kill(parseInt(fs.readFileSync(p,'utf8').trim()),0);process.exit(0);}catch{process.exit(1);}"]
       interval: 30s
       timeout: 5s
       start_period: 15s

--- a/deploy/talonctl-docker.sh
+++ b/deploy/talonctl-docker.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# talonctl-docker.sh — Run talonctl commands against the containerized daemon.
+#
+# Usage:
+#   ./deploy/talonctl-docker.sh status
+#   ./deploy/talonctl-docker.sh reload
+#   ./deploy/talonctl-docker.sh list-channels
+#
+# This is a thin wrapper around `docker exec` that forwards arguments to the
+# talonctl CLI inside the running talond container.
+
+set -euo pipefail
+
+CONTAINER="${TALOND_CONTAINER:-talond}"
+
+if ! docker inspect "$CONTAINER" &>/dev/null; then
+  echo "Error: container '$CONTAINER' not found. Is the daemon running?" >&2
+  exit 1
+fi
+
+exec docker exec -it "$CONTAINER" node dist/cli/index.js "$@"

--- a/scripts/sync-starter-skills.sh
+++ b/scripts/sync-starter-skills.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# sync-starter-skills.sh — copy the user-facing Claude skills into the starter
+# bundle. Source: .claude/skills/<name>/. Destination: starter/.claude/skills/<name>/.
+#
+# Reads the allowlist from starter/.claude/skills/INCLUDED.txt.
+#
+# Usage:
+#   scripts/sync-starter-skills.sh           # sync
+#   scripts/sync-starter-skills.sh --check   # exit non-zero if any allowlisted
+#                                            # skill is missing from .claude/skills/
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="$ROOT/.claude/skills"
+DEST_DIR="$ROOT/starter/.claude/skills"
+ALLOWLIST="$DEST_DIR/INCLUDED.txt"
+
+MODE="sync"
+if [ "${1:-}" = "--check" ]; then
+  MODE="check"
+fi
+
+if [ ! -f "$ALLOWLIST" ]; then
+  echo "sync-starter-skills: allowlist not found at $ALLOWLIST" >&2
+  exit 1
+fi
+
+# Read non-blank, non-comment lines into an array (Bash 3.2 compatible — no mapfile).
+skills=()
+while IFS= read -r line || [ -n "$line" ]; do
+  trimmed="${line%%#*}"
+  trimmed="${trimmed## }"
+  trimmed="${trimmed%% }"
+  [ -z "$trimmed" ] && continue
+  skills+=("$trimmed")
+done < "$ALLOWLIST"
+
+if [ ${#skills[@]} -eq 0 ]; then
+  echo "sync-starter-skills: allowlist is empty"
+  exit 0
+fi
+
+missing=()
+for skill in "${skills[@]}"; do
+  if [ ! -d "$SRC_DIR/$skill" ]; then
+    missing+=("$skill")
+  fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "sync-starter-skills: missing skill dirs in $SRC_DIR:" >&2
+  for m in "${missing[@]}"; do echo "  - $m" >&2; done
+  exit 2
+fi
+
+if [ "$MODE" = "check" ]; then
+  echo "sync-starter-skills: all ${#skills[@]} allowlisted skills present in source"
+  exit 0
+fi
+
+mkdir -p "$DEST_DIR"
+
+# Remove any previously-synced skill dirs (anything inside DEST_DIR other than
+# INCLUDED.txt) so the destination is a fresh, deterministic copy.
+for entry in "$DEST_DIR"/*; do
+  [ -e "$entry" ] || continue
+  base="$(basename "$entry")"
+  [ "$base" = "INCLUDED.txt" ] && continue
+  rm -rf "$entry"
+done
+
+for skill in "${skills[@]}"; do
+  cp -R "$SRC_DIR/$skill" "$DEST_DIR/$skill"
+  echo "  + $skill"
+done
+
+echo "sync-starter-skills: synced ${#skills[@]} skills to $DEST_DIR"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -60,6 +60,11 @@ if (existsSync(envPath)) {
   }
 }
 
+// Default config path for `--config`. Honors TALOND_CONFIG_PATH so the docker
+// starter bundle (which sets this env var in the container) and other deploys
+// don't need to pass --config on every command.
+const DEFAULT_CONFIG_PATH = process.env.TALOND_CONFIG_PATH ?? 'talond.yaml';
+
 const program = new Command();
 
 function parseBooleanOption(value: string): boolean {
@@ -99,7 +104,7 @@ program
 program
   .command('migrate')
   .description('Apply database migrations')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action((opts: { config: string }) => {
     migrateCommand({ configPath: opts.config });
   });
@@ -107,7 +112,7 @@ program
 program
   .command('backup')
   .description('Backup database, config, personas, and skills')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .option('--output <path>', 'Backup output directory (overrides default)')
   .action(async (opts: { config: string; output?: string }) => {
     await backupCommand({
@@ -131,7 +136,7 @@ program
 program
   .command('doctor')
   .description('Check system requirements and configuration')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { config: string }) => {
     await doctorCommand({ configPath: opts.config });
   });
@@ -139,7 +144,7 @@ program
 program
   .command('setup')
   .description('First-time setup: detect environment, create directories, generate config')
-  .option('--config <path>', 'Path to write talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to write talond.yaml', DEFAULT_CONFIG_PATH)
   .option('--data-dir <path>', 'Data directory path', 'data')
   .action(async (opts: { config: string; dataDir: string }) => {
     await setupCommand({
@@ -153,7 +158,7 @@ program
   .description('Add a channel connector to talond.yaml')
   .requiredOption('--name <name>', 'Unique channel name (e.g. my-telegram)')
   .requiredOption('--type <type>', 'Connector type (e.g. telegram, slack, discord)')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { name: string; type: string; config: string }) => {
     await addChannelCommand({
       name: opts.name,
@@ -166,7 +171,7 @@ program
   .command('add-persona')
   .description('Scaffold a persona directory and add it to talond.yaml')
   .requiredOption('--name <name>', 'Persona name (e.g. assistant)')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .option('--templates-dir <path>', 'Path to templates directory', 'templates')
   .option('--model <model>', 'Model name')
   .option('--provider <provider>', 'Provider name')
@@ -207,7 +212,7 @@ program
   .requiredOption('--name <name>', 'Skill name (e.g. web-search)')
   .requiredOption('--persona <persona>', 'Persona to attach the skill to')
   .option('--format <format>', 'Skill format: yaml or skillmd', 'yaml')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { name: string; persona: string; format: string; config: string }) => {
     if (opts.format !== 'yaml' && opts.format !== 'skillmd') {
       console.error(`Error: invalid format "${opts.format}". Must be "yaml" or "skillmd".`);
@@ -269,7 +274,7 @@ program
 program
   .command('list-channels')
   .description('List all configured channels')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { config: string }) => {
     await listChannelsCommand({ configPath: opts.config });
   });
@@ -277,7 +282,7 @@ program
 program
   .command('list-personas')
   .description('List all configured personas')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { config: string }) => {
     await listPersonasCommand({ configPath: opts.config });
   });
@@ -285,7 +290,7 @@ program
 program
   .command('list-skills')
   .description('List all skills (optionally filter by persona)')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .option('--persona <name>', 'Filter skills by persona name')
   .action(async (opts: { config: string; persona?: string }) => {
     await listSkillsCommand({ configPath: opts.config, personaName: opts.persona });
@@ -307,7 +312,7 @@ program
   .option('--remove <labels>', 'Remove from allow list (comma-separated)')
   .option('--require-approval <labels>', 'Replace requireApproval list (comma-separated)')
   .option('--show', 'Show current capabilities without modifying')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: {
     persona: string;
     allow?: string;
@@ -333,7 +338,7 @@ program
   .description('Bind a persona to a channel')
   .requiredOption('--persona <name>', 'Persona name')
   .requiredOption('--channel <name>', 'Channel name')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { persona: string; channel: string; config: string }) => {
     await bindCommand({ persona: opts.persona, channel: opts.channel, configPath: opts.config });
   });
@@ -343,7 +348,7 @@ program
   .description('Remove a persona-channel binding')
   .requiredOption('--persona <name>', 'Persona name')
   .requiredOption('--channel <name>', 'Channel name')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { persona: string; channel: string; config: string }) => {
     await unbindCommand({ persona: opts.persona, channel: opts.channel, configPath: opts.config });
   });
@@ -382,7 +387,7 @@ program
 program
   .command('env-check')
   .description('Check environment variables referenced in config')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { config: string }) => {
     await envCheckCommand({ configPath: opts.config });
   });
@@ -391,7 +396,7 @@ program
   .command('remove-channel')
   .description('Remove a channel from talond.yaml')
   .requiredOption('--name <name>', 'Channel name to remove')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { name: string; config: string }) => {
     await removeChannelCommand({ name: opts.name, configPath: opts.config });
   });
@@ -400,7 +405,7 @@ program
   .command('remove-persona')
   .description('Remove a persona from talond.yaml')
   .requiredOption('--name <name>', 'Persona name to remove')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { name: string; config: string }) => {
     await removePersonaCommand({ name: opts.name, configPath: opts.config });
   });
@@ -408,7 +413,7 @@ program
 program
   .command('config-show')
   .description('Show effective config with env vars substituted (secrets masked)')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .option('--show-secrets', 'Show secret values instead of masking them')
   .action(async (opts: { config: string; showSecrets?: boolean }) => {
     await configShowCommand({ configPath: opts.config, showSecrets: opts.showSecrets });
@@ -430,7 +435,7 @@ program
     '--prompt-file <name>',
     'Prompt file basename in the persona\'s prompts/ dir (without .md), resolved by the scheduler at fire time',
   )
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: {
     persona: string;
     channel: string;
@@ -465,7 +470,7 @@ program
   .command('list-schedules')
   .description('List all scheduled tasks')
   .option('--persona <name>', 'Filter by persona name')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { config: string; persona?: string }) => {
     await listSchedulesCommand({ configPath: opts.config, persona: opts.persona });
   });
@@ -491,7 +496,7 @@ program
     'Localhost callback port (default 8788)',
     (v) => Number.parseInt(v, 10),
   )
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .option('--skills-dir <path>', 'Path to the skills/ directory', 'skills')
   .action(async (
     selector: string,
@@ -533,7 +538,7 @@ program
   .command('remove-schedule')
   .description('Permanently delete a scheduled task')
   .argument('<schedule-id>', 'Schedule ID to remove')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (scheduleId: string, opts: { config: string }) => {
     await removeScheduleCommand({ scheduleId, configPath: opts.config });
   });
@@ -547,7 +552,7 @@ program
   .description('Manually invoke a sub-agent for testing (no daemon required)')
   .requiredOption('--name <name>', 'Sub-agent name (e.g. "session-summarizer")')
   .requiredOption('--input <json>', 'JSON input for the sub-agent')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .option('--subagents-dir <path>', 'Sub-agents directory (overrides config default)')
   .action(async (opts: { name: string; input: string; config: string; subagentsDir?: string }) => {
     await runSubAgentCommand({
@@ -565,7 +570,7 @@ program
 program
   .command('list-providers')
   .description('List all configured providers from agentRunner and backgroundAgent')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { config: string }) => {
     await listProvidersCommand({ configPath: opts.config });
   });
@@ -587,7 +592,7 @@ program
   .option('--summarizer <name>', 'Subagent name used for session summarization', 'session-summarizer')
   .option('--enabled', 'Enable the provider immediately (default: disabled)')
   .option('--default-model <model>', 'Set options.defaultModel (e.g. gemini-2.5-pro)')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: {
     name: string;
     command: string;
@@ -630,7 +635,7 @@ program
   .description('Switch the default provider for agent-runner or background context')
   .requiredOption('--name <name>', 'Provider name to set as default')
   .requiredOption('--context <ctx>', 'Context: agent-runner or background')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { name: string; context: string; config: string }) => {
     await setDefaultProviderCommand({
       name: opts.name,
@@ -644,7 +649,7 @@ program
   .description('Test a provider by running a version check and minimal prompt')
   .requiredOption('--name <name>', 'Provider name to test')
   .option('--context <ctx>', 'Context: agent-runner or background', 'agent-runner')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { name: string; context: string; config: string }) => {
     await testProviderCommand({
       name: opts.name,
@@ -657,7 +662,7 @@ program
   .command('list-threads')
   .description('List persisted threads for a channel, including external IDs and latest provider info')
   .requiredOption('--channel <name>', 'Channel name')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { channel: string; config: string }) => {
     await listThreadsCommand({
       channel: opts.channel,
@@ -672,7 +677,7 @@ program
   .option('--external-id <id>', 'Thread external ID. Use `talonctl list-threads --channel <name>` to discover values.')
   .option('--all', 'Reset affinity for all threads on this channel')
   .option('--yes', 'Bypass the confirmation prompt')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { channel: string; externalId?: string; all?: boolean; yes?: boolean; config: string }) => {
     if (!opts.all && !opts.externalId) {
       console.error('Error: specify --external-id <id> or --all');
@@ -735,7 +740,7 @@ a2a
   .option('--status <state>', 'Filter by task state (submitted, working, completed, failed, canceled)')
   .option('--target <persona>', 'Filter by target persona name')
   .option('--limit <n>', 'Maximum number of tasks to show', '20')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (opts: { status?: string; target?: string; limit: string; config: string }) => {
     const limit = parseInt(opts.limit, 10);
     if (isNaN(limit) || limit < 1) {
@@ -754,7 +759,7 @@ a2a
   .command('send <target-persona> <message>')
   .description('Submit a manual A2A task to a persona (for testing)')
   .option('--source <persona>', 'Source persona name (defaults to "cli")', 'cli')
-  .option('--config <path>', 'Path to talond.yaml', 'talond.yaml')
+  .option('--config <path>', 'Path to talond.yaml', DEFAULT_CONFIG_PATH)
   .action(async (targetPersona: string, message: string, opts: { source: string; config: string }) => {
     await a2aSendCommand({
       configPath: opts.config,

--- a/starter/.claude/skills/INCLUDED.txt
+++ b/starter/.claude/skills/INCLUDED.txt
@@ -1,0 +1,18 @@
+# Allowlist for skills that ship in the starter bundle.
+# One skill directory name per line. Lines starting with `#` are comments.
+# The source is `.claude/skills/<name>/` at the repo root.
+# Run scripts/sync-starter-skills.sh to populate starter/.claude/skills/.
+
+talon-setup
+
+add-telegram
+add-slack
+add-discord
+add-whatsapp
+add-email
+add-terminal
+
+create-profile
+create-personality
+
+manage-schedules

--- a/starter/.env.example
+++ b/starter/.env.example
@@ -1,0 +1,44 @@
+# Talon starter — secrets. Copy to `.env` and fill in the ones you use.
+# Loaded by docker-compose.yaml. Never commit `.env`.
+
+# ---------------------------------------------------------------------------
+# Agent provider — pick ONE based on your talond.yaml
+# ---------------------------------------------------------------------------
+
+# Anthropic API key (default; required if you use the claude-code provider in api_key mode)
+ANTHROPIC_API_KEY=
+
+# OpenAI key (only if you use the openai or codex-cli providers)
+# OPENAI_API_KEY=
+
+# Google AI key (only if you use the gemini-cli provider)
+# GOOGLE_AI_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Channels — fill in the ones you enable in talond.yaml
+# ---------------------------------------------------------------------------
+
+# Telegram bot token from @BotFather.
+# Only one process at a time can poll a given bot — if your other talond is
+# running with this same token, getUpdates will conflict.
+TELEGRAM_BOT_TOKEN=
+
+# Slack
+# SLACK_BOT_TOKEN=
+# SLACK_APP_TOKEN=
+# SLACK_SIGNING_SECRET=
+
+# Discord
+# DISCORD_BOT_TOKEN=
+
+# WhatsApp Business (Twilio / 360dialog / Cloud API)
+# WHATSAPP_API_KEY=
+
+# Terminal channel (for `talonctl chat`)
+# TERMINAL_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Optional
+# ---------------------------------------------------------------------------
+
+# LOG_LEVEL=debug

--- a/starter/README.md
+++ b/starter/README.md
@@ -7,12 +7,14 @@ Run [Talon](https://github.com/ivo-toby/talon) without cloning the source.
 - `docker-compose.yaml` pointing at the published `ghcr.io/ivo-toby/talond` image
 - `.env.example` and a minimal `config/talond.example.yaml`
 - One default persona (`personas/assistant/system.md`)
+- `userdata/` — drop files here for the agent to see (see "Sharing files with the agent" below)
 - `bin/talonctl` — host-side wrapper for the in-container CLI
 - `.claude/skills/` — Claude Code skills that walk you through setup interactively
 
 ## Requirements
 
-- Docker (with `docker compose`)
+- Docker (Engine on Linux, or Docker Desktop on macOS/Windows) with `docker compose`
+- At least one AI provider account or local endpoint (see [Using a different AI provider](#using-a-different-ai-provider))
 - Optional: [Claude Code](https://claude.com/code) for the guided setup flow
 
 ## Quickstart
@@ -26,7 +28,7 @@ cd talon-starter
 ./install.sh
 
 # 3. Configure
-cp .env.example .env                              # fill in TELEGRAM_BOT_TOKEN and ANTHROPIC_API_KEY
+cp .env.example .env                              # fill in TELEGRAM_BOT_TOKEN; ANTHROPIC_API_KEY too if using the default Claude provider
 cp config/talond.example.yaml config/talond.yaml  # edit allowedChatIds at minimum
 
 # 4. Run
@@ -34,8 +36,9 @@ docker compose up -d
 talonctl status
 ```
 
-Then message your Telegram bot. The daemon polls Telegram, queues the message,
-runs the agent, and replies.
+Then DM your Telegram bot — the daemon polls Telegram, queues the message,
+runs the agent, and replies. If you don't get a reply within ~30 seconds,
+`docker compose logs -f talond` will show what happened.
 
 ## Guided setup with Claude Code
 
@@ -59,17 +62,45 @@ The skills edit your `.env`, `config/talond.yaml`, and `personas/` for you.
 
 ## Configuration
 
-| File | Purpose |
+| File or dir | Purpose |
 | --- | --- |
 | `.env` | Secrets (API keys, bot tokens). Never commit. |
 | `config/talond.yaml` | Main config — channels, personas, providers, bindings. |
 | `personas/<name>/system.md` | System prompt for each persona. |
+| `userdata/` | Files you want the agent to see. Bind-mounted at `/userdata`. |
 | `data/` | Persistent state (SQLite DB, IPC socket). Back this up. |
 
-The minimal `talond.yaml` enables Telegram + a Claude-powered assistant
-persona. To use a different provider (OpenAI-compatible endpoint, Gemini CLI,
-Codex CLI), see the full reference config at
-[github.com/ivo-toby/talon](https://github.com/ivo-toby/talon/blob/main/config/talond.example.yaml).
+## Using a different AI provider
+
+The minimal `talond.yaml` defaults to Claude (`claude-code` provider) and reads
+`ANTHROPIC_API_KEY` from `.env`. To use something else:
+
+| Provider | What to change in `talond.yaml` | What to set in `.env` |
+| --- | --- | --- |
+| **OpenAI-compatible** (Ollama Cloud, Groq, Together, vLLM, llama.cpp, …) | Set `provider: openai-compatible` on the persona; configure `agentRunner.providers.openai-compatible` with `baseUrl` + `defaultModel`; set `auth.providers.<providerId>.baseURL` (+ optional `apiKey`) | Your endpoint's API key if it needs one |
+| **Gemini CLI** | Set `provider: gemini-cli`; ensure `gemini` is on PATH inside the container (currently not preinstalled — workaround required) | `GOOGLE_AI_API_KEY` if not using interactive OAuth |
+| **Codex CLI** | Set `provider: codex-cli`; same caveat as Gemini for the binary | `OPENAI_API_KEY` |
+
+See the [full reference config](https://github.com/ivo-toby/talon/blob/main/config/talond.example.yaml)
+for complete provider snippets including context-management and sub-agent tuning.
+
+## Sharing files with the agent
+
+Anything you place in `userdata/` is visible to the running agent at
+`/userdata` inside the container. The agent reads (and writes) via its
+provider's built-in file tools (Claude's `Read`/`Edit`, etc.) — no extra
+configuration needed.
+
+```bash
+mkdir -p userdata/notes
+cp ~/Documents/quarterly-report.pdf userdata/notes/
+# then ask your bot:
+#   "summarize /userdata/notes/quarterly-report.pdf"
+```
+
+The agent can also write artifacts back here — useful for drafts,
+reports, generated code. See [`userdata/README.md`](userdata/README.md)
+inside the bundle for permission notes (Linux UID/GID 1000).
 
 ## Common operations
 
@@ -111,6 +142,11 @@ schema-valid; check your edits.
 
 **`talonctl: container 'talond' not found`** — the daemon isn't running yet.
 `docker compose up -d` first.
+
+**Permission denied writing to `data/` or `userdata/` on Linux** — the
+container runs as UID/GID 1000. If your host user isn't 1000, `chown
+1000:1000 data/ userdata/` (or `chmod 0777` for a quick test). macOS and
+Windows on Docker Desktop don't hit this.
 
 ## License
 

--- a/starter/README.md
+++ b/starter/README.md
@@ -1,0 +1,118 @@
+# Talon — Starter Bundle
+
+Run [Talon](https://github.com/ivo-toby/talon) without cloning the source.
+
+## What you get
+
+- `docker-compose.yaml` pointing at the published `ghcr.io/ivo-toby/talond` image
+- `.env.example` and a minimal `config/talond.example.yaml`
+- One default persona (`personas/assistant/system.md`)
+- `bin/talonctl` — host-side wrapper for the in-container CLI
+- `.claude/skills/` — Claude Code skills that walk you through setup interactively
+
+## Requirements
+
+- Docker (with `docker compose`)
+- Optional: [Claude Code](https://claude.com/code) for the guided setup flow
+
+## Quickstart
+
+```bash
+# 1. Download and extract
+curl -fsSL https://github.com/ivo-toby/talon/releases/latest/download/talon-starter.tar.gz | tar xz
+cd talon-starter
+
+# 2. Install the host-side CLI (no sudo, drops into ~/.local/bin)
+./install.sh
+
+# 3. Configure
+cp .env.example .env                              # fill in TELEGRAM_BOT_TOKEN and ANTHROPIC_API_KEY
+cp config/talond.example.yaml config/talond.yaml  # edit allowedChatIds at minimum
+
+# 4. Run
+docker compose up -d
+talonctl status
+```
+
+Then message your Telegram bot. The daemon polls Telegram, queues the message,
+runs the agent, and replies.
+
+## Guided setup with Claude Code
+
+If you have [Claude Code](https://claude.com/code) installed, you can configure
+Talon conversationally:
+
+```bash
+cd talon-starter
+claude
+```
+
+Then in Claude Code:
+
+- `/talon-setup` — top-level guided setup
+- `/add-telegram`, `/add-slack`, `/add-discord`, `/add-whatsapp`, `/add-email`, `/add-terminal` — add channels
+- `/create-profile` — create a new persona
+- `/create-personality` — customize a persona's voice and tone
+- `/manage-schedules` — set up scheduled agent runs
+
+The skills edit your `.env`, `config/talond.yaml`, and `personas/` for you.
+
+## Configuration
+
+| File | Purpose |
+| --- | --- |
+| `.env` | Secrets (API keys, bot tokens). Never commit. |
+| `config/talond.yaml` | Main config — channels, personas, providers, bindings. |
+| `personas/<name>/system.md` | System prompt for each persona. |
+| `data/` | Persistent state (SQLite DB, IPC socket). Back this up. |
+
+The minimal `talond.yaml` enables Telegram + a Claude-powered assistant
+persona. To use a different provider (OpenAI-compatible endpoint, Gemini CLI,
+Codex CLI), see the full reference config at
+[github.com/ivo-toby/talon](https://github.com/ivo-toby/talon/blob/main/config/talond.example.yaml).
+
+## Common operations
+
+```bash
+docker compose up -d            # start in the background
+docker compose logs -f talond   # tail logs
+docker compose restart talond   # restart after editing config/talond.yaml
+docker compose down             # stop
+
+talonctl status                 # daemon health
+talonctl list-channels          # configured channels
+talonctl --help                 # all commands
+```
+
+## Updating
+
+```bash
+docker compose pull             # pull the latest image
+docker compose up -d            # recreate the container
+```
+
+For a clean upgrade of the bundle itself (new templates, new skills), download
+the latest `talon-starter.tar.gz` from
+[Releases](https://github.com/ivo-toby/talon/releases) and merge the relevant
+files manually — your `.env`, `config/talond.yaml`, and `personas/` are yours
+to keep.
+
+## Troubleshooting
+
+**Telegram polls error 404** — your `botToken` is wrong or empty. Verify with
+`curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe"`.
+
+**`getUpdates` conflict** — another process is polling the same bot. Stop the
+other process or use a separate bot for this instance.
+
+**Container exits immediately** — `docker compose logs talond` will usually
+show a config-validation error. The reference config in this bundle is
+schema-valid; check your edits.
+
+**`talonctl: container 'talond' not found`** — the daemon isn't running yet.
+`docker compose up -d` first.
+
+## License
+
+AGPL-3.0-only, same as the parent project. See
+[LICENSE](https://github.com/ivo-toby/talon/blob/main/LICENSE).

--- a/starter/bin/talonctl
+++ b/starter/bin/talonctl
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# talonctl — host-side wrapper around the in-container CLI.
+#
+# Usage:
+#   talonctl status
+#   talonctl list-channels
+#   talonctl chat
+#
+# Forwards all arguments and stdin/stdout to `node dist/cli/index.js` inside
+# the running talond container. Allocates a TTY only when stdin and stdout are
+# both terminals, so piping works:
+#
+#   talonctl list-channels | jq
+#
+# Container name defaults to `talond`. Override with TALOND_CONTAINER.
+
+set -euo pipefail
+
+CONTAINER="${TALOND_CONTAINER:-talond}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "talonctl: docker not found on PATH." >&2
+  exit 127
+fi
+
+if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
+  echo "talonctl: container '$CONTAINER' not found." >&2
+  echo "  Is the daemon running? Try: docker compose up -d" >&2
+  echo "  Or set TALOND_CONTAINER to the right container name." >&2
+  exit 1
+fi
+
+state="$(docker inspect -f '{{.State.Status}}' "$CONTAINER" 2>/dev/null || echo unknown)"
+if [ "$state" != "running" ]; then
+  echo "talonctl: container '$CONTAINER' is $state, not running." >&2
+  echo "  Start it with: docker compose up -d" >&2
+  exit 1
+fi
+
+# Config path resolution: the CLI honors $TALOND_CONFIG_PATH (set by the
+# bundled docker-compose.yaml to /config/talond.yaml), so we don't need to
+# pass --config explicitly. Override per-command if needed:
+#   talonctl status --config /some/other/path.yaml
+if [ -t 0 ] && [ -t 1 ]; then
+  exec docker exec -it "$CONTAINER" node /opt/talond/dist/cli/index.js "$@"
+else
+  exec docker exec -i  "$CONTAINER" node /opt/talond/dist/cli/index.js "$@"
+fi

--- a/starter/config/talond.example.yaml
+++ b/starter/config/talond.example.yaml
@@ -1,0 +1,82 @@
+# talond.yaml — Talon starter config
+#
+# Minimal end-to-end setup: one Telegram channel, one persona, Claude as the
+# agent. Copy to `talond.yaml` and edit. See the full reference at
+# https://github.com/ivo-toby/talon/blob/main/config/talond.example.yaml
+
+storage:
+  type: sqlite
+  path: data/talond.sqlite
+
+# ---------------------------------------------------------------------------
+# Channels
+# ---------------------------------------------------------------------------
+channels:
+  - type: telegram
+    name: personal-telegram
+    enabled: true
+    config:
+      botToken: ${TELEGRAM_BOT_TOKEN}
+      # Restrict who can message the bot. Find your Telegram user ID via
+      # @userinfobot. Values must be strings, not numbers.
+      allowedChatIds:
+        - "123456789"
+      pollingTimeoutSec: 30
+
+# ---------------------------------------------------------------------------
+# Personas — the agent identity and capabilities
+# ---------------------------------------------------------------------------
+personas:
+  - name: assistant
+    model: claude-sonnet-4-6
+    provider: claude-code
+    systemPromptFile: personas/assistant/system.md
+    skills: []
+    subagents: []
+    capabilities:
+      allow:
+        - channel.send:*
+        - memory.access:*
+    maxConcurrent: 1
+
+# ---------------------------------------------------------------------------
+# Bindings — which persona handles which channel
+# ---------------------------------------------------------------------------
+bindings:
+  - persona: assistant
+    channel: personal-telegram
+    isDefault: true
+
+# ---------------------------------------------------------------------------
+# Agent runtime
+# ---------------------------------------------------------------------------
+agentRunner:
+  defaultProvider: claude-code
+  providers:
+    claude-code:
+      enabled: true
+      command: claude
+      contextWindowTokens: 200000
+
+backgroundAgent:
+  enabled: false
+  defaultProvider: claude-code
+  providers:
+    claude-code:
+      enabled: true
+      command: claude
+      contextWindowTokens: 200000
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+# Default: api_key — reads $ANTHROPIC_API_KEY from .env.
+# For Claude Max subscription auth, set mode: subscription and bind-mount
+# ~/.claude into the container (see https://github.com/ivo-toby/talon/blob/main/starter/README.md).
+auth:
+  mode: api_key
+  providers:
+    anthropic:
+      apiKey: ${ANTHROPIC_API_KEY}
+
+logLevel: info

--- a/starter/docker-compose.yaml
+++ b/starter/docker-compose.yaml
@@ -1,0 +1,70 @@
+# =============================================================================
+# docker-compose.yaml — Talon starter
+# =============================================================================
+# Quick start:
+#   1. cp .env.example .env                          # add your secrets
+#   2. cp config/talond.example.yaml config/talond.yaml   # edit for your setup
+#   3. docker compose up -d
+#   4. ./bin/talonctl status                         # or `talonctl status` if installed
+# =============================================================================
+
+services:
+  talond:
+    image: ghcr.io/ivo-toby/talond:latest
+    container_name: talond
+    restart: unless-stopped
+
+    env_file:
+      - .env
+
+    environment:
+      NODE_ENV: production
+      TALOND_DATA_DIR: /data
+      TALOND_CONFIG_PATH: /config/talond.yaml
+
+    volumes:
+      # Persistent data: SQLite DB, PID file, IPC socket.
+      # Bind-mounted (not a named volume) so `talonctl` from the host can reach
+      # the socket directly once the host-side CLI ships (today's wrapper uses
+      # `docker exec` and works either way).
+      - ./data:/data
+
+      # Configuration: bind-mount your edited talond.yaml. NOT read-only
+      # because the bundled setup skills and talonctl commands (add-channel,
+      # add-persona, bind, …) mutate this file in place.
+      - type: bind
+        source: ./config/talond.yaml
+        target: /config/talond.yaml
+
+      # Personas: edit prompts from the host. Persona dirs live here.
+      - type: bind
+        source: ./personas
+        target: /personas
+
+      # Optional: custom skills and sub-agents.
+      # - type: bind
+      #   source: ./skills
+      #   target: /skills
+      # - type: bind
+      #   source: ./subagents
+      #   target: /subagents
+
+    healthcheck:
+      test: ["CMD", "node", "-e", "const fs=require('fs');const p=process.env.TALON_PID_FILE||'/data/talond.pid';if(!fs.existsSync(p)){process.exit(1);}try{process.kill(parseInt(fs.readFileSync(p,'utf8').trim()),0);process.exit(0);}catch{process.exit(1);}"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+    cap_drop:
+      - ALL
+
+    security_opt:
+      - no-new-privileges:true
+
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M

--- a/starter/docker-compose.yaml
+++ b/starter/docker-compose.yaml
@@ -41,6 +41,15 @@ services:
         source: ./personas
         target: /personas
 
+      # Userdata: a dropbox for files you want the agent to see.
+      # Drop PDFs, notes, repos, attachments — the agent reads them at
+      # /userdata via its own file tools (Claude's Read, etc.). Persona
+      # capabilities don't gate this; access is controlled by what's in the
+      # folder. Read+write so the agent can write artifacts back.
+      - type: bind
+        source: ./userdata
+        target: /userdata
+
       # Optional: custom skills and sub-agents.
       # - type: bind
       #   source: ./skills

--- a/starter/install.sh
+++ b/starter/install.sh
@@ -20,10 +20,10 @@ mkdir -p "$PREFIX"
 install -m 0755 "$SRC" "$DEST"
 echo "Installed: $DEST"
 
-# Ensure the bind-mount source for /data exists before `docker compose up`.
-# Without this, Docker creates it as root-owned on Linux, breaking the
+# Ensure the bind-mount sources exist before `docker compose up`.
+# Without this, Docker creates them as root-owned on Linux, breaking the
 # non-root user inside the container.
-mkdir -p "$HERE/data"
+mkdir -p "$HERE/data" "$HERE/userdata"
 
 case ":$PATH:" in
   *":$PREFIX:"*) ;;

--- a/starter/install.sh
+++ b/starter/install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# install.sh — install the talonctl wrapper to your PATH.
+#
+# Default install location: ~/.local/bin (no sudo). Override with PREFIX:
+#   PREFIX=/usr/local/bin sudo ./install.sh
+
+set -euo pipefail
+
+PREFIX="${PREFIX:-$HOME/.local/bin}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$HERE/bin/talonctl"
+DEST="$PREFIX/talonctl"
+
+if [ ! -f "$SRC" ]; then
+  echo "install.sh: source not found at $SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$PREFIX"
+install -m 0755 "$SRC" "$DEST"
+echo "Installed: $DEST"
+
+# Ensure the bind-mount source for /data exists before `docker compose up`.
+# Without this, Docker creates it as root-owned on Linux, breaking the
+# non-root user inside the container.
+mkdir -p "$HERE/data"
+
+case ":$PATH:" in
+  *":$PREFIX:"*) ;;
+  *)
+    echo
+    echo "Note: $PREFIX is not on your PATH. Add this to your shell rc:"
+    echo "  export PATH=\"$PREFIX:\$PATH\""
+    ;;
+esac
+
+echo
+echo "Try it: talonctl --help"

--- a/starter/personas/assistant/system.md
+++ b/starter/personas/assistant/system.md
@@ -1,0 +1,20 @@
+# Assistant — System Prompt
+
+You are a helpful AI assistant.
+
+## Behaviour
+
+- Be concise and accurate.
+- Reply in clear, plain language.
+- Ask for clarification when the request is ambiguous.
+
+## Constraints
+
+- Do not reveal confidential system information.
+- Decline requests that violate safety guidelines.
+- If you do not know something, say so honestly.
+
+## Tool Access
+
+Configure tool access by editing this file or enabling skills and MCP servers
+in `config/talond.yaml`.

--- a/starter/userdata/.gitignore
+++ b/starter/userdata/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in userdata/ except the documentation.
+# Files dropped here are user content — never commit by accident.
+*
+!.gitignore
+!README.md

--- a/starter/userdata/README.md
+++ b/starter/userdata/README.md
@@ -1,0 +1,48 @@
+# userdata/ — agent dropbox
+
+A convenience folder for files you want the agent to access. Bind-mounted
+into the container at `/userdata`.
+
+## How it works
+
+- The compose file bind-mounts this directory **read+write** into the
+  container at `/userdata`.
+- The agent reads/writes via the file tools of whatever provider you're
+  using (Claude's `Read`/`Edit`/`Bash`, Codex's equivalents, etc.).
+- This folder is the **convenient** place for user content — not a
+  security boundary. The agent's file tools can also reach the
+  container's other bind mounts (`/config`, `/personas`, `/data`) and
+  application files in `/opt/talond`. Provider processes also inherit
+  the container's environment variables. Treat the whole container as
+  the trust boundary, not this directory.
+- Don't put secrets here. `.env` is for secrets — the daemon reads it
+  but the agent has no special path to it (and shouldn't need one).
+
+## What to put here
+
+- Documents you want the agent to summarize, search, or quote (PDFs,
+  markdown, plain text).
+- Repos or working trees the agent should code in.
+- Output the agent should write back to you (drafts, reports, screenshots).
+
+## Examples
+
+Once the daemon is up, ask your bot something like:
+
+> Read everything in `/userdata/notes/` and write a summary to
+> `/userdata/summary.md`.
+
+The agent uses its built-in file tools — no extra configuration needed.
+
+## Permissions on Linux
+
+Bind mounts on Linux use the host UID/GID directly. The container's
+`talond` user is UID/GID 1000. If your host user isn't 1000, the agent
+may be unable to write here. Either:
+
+- Run as a host user with UID 1000 (the default for first-created users
+  on most distros), or
+- `chmod 0777 userdata/` (loose but works) or `chown 1000:1000 userdata/`.
+
+macOS and Windows users on Docker Desktop don't hit this — the
+file-sharing layer maps ownership automatically.


### PR DESCRIPTION
## Summary

Adds a no-clone, no-build distribution path for Talon. Users download a
small tarball from a GitHub release, run `./install.sh`, edit `.env` +
`config/talond.yaml`, and `docker compose up -d`. The daemon image is
published to `ghcr.io/ivo-toby/talond` as multi-arch.

Released as `v0.2.0` — https://github.com/ivo-toby/talon/releases/tag/v0.2.0

## What's in the box

- **`starter/`** — new top-level dir packaged as `talon-starter.tar.gz`:
  - `docker-compose.yaml` pinning the published GHCR image; bind mounts
    for `data/`, `config/talond.yaml`, `personas/`, and `userdata/`.
  - `bin/talonctl` — host-side wrapper that `docker exec`s into the
    daemon container; TTY-aware so pipes work; container name
    overridable via `TALOND_CONTAINER`.
  - `install.sh` — drops `talonctl` into `~/.local/bin`, pre-creates
    `data/` + `userdata/` to avoid root-owned bind-mount sources on Linux.
  - `userdata/` — bind-mounted at `/userdata` so users can drop files
    for the agent to read. `.gitignore` keeps user content out of git.
    README explicitly states it's a convenience folder, not a sandbox.
  - Minimal `.env.example`, `config/talond.example.yaml`, default
    `personas/assistant/system.md`, curated Claude Code skills
    (`talon-setup`, `add-*`, `create-*`, `manage-schedules`).
- **`.github/workflows/release.yaml`** — on `v*` tag: builds + pushes
  multi-arch image to GHCR, syncs allowlisted skills into the bundle,
  tars `starter/`, attaches `talon-starter.tar.gz` to the GitHub
  Release with a bounded inline body.
- **`scripts/sync-starter-skills.sh`** — keeps the bundle's skills in
  sync with source `.claude/skills/` via an allowlist file.
- **Source fixes uncovered during this work:**
  - `config/talond.example.yaml` — Telegram channel keys were wrong:
    `token`→`botToken`, numeric `allowedUserIds`→string `allowedChatIds`,
    `pollIntervalMs`→`pollingTimeoutSec`. Caused the first 404 hit.
  - `src/cli/index.ts` — `talonctl` now honors `$TALOND_CONFIG_PATH` as
    the default `--config` value. Lets the docker bundle work without
    callers passing `--config` everywhere.
- **`deploy/Dockerfile`** — userdel `node` user before creating `talond`
  at UID/GID 1000 (collides on `node:24-slim`); volume + healthcheck
  cleanups.

## Test plan

- [x] Multi-arch image builds on CI (linux/amd64+arm64, ~9m via QEMU)
- [x] Bundle tarball attaches to release, downloads work anonymously
- [x] End-to-end real-deal test: `curl`-download tarball, fresh `docker
      pull`, edit configs, boot, send a Telegram message, reply lands
- [x] `talonctl` wrapper handles TTY, pipes, missing container
- [x] `:latest` and `:v0.2.0` GHCR digests verified identical
- [x] Codex review clean on each commit (only `.minispec/` findings,
      out of scope)

## Follow-ups (tracked in Postgram)

- **v0.2.x**: bake `git`/`jq`/`curl`/`ca-certificates` into the Dockerfile
  (task `5b77008f`)
- **v0.3+**: docker-aware setup skills + expanded docs cookbook (task
  `8991ad7f` — current bundled `talon-setup` skill still assumes native
  install; needs a design conversation first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)