### PR TITLE
Bake codex + gemini CLIs into the image; fix claude/codex container paths

### DIFF
--- a/.claude/skills/talon-setup-docker/SKILL.md
+++ b/.claude/skills/talon-setup-docker/SKILL.md
@@ -140,9 +140,13 @@ Ask: **"Which AI provider do you want to use?"**
 ```
 a) Claude (Anthropic API)            — default, smartest, costs $
 b) OpenAI-compatible endpoint        — local Ollama, vLLM, Groq, Together, custom
-c) Gemini CLI                        — Google's CLI, needs gemini binary in container (advanced)
-d) Codex CLI                         — OpenAI's CLI, same caveat as Gemini (advanced)
+c) Gemini CLI                        — Google's CLI, preinstalled in the image
+d) Codex CLI                         — OpenAI's CLI, preinstalled in the image
 ```
+
+All four work out of the box. `claude` (bundled in the Agent SDK),
+`codex`, and `gemini` ship in the container image; `openai-compatible`
+runs in-process.
 
 For (a) ask for nothing else here — defaults work.
 
@@ -154,10 +158,11 @@ For (b) ask three things, **one at a time**:
 - "Does the endpoint need an API key?" → if yes, ask the env var name
   to use (default: `OPENAI_COMPATIBLE_API_KEY`)
 
-For (c)/(d), explain: "Gemini CLI and Codex CLI run *inside* the
-container. The starter image does not preinstall these binaries — you'd
-need to build a custom image. For most users, OpenAI-compatible (b)
-pointing at Google or OpenAI is simpler." Then offer to switch to (b).
+For (c)/(d), note one caveat: Gemini CLI and Codex CLI store auth/config
+under `~/.gemini` / `~/.codex` inside the container, which is wiped on
+container recreation. Recommend API-key auth (`GOOGLE_AI_API_KEY` /
+`OPENAI_API_KEY` in `.env`, read fresh each run). OAuth state needs a
+`/home/talond` bind-mount to persist — see `docs/providers.md`.
 
 ### Step 2: Configure `.env`
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -60,10 +60,16 @@ RUN apt-get update -qq && \
 # Create a non-root user/group with a fixed UID so host bind-mount
 # permissions are predictable. node:slim ships with a `node` user at
 # UID/GID 1000 already, so remove it first to free the slot.
+#
+# The user gets a real home directory (/home/talond): the codex and
+# gemini CLIs write config/auth under ~/.codex and ~/.gemini and crash
+# without a writable home. OAuth state stored there does NOT survive
+# container recreation — use API-key auth, or bind-mount /home/talond,
+# if you need it to persist.
 RUN userdel node && \
     (getent group node >/dev/null && groupdel node || true) && \
     groupadd --gid 1000 talond && \
-    useradd --uid 1000 --gid talond --no-create-home --shell /usr/sbin/nologin talond
+    useradd --uid 1000 --gid talond --create-home --shell /usr/sbin/nologin talond
 
 # Application directory
 WORKDIR /opt/talond
@@ -75,6 +81,14 @@ COPY --from=builder /build/dist ./dist/
 # We reinstall with --omit=dev so we don't carry devDependencies.
 COPY --from=builder /build/package.json /build/package-lock.json ./
 RUN npm ci --omit=dev
+
+# Install the CLI-based agent providers globally so the `codex-cli` and
+# `gemini-cli` provider strategies work out of the box (their config
+# `command:` resolves `codex` / `gemini` from PATH). The `claude-code`
+# provider needs nothing here — the Claude Code CLI ships bundled inside
+# the `@anthropic-ai/claude-agent-sdk` npm dependency.
+RUN npm install -g @openai/codex @google/gemini-cli && \
+    npm cache clean --force
 
 # Copy the example config so the image is self-documenting
 COPY config/talond.example.yaml ./config/

--- a/src/providers/claude-code-provider.ts
+++ b/src/providers/claude-code-provider.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { err, ok, type Result } from 'neverthrow';
 import { BackgroundAgentError } from '../core/errors/error-types.js';
 import type { AgentProvider, AgentRunInput, AgentStreamEvent } from './provider.js';
