### PR TITLE
Bake git/curl/jq/ca-certificates into the daemon image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -39,10 +39,22 @@ LABEL org.opencontainers.image.title="talond" \
 # Always run in production mode
 ENV NODE_ENV=production
 
-# Install tini as a minimal init process so signals are forwarded correctly
-# and zombie processes are reaped.
+# Install runtime essentials:
+#   tini             — minimal init: forwards signals and reaps zombies
+#   git, curl, jq    — used by agents that need to shell out (clone repos,
+#                      fetch URLs, parse JSON output of tools). These are
+#                      tiny universal building blocks; specialized tools
+#                      (gh, atlassian-cli, …) are added via MCP servers
+#                      instead — see starter/docs/troubleshooting.md.
+#   ca-certificates  — TLS root store, required for HTTPS calls by the
+#                      provider runtime and any tool the agent runs.
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends tini && \
+    apt-get install -y --no-install-recommends \
+        tini \
+        git \
+        curl \
+        jq \
+        ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user/group with a fixed UID so host bind-mount

--- a/starter/README.md
+++ b/starter/README.md
@@ -11,6 +11,12 @@ Run [Talon](https://github.com/ivo-toby/talon) without cloning the source.
 - `bin/talonctl` — host-side wrapper for the in-container CLI
 - `.claude/skills/` — Claude Code skills that walk you through setup interactively
 
+The container image ships with `git`, `curl`, `jq`, and `ca-certificates`
+preinstalled alongside Node.js, so the agent can clone repos, fetch URLs,
+and parse JSON without you adding tools. More specialized integrations
+(GitHub, Atlassian, Gmail, Slack, …) come through MCP servers added via
+`talonctl add-mcp` — no image rebuild needed.
+
 ## Requirements
 
 - Docker (Engine on Linux, or Docker Desktop on macOS/Windows) with `docker compose`


### PR DESCRIPTION
## Summary

Adds three universal CLI tools and TLS roots to the production image so
agents can shell out for common operations (clone a repo, fetch a URL,
parse JSON) without the user rebuilding the image. Specialized tools
(gh, atlassian-cli, etc.) continue to come through MCP servers — these
four are just the universal building blocks.

Refs Postgram task `5b77008f-3bda-4276-9689-080aa41327b5` (deliverable B).

## What changed

- `deploy/Dockerfile` — single `apt-get install` line adds `git`,
  `curl`, `jq`, `ca-certificates` alongside the existing `tini`. Uses
  `--no-install-recommends` and cleans `/var/lib/apt/lists/*`.
- `starter/README.md` — new paragraph under "What you get" documents
  what's preinstalled, so users know without inspecting the Dockerfile.

## Image size

- Before: ~644 MB
- After: ~743 MB (+99 MB)

Larger than the ~30 MB I estimated when scoping the work — `git` pulls
in `perl` and `openssh-client` as dependencies. Still acceptable for a
self-hosted daemon image; tradeoff favors out-of-the-box capability over
ultra-lean.

## Test plan

- [x] Local `docker build -f deploy/Dockerfile .` succeeds
- [x] `tini`, `git`, `curl`, `jq` all execute as the unprivileged
      `talond` user (UID 1000) in the built image
- [x] `/etc/ssl/certs/ca-certificates.crt` present
- [x] Codex review clean on in-scope files
- [ ] CI: multi-arch build succeeds on linux/amd64+arm64 when tagged
- [ ] End-to-end: pull the new image, boot a starter bundle, agent can
      `git clone`, `curl`, `jq`

## After merge

Tag `v0.2.1` to publish. The release workflow will pick it up unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)