### PR TITLE
fix(starter): persist skills/ and subagents/ via bind mounts

### DIFF
--- a/starter/docker-compose.yaml
+++ b/starter/docker-compose.yaml
@@ -50,13 +50,17 @@ services:
         source: ./userdata
         target: /userdata
 
-      # Optional: custom skills and sub-agents.
-      # - type: bind
-      #   source: ./skills
-      #   target: /skills
-      # - type: bind
-      #   source: ./subagents
-      #   target: /subagents
+      # Skills and sub-agents. Bind-mounted (not optional) so that writes
+      # from `talonctl add-mcp` / `add-skill` and any hand-authored skills
+      # persist across container recreation. Without these mounts the
+      # daemon's /skills and /subagents live only in the container's
+      # ephemeral layer and are lost on `docker compose up` / `pull`.
+      - type: bind
+        source: ./skills
+        target: /skills
+      - type: bind
+        source: ./subagents
+        target: /subagents
 
     healthcheck:
       test: ["CMD", "node", "-e", "const fs=require('fs');const p=process.env.TALON_PID_FILE||'/data/talond.pid';if(!fs.existsSync(p)){process.exit(1);}try{process.kill(parseInt(fs.readFileSync(p,'utf8').trim()),0);process.exit(0);}catch{process.exit(1);}"]

--- a/starter/install.sh
+++ b/starter/install.sh
@@ -22,8 +22,10 @@ echo "Installed: $DEST"
 
 # Ensure the bind-mount sources exist before `docker compose up`.
 # Without this, Docker creates them as root-owned on Linux, breaking the
-# non-root user inside the container.
-mkdir -p "$HERE/data" "$HERE/userdata"
+# non-root user inside the container. `skills/` and `subagents/` must
+# exist so `talonctl add-mcp` / `add-skill` writes land on the host and
+# survive container recreation.
+mkdir -p "$HERE/data" "$HERE/userdata" "$HERE/skills" "$HERE/subagents"
 
 case ":$PATH:" in
   *":$PREFIX:"*) ;;

--- a/starter/skills/.gitkeep
+++ b/starter/skills/.gitkeep
@@ -1,0 +1,2 @@
+# Talon skills live here. The daemon loads them from /skills (bind-mounted).
+# `talonctl add-mcp` / `add-skill` write here; drop hand-authored skills here too.

--- a/starter/subagents/.gitkeep
+++ b/starter/subagents/.gitkeep
@@ -1,0 +1,3 @@
+# Custom Talon sub-agents live here. The daemon loads them from /subagents
+# (bind-mounted). Built-in sub-agents ship inside the image; this is for
+# your own additions.


### PR DESCRIPTION
## Summary

Found while testing: `talonctl add-mcp` (and `add-skill`) inside the
starter container write to `/skills`, but that path **isn't bind-mounted
from the host** — the starter `docker-compose.yaml` left the `./skills`
and `./subagents` mounts commented out as "optional".

The Dockerfile creates `/skills` and `/subagents` inside the image, so
they exist — but in the container's ephemeral writable layer. Any skill
or MCP server added via `talonctl` is **silently lost** on the next
`docker compose up` / `docker compose pull` recreation. Persona prompts
survived only because `./personas` was already mounted.

## Changes

- `docker-compose.yaml` — activate the `./skills` and `./subagents`
  bind mounts (no longer commented out).
- `install.sh` — `mkdir` `skills/` and `subagents/` alongside `data/`
  and `userdata/`, so the bind-mount sources exist before first `up`
  (avoids Docker creating them root-owned on Linux).
- Ship `skills/.gitkeep` + `subagents/.gitkeep` so the directories are
  present in the release tarball.

## Test plan

- [x] `docker-compose.yaml` parses; mounts point at `./skills` /
      `./subagents`
- [ ] After merge + release: `talonctl add-mcp ...`, then
      `docker compose up -d` (recreate) — the added skill/MCP server
      survives

## Notes

The forthcoming Talon+Postgram stack kit already mounts `./skills`
(its bundled `postgram-memory` skill lives there) — this fix brings the
existing single-service starter in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)