### PR TITLE
Docker-aware talon-setup skill + provider/troubleshooting docs

### DIFF
--- a/.claude/skills/talon-setup-docker/SKILL.md
+++ b/.claude/skills/talon-setup-docker/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: talon.setup.docker
+description: |
+  Use when setting up Talon from the starter bundle (docker-based install)
+  for the first time, adding channels or personas, changing the AI provider,
+  or troubleshooting. Triggers on phrases like "set up talon", "configure
+  talon", "add channel", "switch provider", "talonctl …".
+triggers:
+  - "set up talon"
+  - "setup talon"
+  - "configure talon"
+  - "talon setup"
+  - "add channel"
+  - "add persona"
+  - "switch provider"
+  - "change provider"
+  - "talon doctor"
+  - "talonctl"
+---
+
+# Talon setup — docker bundle
+
+Guide the user through configuring the Talon starter bundle. This is a
+conversational wizard — **one question at a time**, act on the answer,
+move on.
+
+## Core principles
+
+- **Docker-first.** The bundle ships a published image and a host-side
+  `talonctl` wrapper. Never run `npx talonctl`, `npm install`, or
+  `node dist/index.js`.
+- **`talonctl` requires the daemon to be running.** The wrapper is a
+  `docker exec` into the `talond` container. For first-time setup, the
+  user edits `.env` and `config/talond.yaml` manually, then boots the
+  daemon, then `talonctl` is available for everything else.
+- **One question at a time.** Never dump a wall of options.
+- **No secrets.** Never ask for or write actual tokens. Only show
+  `${ENV_VAR}` placeholders in `config/talond.yaml`. Real values go in
+  `.env`.
+- **Show output.** When you run a command, show what came back.
+
+## Detect state first
+
+Before asking anything, look at the bundle directory:
+
+```bash
+ls -la                                                              # bundle layout
+test -f .env && echo ".env present" || echo ".env missing"           # exists?
+grep -oE '^[A-Z][A-Z0-9_]*' .env 2>/dev/null | sort -u                # which env vars set? (names only)
+test -f config/talond.yaml && echo "yaml present" || echo "yaml missing"
+docker ps --filter name=talond --format '{{.Names}} {{.Status}}'    # daemon running?
+```
+
+**Never print secret values.**
+
+- `.env` contains real secrets — only inspect variable *names*, never
+  `cat .env`.
+- `config/talond.yaml` *should* only contain `${ENV_VAR}` placeholders,
+  but some users hand-paste literal keys. Don't `cat` it either. When
+  the daemon is running, use `talonctl config-show` (auto-masked). Until
+  then, inspect specific sections you need with `grep -A` for the keys
+  you're checking, and never display lines that match `apiKey:`,
+  `botToken:`, `password:`, `secret`, or `token:` patterns with a
+  literal value.
+
+If you need to *show* a config snippet to the user, use:
+
+```bash
+talonctl config-show 2>/dev/null         # post-boot, masked
+# OR pre-boot, redact inline:
+sed -E 's/^(  *(apiKey|botToken|.*[Tt]oken|.*[Ss]ecret|password): )(.+)$/\1***MASKED***/' config/talond.yaml
+```
+
+Use the state to skip steps:
+
+| State | Action |
+|-------|--------|
+| `.env` missing | Run `cp .env.example .env`, fill in step 2 |
+| `config/talond.yaml` missing | Run `cp config/talond.example.yaml config/talond.yaml`, edit in step 3 |
+| Daemon already running | Skip to talonctl-based additions (step 6) |
+| All configured + daemon running | Present the menu (see "Returning user menu") |
+
+### Returning user menu
+
+If everything is configured:
+
+```
+What would you like to do?
+  a) Switch AI provider
+  b) Add another channel (Telegram, Slack, …)
+  c) Add or modify a persona
+  d) Bind/unbind a persona to a channel
+  e) Manage scheduled tasks
+  f) Run health check (talonctl doctor)
+  g) Show current config (talonctl config-show)
+  h) View daemon logs (docker compose logs -f talond)
+  i) Restart the daemon
+```
+
+## Available talonctl commands (post-boot)
+
+All commands run via the bundle's `bin/talonctl` wrapper (or the
+installed `talonctl` if `./install.sh` has been run):
+
+| Command | Purpose |
+|---------|---------|
+| `talonctl status` | Daemon health, active runs, queue depth |
+| `talonctl doctor` | Validate config + environment |
+| `talonctl config-show` | Show current config (secrets masked) |
+| `talonctl env-check` | List env-var placeholders the config expects |
+| `talonctl list-channels` | Configured channels |
+| `talonctl add-channel --name <n> --type <t>` | Add a channel |
+| `talonctl remove-channel --name <n>` | Remove a channel |
+| `talonctl list-personas` | Configured personas |
+| `talonctl add-persona --name <n>` | Scaffold a persona dir + add to config |
+| `talonctl remove-persona --name <n>` | Remove a persona |
+| `talonctl bind --persona <p> --channel <c>` | Bind persona to channel |
+| `talonctl unbind --persona <p> --channel <c>` | Remove a binding |
+| `talonctl add-mcp --skill <s> --name <n> --transport stdio --command <c>` | Add an MCP server to a skill |
+| `talonctl list-providers` | Configured AI providers |
+| `talonctl add-provider --name <n> --command <c> [--context both]` | Add a provider |
+| `talonctl set-default-provider --name <n> --context <ctx>` | Set default provider |
+| `talonctl test-provider --name <n>` | Verify a provider connects |
+| `talonctl list-capabilities` | All available capability labels |
+| `talonctl set-capabilities --persona <p> --add <labels>` | Add capabilities |
+| `talonctl set-capabilities --persona <p> --remove <labels>` | Remove capabilities |
+| `talonctl list-schedules` | Configured scheduled tasks |
+| `talonctl add-schedule --persona <p> --channel <c> --cron <expr> --label <l> --prompt <text>` | Add a scheduled task |
+| `talonctl remove-schedule <id>` | Remove a scheduled task |
+
+Use these for all post-boot mutations. **Do not edit `config/talond.yaml`
+by hand** once the daemon is running — talonctl handles it correctly.
+
+## First-time setup flow
+
+### Step 1: Pick an AI provider
+
+Ask: **"Which AI provider do you want to use?"**
+
+```
+a) Claude (Anthropic API)            — default, smartest, costs $
+b) OpenAI-compatible endpoint        — local Ollama, vLLM, Groq, Together, custom
+c) Gemini CLI                        — Google's CLI, needs gemini binary in container (advanced)
+d) Codex CLI                         — OpenAI's CLI, same caveat as Gemini (advanced)
+```
+
+For (a) ask for nothing else here — defaults work.
+
+For (b) ask three things, **one at a time**:
+- "What's the base URL? (e.g. `https://api.groq.com/openai/v1`,
+  `http://host.docker.internal:11434/v1` for local Ollama, etc.)"
+- "What model name does the endpoint serve?
+  (e.g. `qwen3-coder:30b`, `llama-3.3-70b-versatile`)"
+- "Does the endpoint need an API key?" → if yes, ask the env var name
+  to use (default: `OPENAI_COMPATIBLE_API_KEY`)
+
+For (c)/(d), explain: "Gemini CLI and Codex CLI run *inside* the
+container. The starter image does not preinstall these binaries — you'd
+need to build a custom image. For most users, OpenAI-compatible (b)
+pointing at Google or OpenAI is simpler." Then offer to switch to (b).
+
+### Step 2: Configure `.env`
+
+If `.env` doesn't exist: `cp .env.example .env`
+
+Ask: **"Which channel do you want to connect first?"** Answer determines
+which env var the user needs to fill:
+
+| Channel | Env var(s) |
+|---------|-----------|
+| Telegram | `TELEGRAM_BOT_TOKEN` (from @BotFather) |
+| Slack | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET` |
+| Discord | `DISCORD_BOT_TOKEN` |
+| WhatsApp Business | `WHATSAPP_API_KEY` |
+| WhatsApp Baileys | (no env, uses QR-code auth at first boot) |
+| Email | IMAP/SMTP credentials (see add-email skill) |
+| Terminal | `TERMINAL_TOKEN` (just `talonctl chat`) |
+
+Plus the provider env from step 1 (e.g. `ANTHROPIC_API_KEY` for Claude).
+
+Tell the user **exactly** which lines to uncomment/fill in `.env`.
+Do not write the actual secrets to disk.
+
+### Step 3: Configure `config/talond.yaml`
+
+If `config/talond.yaml` doesn't exist:
+`cp config/talond.example.yaml config/talond.yaml`
+
+The default config uses Claude + Telegram. If the user picked something
+else in step 1, walk them through the edits:
+
+#### Edit the persona
+
+Find:
+```yaml
+personas:
+  - name: assistant
+    model: claude-sonnet-4-6
+    provider: claude-code
+```
+
+If provider is OpenAI-compatible:
+```yaml
+    model: <model from step 1>
+    provider: openai-compatible
+```
+
+If Gemini CLI:
+```yaml
+    model: gemini-2.5-pro
+    provider: gemini-cli
+```
+
+#### Replace the `agentRunner.providers` block
+
+For Claude (default), no change.
+
+For OpenAI-compatible — replace the `claude-code:` block under
+`agentRunner.providers:` with:
+
+```yaml
+    openai-compatible:
+      enabled: true
+      command: node
+      contextWindowTokens: 32000
+      options:
+        baseUrl: <base URL from step 1>
+        defaultModel: <model from step 1>
+        providerId: <a short slot name, e.g. "groq" or "ollama">
+        toolOutputCap: 4000
+```
+
+Apply the same change to `backgroundAgent.providers` (or set
+`backgroundAgent.enabled: false` if you don't need background work).
+
+#### Replace `auth.providers`
+
+For Claude, the default block is fine.
+
+For OpenAI-compatible:
+```yaml
+auth:
+  mode: api_key
+  providers:
+    <slot name from above>:
+      baseURL: <base URL from step 1>
+      # apiKey: ${YOUR_ENV_VAR}   # uncomment if the endpoint needs one
+```
+
+#### Set the channel's `allowedChatIds` / equivalent
+
+For Telegram, find the channels block and set the chat ID the bot is
+allowed to talk to (find your ID via [@userinfobot](https://t.me/userinfobot)):
+
+```yaml
+channels:
+  - type: telegram
+    name: personal-telegram
+    config:
+      botToken: ${TELEGRAM_BOT_TOKEN}
+      allowedChatIds:
+        - "<your-numeric-chat-id>"        # must be a string, not a number
+      pollingTimeoutSec: 30
+```
+
+For other channels, refer to the matching `add-*` skill.
+
+### Step 4: Boot the daemon
+
+```bash
+./install.sh                                  # ensures data/ + userdata/ exist + installs talonctl wrapper
+docker compose up -d                          # detached
+docker compose logs --tail=50 talond          # confirm clean boot — no -f, no head; just the last 50 lines
+```
+
+Look for `bootstrap: config loaded`, the channel connector starting,
+and `daemon: running`. If the daemon exits, the logs will say why
+(usually a config validation error).
+
+### Step 5: Verify
+
+```bash
+talonctl status                # health, queue depth, channels, personas
+talonctl doctor                # full validation
+talonctl list-channels         # confirms the channel is registered
+talonctl test-provider --name <provider-name>   # round-trips a request
+```
+
+Then ask the user to **send a real message** to the configured channel
+(Telegram DM, Slack message, etc.) and confirm a reply lands. Tail
+`docker compose logs -f talond` while they do.
+
+### Step 6: Optional additions
+
+Once boot is verified, anything else uses `talonctl`:
+
+- **Add another channel** — invoke the matching channel skill (`/add-slack`,
+  `/add-discord`, etc.) OR `talonctl add-channel` directly.
+- **Add another persona** — `talonctl add-persona --name <n>`, then edit
+  the generated `personas/<name>/system.md`.
+- **Bind persona ↔ channel** — `talonctl bind --persona <p> --channel <c>`.
+- **Adjust capabilities** — `talonctl set-capabilities --persona <p> --show`
+  to see current, then `--add` or `--remove`.
+- **Schedule tasks** — `talonctl add-schedule …` (see `/manage-schedules`).
+- **Add MCP servers** — `talonctl add-mcp …`. Pre-built MCP servers for
+  GitHub, Atlassian, Gmail, Slack, etc. are documented in
+  `starter/docs/troubleshooting.md` and the upstream MCP server registry.
+
+Each mutation modifies `config/talond.yaml`. The daemon **does not
+auto-reload** — after a mutation, tell the user to apply it:
+
+```bash
+talonctl reload          # hot-reload via IPC; works for most changes
+# or for changes that require a full restart:
+docker compose restart talond
+```
+
+After `add-channel` or `add-provider`, also run:
+```bash
+talonctl env-check       # confirm any new ${ENV_VAR} placeholders are set in .env
+talonctl test-provider --name <n>   # if a provider was added
+```
+
+## Rules
+
+1. **Never write actual secrets.** Only `${ENV_VAR}` placeholders in
+   `config/talond.yaml`. Real values are in `.env`, edited by the user.
+2. **Use `talonctl` for all post-boot mutations.** Exceptions: persona
+   `system.md` files (these are agent-facing prompts and benefit from
+   hand-editing) and `.env`.
+3. **One question per message.** Do not batch.
+4. **Show command output.** Let the user see what happened.
+5. **Don't start or stop the daemon** without telling the user. Boot
+   only after they've confirmed the config is ready. Use
+   `docker compose up -d` (detached) so logs don't block their terminal.
+6. **Always validate.** After meaningful changes, run `talonctl doctor`
+   and `talonctl env-check`. After provider changes, run
+   `talonctl test-provider`.
+7. **Tell users when something is broken or unsupported.** Some channel
+   skills (add-telegram, add-slack, …) were lifted from the native-install
+   workflow and still reference `npx talonctl`; treat their guidance as
+   *informational* and execute the equivalent via the docker wrapper.
+
+## Differences from `talon-setup` (native)
+
+This skill replaces the native-install `talon-setup` skill for users of
+the docker starter bundle. Key differences:
+
+- No prereq check for `node_modules/`, `dist/`, or local `node --version`
+  — the image ships everything.
+- No `npx talonctl setup` or `talonctl migrate` step — the daemon
+  bootstraps + migrates on first boot.
+- Provider menu lists OpenAI-compatible as a first-class option.
+- Service install via systemd is skipped — `docker compose up -d`
+  + `restart: unless-stopped` is the equivalent.
+- Daemon start is `docker compose up -d`, never `node dist/index.js`.

--- a/starter/.claude/skills/INCLUDED.txt
+++ b/starter/.claude/skills/INCLUDED.txt
@@ -3,7 +3,11 @@
 # The source is `.claude/skills/<name>/` at the repo root.
 # Run scripts/sync-starter-skills.sh to populate starter/.claude/skills/.
 
-talon-setup
+# Top-level guided flow — docker-aware variant.
+# (The native-install `talon-setup` is intentionally NOT shipped — it
+# assumes `npx talonctl`, node_modules/, etc. and would mislead bundle
+# users.)
+talon-setup-docker
 
 add-telegram
 add-slack

--- a/starter/README.md
+++ b/starter/README.md
@@ -52,13 +52,15 @@ claude
 
 Then in Claude Code:
 
-- `/talon-setup` — top-level guided setup
+- `/talon-setup-docker` — top-level guided setup (docker-aware)
 - `/add-telegram`, `/add-slack`, `/add-discord`, `/add-whatsapp`, `/add-email`, `/add-terminal` — add channels
 - `/create-profile` — create a new persona
 - `/create-personality` — customize a persona's voice and tone
 - `/manage-schedules` — set up scheduled agent runs
 
-The skills edit your `.env`, `config/talond.yaml`, and `personas/` for you.
+The skills walk you through editing `.env` and `config/talond.yaml`
+manually for first-time setup, then drive `talonctl` for follow-on
+changes (add another channel, swap providers, etc.).
 
 ## Configuration
 
@@ -101,6 +103,15 @@ cp ~/Documents/quarterly-report.pdf userdata/notes/
 The agent can also write artifacts back here — useful for drafts,
 reports, generated code. See [`userdata/README.md`](userdata/README.md)
 inside the bundle for permission notes (Linux UID/GID 1000).
+
+## Documentation
+
+The `docs/` folder in this bundle has deeper guides:
+
+| File | What's in it |
+| --- | --- |
+| [`docs/providers.md`](docs/providers.md) | Full config snippets for Claude, OpenAI-compatible, Gemini CLI, Codex CLI |
+| [`docs/troubleshooting.md`](docs/troubleshooting.md) | Common issues — Telegram errors, permission problems, provider connectivity, MCP server setup |
 
 ## Common operations
 

--- a/starter/docs/providers.md
+++ b/starter/docs/providers.md
@@ -1,0 +1,255 @@
+# Provider cookbook
+
+Talon supports four AI provider strategies. This file shows the YAML
+snippet for each, plus the matching `.env` entries. The starter ships
+configured for Claude — pick whichever provider you actually want, edit
+`config/talond.yaml`, and restart with `docker compose restart talond`.
+
+For complete schema reference, see
+[`config/talond.example.yaml`](https://github.com/ivo-toby/talon/blob/main/config/talond.example.yaml)
+in the source repo.
+
+---
+
+## Claude (Anthropic API)
+
+**Default in the starter.** Smartest, most capable, costs the most per
+token. Good first choice if you have an Anthropic API key.
+
+### `config/talond.yaml`
+
+```yaml
+personas:
+  - name: assistant
+    model: claude-sonnet-4-6        # or claude-opus-4-7, claude-haiku-4-5
+    provider: claude-code
+
+agentRunner:
+  defaultProvider: claude-code
+  providers:
+    claude-code:
+      enabled: true
+      command: claude
+      contextWindowTokens: 200000
+
+auth:
+  mode: api_key
+  providers:
+    anthropic:
+      apiKey: ${ANTHROPIC_API_KEY}
+```
+
+### `.env`
+
+```ini
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+### Notes
+
+- `claude-code` is Talon's wrapper around the
+  [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python).
+  The image ships with it preinstalled.
+- For Claude Max subscription auth (no API key), set `auth.mode: subscription`
+  and bind-mount `~/.claude` from the host into the container. Edit
+  `docker-compose.yaml` and add `~/.claude:/home/talond/.claude:ro` under
+  `volumes`.
+
+---
+
+## OpenAI-compatible endpoint
+
+The most flexible provider. Works with:
+
+- **Local Ollama** (`http://host.docker.internal:11434/v1`)
+- **Local vLLM / llama.cpp / LM Studio** (any OpenAI-compatible server)
+- **Groq, Together, Fireworks, OpenAI itself** (hosted endpoints)
+- **OpenAI-compatible CDN endpoints** (Cloudflare, custom proxies)
+
+### `config/talond.yaml`
+
+```yaml
+personas:
+  - name: assistant
+    model: <whatever the endpoint serves>      # e.g. "llama-3.3-70b-versatile", "qwen3-coder:30b"
+    provider: openai-compatible
+
+agentRunner:
+  defaultProvider: openai-compatible
+  providers:
+    openai-compatible:
+      enabled: true
+      command: node                            # in-process; "node" is just a placeholder
+      contextWindowTokens: 32000               # adjust to the model's actual window
+      options:
+        baseUrl: https://api.groq.com/openai/v1
+        defaultModel: llama-3.3-70b-versatile
+        providerId: groq                       # short slot name — pick anything
+        toolOutputCap: 4000
+
+backgroundAgent:
+  enabled: false                               # or mirror the above
+
+auth:
+  mode: api_key
+  providers:
+    groq:                                      # matches providerId above
+      baseURL: https://api.groq.com/openai/v1
+      apiKey: ${GROQ_API_KEY}                  # omit if endpoint needs no key
+```
+
+### `.env`
+
+```ini
+GROQ_API_KEY=gsk_...                           # name matches whatever you used above
+```
+
+### Notes
+
+- `providerId` (under `options:`) and the slot under `auth.providers:`
+  must match. Talon resolves credentials by looking up
+  `auth.providers.<providerId>`.
+- `toolOutputCap` caps a single tool result's size before it enters the
+  agent's message history. Recommended for small-window models. Set to
+  `0` to disable.
+- For local Ollama on macOS Docker Desktop, use
+  `http://host.docker.internal:11434/v1` (the special Docker DNS name).
+  On Linux you may need `--network host` or `--add-host` instead.
+- No API key is needed for local Ollama / vLLM / llama.cpp — omit
+  `apiKey` in the `auth.providers.<slot>` block.
+
+---
+
+## Gemini CLI
+
+Google's [Gemini CLI](https://github.com/google-gemini/gemini-cli). Runs
+as a subprocess inside the container, so the `gemini` binary must be on
+the container's PATH.
+
+### Caveat: not preinstalled
+
+The starter image does **not** ship the `gemini` binary. To use this
+provider you need a custom image. The simplest path is a small
+Dockerfile that extends the upstream image:
+
+```dockerfile
+FROM ghcr.io/ivo-toby/talond:latest
+USER root
+RUN npm install -g @google/gemini-cli@latest && \
+    chown -R talond:talond /usr/local/lib/node_modules
+USER talond
+```
+
+Build + tag locally, then point `docker-compose.yaml` at it:
+`image: my-talond-gemini:latest`.
+
+For most users, accessing Gemini through the **OpenAI-compatible**
+provider (above) pointing at Google's OpenAI-compatible endpoint is
+simpler and doesn't need a custom image.
+
+### `config/talond.yaml`
+
+```yaml
+personas:
+  - name: assistant
+    model: gemini-2.5-pro
+    provider: gemini-cli
+
+agentRunner:
+  defaultProvider: gemini-cli
+  providers:
+    gemini-cli:
+      enabled: true
+      command: gemini
+      contextWindowTokens: 1000000
+      options:
+        defaultModel: gemini-2.5-pro
+```
+
+### `.env`
+
+```ini
+GOOGLE_AI_API_KEY=...                          # or rely on interactive OAuth (more setup)
+```
+
+---
+
+## Codex CLI
+
+OpenAI's [Codex CLI](https://github.com/openai/codex). Same model as
+Gemini CLI — runs as a subprocess, needs the binary on PATH.
+
+### Caveat: not preinstalled
+
+Same as Gemini. Custom image required:
+
+```dockerfile
+FROM ghcr.io/ivo-toby/talond:latest
+USER root
+RUN npm install -g @openai/codex@latest && \
+    chown -R talond:talond /usr/local/lib/node_modules
+USER talond
+```
+
+### `config/talond.yaml`
+
+```yaml
+personas:
+  - name: assistant
+    model: gpt-5.4
+    provider: codex-cli
+
+agentRunner:
+  defaultProvider: codex-cli
+  providers:
+    codex-cli:
+      enabled: true
+      command: codex
+      contextWindowTokens: 1048576
+      options:
+        defaultModel: gpt-5.4
+```
+
+### `.env`
+
+```ini
+OPENAI_API_KEY=sk-...
+```
+
+---
+
+## Switching providers without redeploying
+
+Once the daemon is running, you can swap providers via `talonctl`. The
+exact flag set depends on the provider — for OpenAI-compatible, the
+required options aren't all exposed as flags on `add-provider` today,
+so the cleanest path is:
+
+1. Edit `agentRunner.providers.<name>` in `config/talond.yaml` directly
+   (use the snippets above as a template).
+2. Edit `auth.providers.<slot>` in the same file.
+3. Reload:
+   ```bash
+   talonctl reload
+   talonctl test-provider --name openai-compatible
+   ```
+
+For providers that *are* fully covered by `add-provider` flags (Claude,
+Gemini CLI, Codex CLI with the binary preinstalled in a custom image):
+
+```bash
+talonctl list-providers
+talonctl add-provider --name claude-code \
+  --command claude --context both \
+  --context-window 200000 --enabled
+talonctl set-default-provider --name claude-code --context agent-runner
+talonctl set-default-provider --name claude-code --context background
+talonctl env-check                           # confirm $ANTHROPIC_API_KEY is set
+talonctl test-provider --name claude-code    # real round-trip
+```
+
+`--enabled` is important — `add-provider` writes the entry as disabled
+unless you opt in.
+
+After any provider change, `talonctl reload` applies it without a
+container restart.

