### PR TITLE
docs(readme): Docker quick start front and center

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,43 @@ It is built for single-user or small-team deployments where you want persistent,
 
 ---
 
+## Quick start (Docker)
+
+The fastest way to run Talon — no clone, no build, no toolchain. Download
+the starter bundle, add your tokens, and bring it up:
+
+```bash
+# 1. Download and extract the starter bundle
+curl -fsSL https://github.com/ivo-toby/talon/releases/latest/download/talon-starter.tar.gz | tar xz
+cd talon-starter
+
+# 2. Install the talonctl helper (no sudo)
+./install.sh
+
+# 3. Configure
+cp .env.example .env                              # add your bot token + provider key
+cp config/talond.example.yaml config/talond.yaml  # set allowedChatIds, pick a provider
+
+# 4. Run
+docker compose up -d
+talonctl status
+```
+
+The daemon image is published to `ghcr.io/ivo-toby/talond` — multi-arch
+(linux/amd64 + linux/arm64), `:latest` plus per-release tags. The compose
+file pulls it for you; there is nothing to build.
+
+**Guided setup with Claude Code.** The bundle ships a setup skill — run
+`claude` in the extracted folder and type `/talon-setup-docker` to be
+walked through provider choice, channel config, and first boot
+conversationally.
+
+Full bundle reference: [`starter/README.md`](starter/README.md). Prefer
+running from a source clone as a systemd service? See
+[Quick start (from source)](#quick-start-from-source).
+
+---
+
 ## Features
 
 ### Channels
@@ -242,7 +279,11 @@ sequenceDiagram
 
 ---
 
-## Quick start
+## Quick start (from source)
+
+Run Talon from a clone — the path for native/systemd deployments and
+local development. For the zero-build container path, see
+[Quick start (Docker)](#quick-start-docker) above.
 
 For the full deployment walkthrough, see the [setup guide](docs/setup-guide.md).
 
@@ -1945,7 +1986,32 @@ The service includes security hardening: `NoNewPrivileges`, `PrivateTmp`, `Prote
 
 ### 2. Containerized Daemon (Docker)
 
-> **Coming soon** — Docker deployment is under active development. The goal is to run provider runtimes inside Docker containers for blast-radius isolation against prompt injection from untrusted input (repos, emails, messages). The host-mode path will remain as fallback. Dockerfiles and Compose config exist in `deploy/` and will be updated for the current architecture.
+The zero-build path — a published multi-arch image plus a starter bundle
+of config templates, a `talonctl` wrapper, and guided setup skills.
+
+```bash
+curl -fsSL https://github.com/ivo-toby/talon/releases/latest/download/talon-starter.tar.gz | tar xz
+cd talon-starter
+./install.sh
+cp .env.example .env                              # fill in secrets
+cp config/talond.example.yaml config/talond.yaml  # edit for your setup
+docker compose up -d
+```
+
+The image is published at `ghcr.io/ivo-toby/talond` (`:latest` and
+per-release tags, linux/amd64 + linux/arm64). The bundle bind-mounts
+`config/`, `personas/`, `data/`, and `userdata/` so you edit everything
+from the host. See [`starter/README.md`](starter/README.md) for the full
+walkthrough, [`starter/docs/providers.md`](starter/docs/providers.md) for
+provider configuration, and
+[`starter/docs/troubleshooting.md`](starter/docs/troubleshooting.md) when
+something misbehaves.
+
+To build the image yourself instead of pulling the published one:
+
+```bash
+docker build -f deploy/Dockerfile -t talond .
+```
 
 ### 3. Wake-Only Mode (Timer)
 


### PR DESCRIPTION
## Summary

The repo README never documented the Docker path — it still had a
"Coming soon" placeholder in the Deployment section — even though the
starter bundle and published image have shipped since v0.2.0. This makes
the easiest way to run Talon front-and-centre.

## Changes

- **New "Quick start (Docker)" section** near the top of the README,
  right after "Why Talon?" and before "Features". A reader now sees the
  zero-build path first: download the starter bundle, `./install.sh`,
  copy the two config templates, `docker compose up -d`. Mentions the
  published `ghcr.io/ivo-toby/talond` image and the `/talon-setup-docker`
  guided skill.
- **Renamed the existing "Quick start" → "Quick start (from source)"**
  and cross-linked the two, so the native/systemd/dev path is still
  easy to find. No internal anchors pointed at `#quick-start`, so
  nothing breaks.
- **Replaced the stale "Coming soon"** in `## Deployment` → `### 2.
  Containerized Daemon (Docker)` with real instructions: the GHCR image,
  the starter bundle flow, links to `starter/README.md`,
  `starter/docs/providers.md`, `starter/docs/troubleshooting.md`, and a
  `docker build` snippet for building locally.

## Not changed

The "agent sandboxing in Docker is coming soon" note in the Security
Model section is **left as-is** — that's the Sprites execution-env
feature (wrapping individual agent runs in throwaway containers), a
different track from daemon containerization. Flagging it here in case
you want it revisited separately.

## Test plan

- [x] `grep '^## '` confirms heading structure: "Quick start (Docker)"
      at the top, "Quick start (from source)" later
- [x] Cross-link anchors resolve (`#quick-start-docker`,
      `#quick-start-from-source`)
- [x] No remaining "Coming soon" for daemon Docker deployment
- [x] Codex review clean on README (only `.minispec/` findings, out of
      scope)
- [ ] Rendered-markdown eyeball on GitHub after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)