@@ -20,6 +21,41 @@ export class ClaudeCodeProvider implements AgentProvider {
   readonly skillLoaderTransport = 'in-process' as const;
 
   constructor(private readonly config: ProviderConfig) {}
+
+  /**
+   * Resolve the executable for background (subprocess) invocations.
+   *
+   * Foreground turns run through the Agent SDK in-process, but background
+   * runs spawn the Claude Code CLI as a subprocess.
+   *
+   * An explicitly configured `command` (anything other than the default
+   * bare `claude`) is honored verbatim — an operator who set a specific
+   * path or wrapper did so deliberately.
+   *
+   * For the default `claude`, we resolve the CLI bundled inside the
+   * `@anthropic-ai/claude-agent-sdk` package (`cli.js`) and spawn it via
+   * node. That makes background runs work without a `claude` binary on
+   * PATH (e.g. inside the docker image, where only the SDK dependency is
+   * present) and keeps the CLI version matched to the SDK the foreground
+   * path uses. Falls back to bare `claude` if the SDK layout changes.
+   */
+  private resolveBackgroundCommand(): { command: string; prefixArgs: string[] } {
+    if (this.config.command !== 'claude') {
+      return { command: this.config.command, prefixArgs: [] };
+    }
+    try {
+      const require = createRequire(import.meta.url);
+      const sdkDir = dirname(require.resolve('@anthropic-ai/claude-agent-sdk'));
+      const cliJs = join(sdkDir, 'cli.js');
+      if (existsSync(cliJs)) {
+        return { command: process.execPath, prefixArgs: [cliJs] };
+      }
+    } catch {
+      // SDK layout changed or not resolvable — fall back to the
+      // configured command below.
+    }
+    return { command: this.config.command, prefixArgs: [] };
+  }
 
   createExecutionStrategy() {
     return {
@@ -62,9 +98,11 @@ export class ClaudeCodeProvider implements AgentProvider {
         args.push('--model', input.model);
       }
 
+      const { command, prefixArgs } = this.resolveBackgroundCommand();
+
       return ok({
-        command: this.config.command,
-        args,
+        command,
+        args: [...prefixArgs, ...args],
         stdin: input.prompt,
         env: input.traceparent ? { TALOND_TRACEPARENT: input.traceparent } : undefined,
         cwd: input.cwd,

--- a/src/providers/codex-cli-provider.ts
+++ b/src/providers/codex-cli-provider.ts
@@ -129,18 +129,24 @@ export class CodexCliProvider implements AgentProvider {
       const codexDir = join(homeDir, '.codex');
       mkdirSync(codexDir, { recursive: true, mode: 0o700 });
 
+      // Copy operator state (auth.json, etc.) from the operator's own
+      // ~/.codex when it exists. On a fresh container it won't — that is
+      // fine for API-key auth, where the CLI reads OPENAI_API_KEY from
+      // the environment and needs no seeded state.
       const sourceCodexDir = this.operatorCodexDir();
-      for (const entry of readdirSync(sourceCodexDir)) {
-        if (!this.shouldCopyCodexStateFile(entry)) {
-          continue;
-        }
+      if (existsSync(sourceCodexDir)) {
+        for (const entry of readdirSync(sourceCodexDir)) {
+          if (!this.shouldCopyCodexStateFile(entry)) {
+            continue;
+          }
 
-        const sourcePath = join(sourceCodexDir, entry);
-        if (!existsSync(sourcePath) || !statSync(sourcePath).isFile()) {
-          continue;
-        }
+          const sourcePath = join(sourceCodexDir, entry);
+          if (!existsSync(sourcePath) || !statSync(sourcePath).isFile()) {
+            continue;
+          }
 
-        copyFileSync(sourcePath, join(codexDir, entry));
+          copyFileSync(sourcePath, join(codexDir, entry));
+        }
       }
 
       const renderedConfig = this.renderConfigToml({ cwd, model, mcpServers });

--- a/starter/README.md
+++ b/starter/README.md
@@ -86,11 +86,14 @@ The minimal `talond.yaml` defaults to Claude (`claude-code` provider) and reads
 | Provider | What to change in `talond.yaml` | What to set in `.env` |
 | --- | --- | --- |
 | **OpenAI-compatible** (Ollama Cloud, Groq, Together, vLLM, llama.cpp, …) | Set `provider: openai-compatible` on the persona; configure `agentRunner.providers.openai-compatible` with `baseUrl` + `defaultModel`; set `auth.providers.<providerId>.baseURL` (+ optional `apiKey`) | Your endpoint's API key if it needs one |
-| **Gemini CLI** | Set `provider: gemini-cli`; ensure `gemini` is on PATH inside the container (currently not preinstalled — workaround required) | `GOOGLE_AI_API_KEY` if not using interactive OAuth |
-| **Codex CLI** | Set `provider: codex-cli`; same caveat as Gemini for the binary | `OPENAI_API_KEY` |
+| **Gemini CLI** | Set `provider: gemini-cli`. The `gemini` binary is preinstalled in the image. | `GOOGLE_AI_API_KEY` if not using interactive OAuth |
+| **Codex CLI** | Set `provider: codex-cli`. The `codex` binary is preinstalled in the image. | `OPENAI_API_KEY` |
 
-See the [full reference config](https://github.com/ivo-toby/talon/blob/main/config/talond.example.yaml)
-for complete provider snippets including context-management and sub-agent tuning.
+All four providers work out of the box — `claude` (bundled in the Agent
+SDK), `codex`, and `gemini` ship in the image; `openai-compatible` runs
+in-process. See [`docs/providers.md`](docs/providers.md) for full config
+snippets, and the [reference config](https://github.com/ivo-toby/talon/blob/main/config/talond.example.yaml)
+for context-management and sub-agent tuning.
 
 ## Sharing files with the agent
 

--- a/starter/docs/providers.md
+++ b/starter/docs/providers.md
@@ -123,29 +123,14 @@ GROQ_API_KEY=gsk_...                           # name matches whatever you used 
 ## Gemini CLI
 
 Google's [Gemini CLI](https://github.com/google-gemini/gemini-cli). Runs
-as a subprocess inside the container, so the `gemini` binary must be on
-the container's PATH.
+as a subprocess inside the container — the `gemini` binary is
+**preinstalled** in the image, so no custom build is needed.
 
-### Caveat: not preinstalled
-
-The starter image does **not** ship the `gemini` binary. To use this
-provider you need a custom image. The simplest path is a small
-Dockerfile that extends the upstream image:
-
-```dockerfile
-FROM ghcr.io/ivo-toby/talond:latest
-USER root
-RUN npm install -g @google/gemini-cli@latest && \
-    chown -R talond:talond /usr/local/lib/node_modules
-USER talond
-```
-
-Build + tag locally, then point `docker-compose.yaml` at it:
-`image: my-talond-gemini:latest`.
-
-For most users, accessing Gemini through the **OpenAI-compatible**
-provider (above) pointing at Google's OpenAI-compatible endpoint is
-simpler and doesn't need a custom image.
+> **Auth state does not persist.** Gemini CLI stores OAuth credentials
+> under `~/.gemini` inside the container, which is wiped on every
+> container recreation. Use `GOOGLE_AI_API_KEY` (read fresh from `.env`
+> each run) for a stateless setup, or bind-mount `/home/talond` in
+> `docker-compose.yaml` if you need OAuth state to survive restarts.
 
 ### `config/talond.yaml`
 
@@ -176,20 +161,13 @@ GOOGLE_AI_API_KEY=...                          # or rely on interactive OAuth (m
 
 ## Codex CLI
 
-OpenAI's [Codex CLI](https://github.com/openai/codex). Same model as
-Gemini CLI — runs as a subprocess, needs the binary on PATH.
+OpenAI's [Codex CLI](https://github.com/openai/codex). Runs as a
+subprocess — the `codex` binary is **preinstalled** in the image.
 
-### Caveat: not preinstalled
-
-Same as Gemini. Custom image required:
-
-```dockerfile
-FROM ghcr.io/ivo-toby/talond:latest
-USER root
-RUN npm install -g @openai/codex@latest && \
-    chown -R talond:talond /usr/local/lib/node_modules
-USER talond
-```
+> **Auth state does not persist.** Codex CLI stores config and auth
+> under `~/.codex` inside the container, wiped on container recreation.
+> Use `OPENAI_API_KEY` from `.env` for a stateless setup, or bind-mount
+> `/home/talond` to persist it.
 
 ### `config/talond.yaml`
 
@@ -235,7 +213,7 @@ so the cleanest path is:
    ```
 
 For providers that *are* fully covered by `add-provider` flags (Claude,
-Gemini CLI, Codex CLI with the binary preinstalled in a custom image):
+Gemini CLI, Codex CLI — all preinstalled in the image):
 
 ```bash
 talonctl list-providers

--- a/starter/docs/providers.md
+++ b/starter/docs/providers.md
@@ -45,15 +45,66 @@ auth:
 ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-### Notes
+### Authentication
 
-- `claude-code` is Talon's wrapper around the
-  [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python).
-  The image ships with it preinstalled.
-- For Claude Max subscription auth (no API key), set `auth.mode: subscription`
-  and bind-mount `~/.claude` from the host into the container. Edit
-  `docker-compose.yaml` and add `~/.claude:/home/talond/.claude:ro` under
-  `volumes`.
+The `claude-code` provider is a thin wrapper: Talon runs the Claude Code
+CLI (bundled inside the `@anthropic-ai/claude-agent-sdk` npm dependency,
+so nothing extra to install) and the CLI does its own auth resolution
+from the container's environment and `~/.claude`. **Anything the Claude
+Code CLI supports natively works here** — you just have to get the
+credentials in. Three options:
+
+#### API key (simplest)
+
+```ini
+# .env
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+docker-compose puts it in the container environment; the CLI reads it.
+Nothing else to do.
+
+#### AWS Bedrock (best fit for a server/container)
+
+Entirely env-var driven — no mounts, no OAuth refresh, no state:
+
+```ini
+# .env
+CLAUDE_CODE_USE_BEDROCK=1
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=us-east-1
+ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-...   # a Bedrock model ID
+```
+
+The CLI inherits these and honors Bedrock natively. If the container
+runs *on* AWS (ECS/EC2), drop the keys and let it use the instance
+role. This is the recommended path for an always-on deployment.
+
+#### Claude Max / Pro subscription
+
+Possible, but the awkward path in docker:
+
+- Credentials live in `~/.claude/`. On **Linux** that's a file
+  (`~/.claude/.credentials.json`); on **macOS** it's the **Keychain** —
+  not a file, so it cannot be bind-mounted.
+- Bind-mount the host's `~/.claude` into the container, **read-write**
+  (the OAuth token refreshes and the CLI must write the new one back):
+  ```yaml
+  # docker-compose.yaml, under the talond service `volumes:`
+  - ~/.claude:/home/talond/.claude
+  ```
+- This only works when the host has the file form — i.e. a Linux host
+  where `claude login` was run. A macOS host can't share its Keychain
+  credentials with a Linux container.
+- **One subscription per daemon.** The claude-code provider has no
+  per-persona home isolation — a single daemon shares one `~/.claude`,
+  hence one Max account. For multiple subscriptions, run separate
+  daemon instances (one container each).
+
+For a containerized deployment, prefer **API key or Bedrock**. Max works
+on a Linux host with a read-write `~/.claude` mount, but it is the
+fragile path (token refresh, the macOS Keychain wall, no multi-account).
 
 ---
 
@@ -193,6 +244,56 @@ agentRunner:
 ```ini
 OPENAI_API_KEY=sk-...
 ```
+
+---
+
+## Using your host's codex / gemini auth in the container
+
+If you've already authenticated `codex` (or `gemini`) on your host —
+e.g. `codex login` — you can reuse that login inside the container
+instead of putting an API key in `.env`.
+
+### Codex
+
+Talon's codex provider seeds each run from the *operator's* `~/.codex`:
+before every invocation it copies `auth.json` (and the model/version
+caches and state) into a fresh per-run codex home, then runs the CLI
+against that copy. So you only need to make your host's `~/.codex`
+visible to the daemon at the path it looks for — `~/.codex` relative to
+the container user's home, i.e. `/home/talond/.codex`:
+
+```yaml
+# docker-compose.yaml, under the talond service `volumes:`
+- ~/.codex:/home/talond/.codex:ro
+```
+
+**Read-only is correct** — Talon never writes back to this directory, it
+only reads and copies. A read-only mount keeps your host credentials
+safe and still works fully.
+
+Caveats:
+
+- **OAuth vs API key.** If your host codex login is an OAuth token that
+  expires, the container uses a per-run snapshot — it picks up a
+  refreshed token on the next run *after* your host refreshes it, but
+  the container itself can't refresh (read-only, and it's a copy). A
+  static API key has no expiry concern.
+- **Linux permissions.** The container runs as UID 1000; the host
+  `~/.codex` files must be readable by it. Transparent on macOS Docker
+  Desktop; on Linux the host user should be UID 1000 or you adjust
+  permissions.
+
+### Gemini
+
+Gemini CLI keeps its auth/config under `~/.gemini` and Talon does not
+seed it per-run. To reuse a host login, bind-mount the directory
+**read-write** (so token refresh can persist):
+
+```yaml
+- ~/.gemini:/home/talond/.gemini
+```
+
+For most setups, `GOOGLE_AI_API_KEY` in `.env` is simpler and stateless.
 
 ---
 

--- a/tests/unit/providers/claude-code-provider.test.ts
+++ b/tests/unit/providers/claude-code-provider.test.ts
@@ -51,7 +51,11 @@ describe('ClaudeCodeProvider', () => {
     const invocation = result._unsafeUnwrap();
     cleanupPaths.push(...invocation.cleanupPaths);
 
-    expect(invocation.command).toBe('claude');
+    // Background runs spawn the Claude Code CLI bundled inside the Agent
+    // SDK via node, so a `claude` binary need not be on PATH (this is
+    // what makes background runs work inside the docker image).
+    expect(invocation.command).toBe(process.execPath);
+    expect(invocation.args[0]).toMatch(/cli\.js$/);
     expect(invocation.stdin).toBe('Refactor the auth module.');
     expect(invocation.cwd).toBe('/tmp');
     expect(invocation.args).toContain('--append-system-prompt');
@@ -95,6 +99,31 @@ describe('ClaudeCodeProvider', () => {
     expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual({
       mcpServers: {},
     });
+  });
+
+  it('honors an explicitly configured command for background invocations', () => {
+    // A non-default command (operator chose a specific path/wrapper) is
+    // used verbatim — not replaced by the SDK-bundled CLI.
+    const customProvider = new ClaudeCodeProvider({
+      enabled: true,
+      command: '/opt/claude/bin/claude',
+      contextWindowTokens: 200000,
+    });
+
+    const result = customProvider.prepareBackgroundInvocation({
+      prompt: 'Ping.',
+      systemPrompt: 'You are a helpful assistant.',
+      mcpServers: {},
+      cwd: '/tmp',
+      timeoutMs: 60_000,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const invocation = result._unsafeUnwrap();
+    cleanupPaths.push(...invocation.cleanupPaths);
+
+    expect(invocation.command).toBe('/opt/claude/bin/claude');
+    expect(invocation.args[0]).toBe('--print');
   });
 
   it('parses Claude JSON output into normalized usage and text', () => {


### PR DESCRIPTION
## Summary

Discovered while testing the v0.2.1 bundle: picking the `codex-cli`
provider fails because the `codex` binary isn't in the container. The
starter image shipped only Node + tini + git/jq/curl. This bakes in the
two CLI-based providers and fixes two container-path bugs that surfaced
along the way, so **all four providers work out of the box**.

Refs Postgram task `5b77008f`.

## Changes

### `deploy/Dockerfile`
- `npm install -g @openai/codex @google/gemini-cli` in the production
  stage. Both land on PATH; the `codex-cli` / `gemini-cli` providers
  resolve `codex` / `gemini` from there.
- The `talond` user now gets a **real home directory** (`--create-home`
  instead of `--no-create-home`). codex and gemini write config/auth
  under `~/.codex` / `~/.gemini` and crash without a writable `$HOME`.
- Image size: ~644 MB → **~1.03 GB** (+~286 MB). Accepted tradeoff for
  out-of-the-box provider support.

### `src/providers/claude-code-provider.ts`
The background-agent path returned `command: this.config.command`
(→ bare `claude`), which isn't on PATH in the container. (Foreground was
always fine — it runs the Agent SDK in-process.)
- Background runs now resolve the Claude Code CLI **bundled inside
  `@anthropic-ai/claude-agent-sdk`** (`cli.js`, 13 MB) and spawn it via
  `node`. No `claude` on PATH needed.
- An explicitly configured non-default `command` is still honored
  verbatim — only the default `claude` falls through to the bundled CLI.
- New test covers the explicit-custom-command case; existing background
  test updated for the bundled-CLI behavior.

### `src/providers/codex-cli-provider.ts`
`seedCodexHome()` did `readdirSync` on the operator's `~/.codex` source
dir unconditionally. On a fresh container that dir doesn't exist →
ENOENT before the CLI ever spawns, so codex-cli was broken even with the
binary present.
- Guarded with `existsSync`. A missing source dir means there's nothing
  to copy — correct for API-key auth (the CLI reads `OPENAI_API_KEY`
  from the environment).

### Docs
`starter/docs/providers.md`, `starter/README.md`, and the
`talon-setup-docker` skill no longer claim codex/gemini need a custom
image. They now document the real caveat: OAuth state under
`~/.codex` / `~/.gemini` does not survive container recreation — use
API-key auth, or bind-mount `/home/talond` to persist it.

## Test plan

- [x] `docker build` succeeds; `codex --version` (0.133.0) and
      `gemini --version` (0.43.0) both run cleanly as the `talond` user
- [x] `$HOME=/home/talond` exists and is writable
- [x] Claude Agent SDK `cli.js` present and resolvable in the image
- [x] `claude-code-provider.test.ts` (21) + `codex-cli-provider.test.ts`
      (24) pass
- [x] Codex review clean on in-scope files (3 passes; addressed the
      explicit-command regression and the codex ENOENT)
- [ ] CI multi-arch build on the tag
- [ ] End-to-end: pull the new image, configure codex-cli with
      `OPENAI_API_KEY`, confirm a Telegram round-trip

## Notes

- Gemini CLI provider has no `seedHome`-style operator-state copy, so it
  doesn't have the codex ENOENT bug — no change needed there.
- Image is now ~1 GB. If that becomes a concern, a future option is
  splitting codex/gemini into an optional `talond-full` image variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)