--- a/starter/docs/troubleshooting.md
+++ b/starter/docs/troubleshooting.md
@@ -1,0 +1,238 @@
+# Troubleshooting
+
+Common issues hit during real Talon installations. The bundle README's
+"Troubleshooting" section is the short list; this file is the long one.
+
+If you find something not covered here, please open an issue at
+[github.com/ivo-toby/talon/issues](https://github.com/ivo-toby/talon/issues).
+
+---
+
+## Container won't start
+
+### `docker compose up` exits immediately
+
+`docker compose logs talond` will show the error. Common causes:
+
+- **Config validation error.** The schema is strict — typos in YAML keys
+  cause the daemon to refuse to start. Run with the bundled example
+  config first to confirm the image is fine, then bisect your edits.
+- **`/config/talond.yaml` not bind-mounted.** Check
+  `docker-compose.yaml` — the bind source `./config/talond.yaml` must
+  exist on the host. `cp config/talond.example.yaml config/talond.yaml`
+  before `docker compose up`.
+- **`personas/<name>/system.md` missing.** If your persona's
+  `systemPromptFile` points at a path that doesn't exist on the host,
+  the daemon refuses to load. The starter ships
+  `personas/assistant/system.md`; if you add personas, make sure their
+  system prompt files exist.
+
+### Healthcheck reports `unhealthy`
+
+The healthcheck looks for `/data/talond.pid` and tests that the PID is
+alive. Causes:
+
+- **Daemon failed to write the PID file.** Usually a permission issue on
+  `/data` — the container runs as UID 1000. On Linux, `chown 1000:1000
+  data/` on the host.
+- **Daemon crashed.** `docker compose logs talond` will show why. Common
+  trigger: a sub-agent referenced by a persona doesn't have its required
+  env var (e.g. `OPENAI_API_KEY` for the `spark-coder` sub-agent).
+
+---
+
+## Telegram
+
+### `Telegram getUpdates failed (404): Not Found`
+
+Your `botToken` is wrong, empty, or never reached the container.
+
+Verify the token directly:
+```bash
+curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe"
+```
+
+`{"ok":true,...}` means the token is good. If you get 404, the token
+itself is bad. If `getMe` works but the daemon still 404s, check:
+
+- `.env` actually contains `TELEGRAM_BOT_TOKEN=...` (no quotes, no
+  trailing spaces)
+- `docker-compose.yaml` has `env_file: .env`
+- Restart the container after editing `.env`:
+  `docker compose restart talond` (env vars are only read at boot)
+
+### `Telegram getUpdates conflict (409)`
+
+Another process is polling the same bot. Telegram allows exactly one
+poller per bot. Either:
+
+- Stop the other process (e.g. another talond instance on a VM)
+- Use a different bot token for this instance — create a second bot via
+  @BotFather
+
+### Bot replies to me but I never sent a message
+
+Your `allowedChatIds` is empty or wrong, so messages from your account
+are being filtered out, but messages from `/start`-like Telegram
+mechanics still reach the bot. Confirm:
+
+```bash
+talonctl config-show | grep -A4 allowedChatIds
+```
+
+`allowedChatIds` must be an array of **strings**, not numbers. Get your
+Telegram user ID via [@userinfobot](https://t.me/userinfobot).
+
+### `Telegram sendMessage failed (400/404)`
+
+Most often:
+
+- **400** — `parse_mode: MarkdownV2` rejected because the response
+  contains an unescaped special character. Known issue with some
+  models. Workarounds: edit the persona's system prompt to discourage
+  markdown, or open an issue.
+- **404** — the chat ID being sent to is wrong. The starter normally
+  uses the inbound chat's ID for the outbound, so this is rare. If you
+  see it, check `runs.error` in the SQLite DB:
+  ```bash
+  docker exec talond sh -c "sqlite3 /data/talond.sqlite \
+    'SELECT id, error FROM runs WHERE status=\"failed\" ORDER BY created_at DESC LIMIT 5;'"
+  ```
+
+---
+
+## Providers
+
+### `Cannot find module '/opt/talond/dist/index.js'`
+
+Image is from a different (or broken) build. Pull the latest:
+```bash
+docker compose pull
+docker compose up -d
+```
+
+### `OpenAI-compatible provider requires options.baseUrl, or auth.providers.<options.providerId>.baseURL`
+
+Your provider config is missing the base URL. See
+[`providers.md`](providers.md) for the correct structure.
+
+### Provider response times out
+
+- Increase `contextWindowTokens` if model's actual window is larger than
+  the configured limit (Talon caps history at the configured window).
+- Increase the agent's timeout: most providers don't expose this in the
+  starter config; for very slow local models, comment out
+  `backgroundAgent` (timeouts there cascade to the foreground).
+- Check the model is actually returning — `curl` the endpoint directly:
+  ```bash
+  curl -sS https://your-endpoint/v1/chat/completions \
+    -H "Authorization: Bearer $YOUR_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"your-model","messages":[{"role":"user","content":"hi"}]}'
+  ```
+
+### Two messages in a row — second one dead-letters
+
+Symptom: first message replies fine, second one fails with no
+`agent-runner: query completed` log. Check the queue:
+
+```bash
+docker exec talond sh -c "sqlite3 /data/talond.sqlite \
+  'SELECT id,status,attempts,error FROM queue_items ORDER BY created_at DESC LIMIT 5;'"
+```
+
+`status: dead_letter` with `error: ... sendMessage ... (404)` is a known
+artifact of `parse_mode: MarkdownV2`. The agent's response contained an
+unescaped character that Telegram rejected. The pipeline retries 3
+times then dead-letters. Subsequent messages should work — the queue
+is per-thread but doesn't block on dead-letters.
+
+---
+
+## Permissions (Linux)
+
+### `Permission denied` writing to `data/` or `userdata/`
+
+Container runs as UID/GID 1000. If your host user isn't 1000, the
+container can't write to bind-mounted host directories.
+
+Fix once:
+```bash
+chown -R 1000:1000 data/ userdata/
+```
+
+Or loosen:
+```bash
+chmod 0777 data/ userdata/
+```
+
+macOS and Windows on Docker Desktop don't hit this — Docker Desktop's
+file-sharing layer maps ownership transparently.
+
+---
+
+## Talonctl wrapper
+
+### `talonctl: container 'talond' not found`
+
+The daemon isn't running yet. `docker compose up -d` first.
+
+### `talonctl: container 'talond' is exited, not running`
+
+Container crashed or was stopped. `docker compose logs talond` for the
+reason; `docker compose up -d` to restart.
+
+### Pipes don't work — `talonctl list-channels | jq` shows nothing
+
+The wrapper should handle this; if it doesn't, you're on an older
+bundle. Reinstall with `./install.sh` from the current bundle, or use
+the full form: `docker exec talond node /opt/talond/dist/cli/index.js list-channels | jq`.
+
+---
+
+## MCP servers
+
+### Adding common MCP servers
+
+The bundle preinstalls `git`, `curl`, `jq`, and `ca-certificates` for
+general agent use. Specialized integrations come through MCP servers.
+Add them via `talonctl add-mcp`:
+
+`--args` is variadic — pass each argv token as a separate value, no
+shell-quoted bundle (Commander does not split a single quoted string):
+
+```bash
+# GitHub (issues, PRs, repos)
+talonctl add-mcp --skill <skill-name> --name github \
+  --transport stdio --command npx \
+  --args -y @modelcontextprotocol/server-github
+
+# Filesystem (within /userdata)
+talonctl add-mcp --skill <skill-name> --name filesystem \
+  --transport stdio --command npx \
+  --args -y @modelcontextprotocol/server-filesystem /userdata
+
+# PostgreSQL — use environment variable for the connection string
+talonctl add-mcp --skill <skill-name> --name postgres \
+  --transport stdio --command npx \
+  --args -y @modelcontextprotocol/server-postgres '${POSTGRES_DSN}'
+```
+
+Then grant the persona access:
+```bash
+talonctl set-capabilities --persona assistant --add "mcp.github:*"
+```
+
+Most popular MCP servers are listed at
+[modelcontextprotocol.io/servers](https://modelcontextprotocol.io/servers).
+
+---
+
+## Where to dig deeper
+
+- `docker compose logs -f talond` — live daemon logs
+- `talonctl doctor` — config + environment validation
+- `talonctl env-check` — list env-var placeholders the config expects
+- `talonctl config-show` — effective config (secrets masked)
+- SQLite shell inside the container — for queue, runs, messages
+  inspection: `docker exec -it talond sh -c "sqlite3 /data/talond.sqlite"`


### PR DESCRIPTION
## Summary

Adds a `talon-setup-docker` skill that actually works for the starter
bundle (the native-install `talon-setup` was lifted verbatim and assumed
`npx talonctl`, `node_modules/`, `dist/`, none of which exist for bundle
users). Also adds two new docs files — provider cookbook and
troubleshooting — and links them from the bundle README.

Refs Postgram task `8991ad7f-cdc2-404a-8604-7f0f268619de` (covers
workstream 1: setup skill, and workstream 3: expanded docs — partial).
Workstream 2 (cross-agent recipe generator) is still deferred for the
design conversation.

## What changed

### New: `.claude/skills/talon-setup-docker/SKILL.md`

The docker-aware setup wizard. Key differences from the native skill:

- Uses the bundled `talonctl` `docker exec` wrapper. No `npx`, no
  local node tooling.
- Lists OpenAI-compatible as a first-class provider option (in addition
  to Claude, Gemini CLI, Codex CLI). The native skill only mentions
  Claude + Gemini.
- Walks first-time users through manual `.env` + `config/talond.yaml`
  edits, then transitions to `talonctl`-based mutations once the daemon
  is running.
- Explicitly avoids leaking secrets: never `cat .env`, never unredacted
  `cat config/talond.yaml`. Provides an inline `sed` redaction snippet
  for pre-boot inspection.
- Tells users to run `talonctl reload` after config mutations — the
  daemon does not auto-reload from yaml edits.
- Uses `docker compose logs --tail=50` instead of `-f | head`, which
  would hang if fewer than 50 lines were emitted.

### Bundle: `starter/.claude/skills/INCLUDED.txt`

Swaps `talon-setup` → `talon-setup-docker`. The native variant remains
in source for repo-clone users; only the docker variant ships in the
tarball.

### New: `starter/docs/providers.md`

Full provider cookbook with config snippets and `.env` entries for:

- Claude (default, with notes on api_key vs subscription auth)
- OpenAI-compatible (Ollama, vLLM, Groq, Together, llama.cpp,
  Cloudflare/custom proxies, etc.) — with `providerId`/auth-slot
  matching explained
- Gemini CLI (with custom-image instructions since gemini isn't
  preinstalled)
- Codex CLI (same caveat)

Plus a "Switching providers without redeploying" section showing the
`talonctl reload` flow and noting that openai-compatible isn't fully
covered by `add-provider` flags yet.

### New: `starter/docs/troubleshooting.md`

Long-form troubleshooting for issues hit during real installs:

- Container won't start (config validation, missing bind mounts,
  healthcheck unhealthy)
- Telegram errors (404 getUpdates, 409 conflict, 400/404 sendMessage)
- Providers (module-not-found, missing baseUrl, dead-letter on
  MarkdownV2 escape errors)
- Linux UID/GID 1000 permission issues
- Talonctl wrapper edge cases (container not running, pipe handling)
- MCP server setup with correct variadic `--args` syntax (Commander
  doesn't split a single quoted string — must pass each argv token
  separately)

### Updated: `starter/README.md`

- Guided-setup section points at `/talon-setup-docker`
- New "Documentation" section linking to both docs files

## Test plan

- [x] `scripts/sync-starter-skills.sh --check` passes
- [x] `scripts/sync-starter-skills.sh` syncs all 10 skills (replaces
      old talon-setup in the bundle with talon-setup-docker)
- [x] Codex review clean on all in-scope files (4 review passes; final
      pass only `.minispec/` findings, all out of scope)
- [ ] After merge + next tagged release, dogfood `/talon-setup-docker`
      against a fresh extraction to confirm the wizard works as
      documented

## Not yet covered (for a future PR)

- Channel-specific skills (`add-telegram`, `add-slack`, …) still
  reference `npx talonctl` in their bodies. The new `talon-setup-docker`
  flags this and tells users to treat that guidance as informational.
  Audit + rewrite is its own piece of work.
- Cross-agent format generation (Claude Code + Codex CLI + AGENTS.md
  from a single canonical recipe source) — needs the design conversation
  with @ivo-toby first.
- Other cookbook entries (channel-cookbook.md, mcp-cookbook.md,
  security.md, upgrades.md, backup-restore.md) — not blocking this PR.

## Note on push auth

This branch was pushed via HTTPS (gh token) because the SSH agent
dropped its keys between sessions; the push URL has been restored to
SSH afterward. No remote config changes persist beyond what was here
before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)