### PR TITLE
Talon + Postgram combined stack kit (starter-stack/)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,36 +66,42 @@ jobs:
           chmod +x scripts/sync-starter-skills.sh
           scripts/sync-starter-skills.sh
 
-      - name: Ensure starter/data exists in tarball
-        run: mkdir -p starter/data
+      - name: Ensure bind-mount dirs exist in tarballs
+        run: mkdir -p starter/data starter-stack/data
 
-      - name: Create tarball
+      - name: Create tarballs
         run: |
-          # Rename top-level dir from `starter/` to `talon-starter/` so users
-          # get a friendlier name when they extract. Done via a copy (portable
-          # across BSD and GNU tar) rather than --transform.
+          # Rename top-level dirs to friendly names inside the tar, via a
+          # copy (portable across BSD and GNU tar) rather than --transform.
           #
-          # The artifact filename is unversioned (`talon-starter.tar.gz`) so the
-          # GitHub `/releases/latest/download/talon-starter.tar.gz` URL — what
-          # the starter README documents — resolves correctly. The release tag
-          # itself carries the version.
+          # Artifact filenames are unversioned so the GitHub
+          # `/releases/latest/download/<name>.tar.gz` URLs — what the
+          # READMEs document — resolve correctly. The release tag carries
+          # the version.
           rm -rf build && mkdir build
           cp -R starter build/talon-starter
+          cp -R starter-stack build/talon-postgram-stack
           tar -czf talon-starter.tar.gz -C build talon-starter
+          tar -czf talon-postgram-stack.tar.gz -C build talon-postgram-stack
 
       - name: Attach to release
         uses: softprops/action-gh-release@v3
         with:
-          files: talon-starter.tar.gz
+          files: |
+            talon-starter.tar.gz
+            talon-postgram-stack.tar.gz
           fail_on_unmatched_files: true
           generate_release_notes: false
           body: |
             ## Talon ${{ github.ref_name }}
 
             **Container image:** `ghcr.io/ivo-toby/talond:${{ github.ref_name }}` (also tagged `:latest`)
-            **Starter bundle:** `talon-starter.tar.gz` attached below
 
-            ### Quick start
+            **Bundles attached below:**
+            - `talon-starter.tar.gz` — single Talon daemon
+            - `talon-postgram-stack.tar.gz` — Talon + Postgram (persistent memory)
+
+            ### Quick start (single daemon)
 
             ```bash
             curl -fsSL https://github.com/ivo-toby/talon/releases/download/${{ github.ref_name }}/talon-starter.tar.gz | tar xz
@@ -103,6 +109,16 @@ jobs:
             ./install.sh
             # edit .env + config/talond.yaml, then:
             docker compose up -d
+            ```
+
+            ### Quick start (Talon + Postgram)
+
+            ```bash
+            curl -fsSL https://github.com/ivo-toby/talon/releases/download/${{ github.ref_name }}/talon-postgram-stack.tar.gz | tar xz
+            cd talon-postgram-stack
+            ./install.sh
+            # edit .env + config/talond.yaml, then:
+            ./bootstrap.sh
             ```
 
             See the [starter README](https://github.com/ivo-toby/talon/blob/main/starter/README.md) for full setup.

--- a/starter-stack/.env.example
+++ b/starter-stack/.env.example
@@ -1,0 +1,39 @@
+# Talon + Postgram stack — secrets. Copy to `.env` and fill in.
+# Loaded by docker-compose.yaml. Never commit `.env`.
+
+# ---------------------------------------------------------------------------
+# Postgram
+# ---------------------------------------------------------------------------
+
+# Postgres password for the Postgram database. Pick any strong value —
+# it's used only inside the compose network.
+POSTGRES_PASSWORD=
+
+# OpenAI API key — Postgram uses it to embed stored knowledge for
+# semantic search. Required.
+OPENAI_API_KEY=
+
+# Postgram API key for Talon → Postgram auth. LEAVE BLANK — ./bootstrap.sh
+# mints it after Postgram starts and fills it in here.
+PGM_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Talon — agent provider
+# ---------------------------------------------------------------------------
+
+# The starter persona uses the claude-code provider. Set this if you use
+# it with API-key auth. To use a different provider, see
+# https://github.com/ivo-toby/talon/blob/main/starter/docs/providers.md
+ANTHROPIC_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Talon — channel
+# ---------------------------------------------------------------------------
+
+# Telegram bot token from @BotFather.
+TELEGRAM_BOT_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Optional
+# ---------------------------------------------------------------------------
+# LOG_LEVEL=debug

--- a/starter-stack/.gitignore
+++ b/starter-stack/.gitignore
@@ -1,0 +1,9 @@
+# Rendered by bootstrap.sh from postgram.json.template — contains the
+# minted Postgram API key. Never commit.
+skills/postgram-memory/mcp/postgram.json
+
+# User content dropped for the agent.
+userdata/*
+!userdata/.gitkeep
+
+# (.env, data/, config/talond.yaml are covered by the repo-root .gitignore.)

--- a/starter-stack/README.md
+++ b/starter-stack/README.md
@@ -1,0 +1,116 @@
+# Talon + Postgram — Stack
+
+A self-hosted AI agent ([Talon](https://github.com/ivo-toby/talon)) wired
+to a persistent knowledge store ([Postgram](https://github.com/ivo-toby/postgram))
+so the agent **remembers across conversations** out of the box.
+
+Four containers, all from published images — nothing to build:
+
+| Service | Image | Role |
+| --- | --- | --- |
+| `postgres` | `pgvector/pgvector:pg17` | Postgram's database |
+| `postgram` | `ghcr.io/ivo-toby/postgram` | Knowledge store (REST + MCP) |
+| `talond` | `ghcr.io/ivo-toby/talond` | The Talon agent daemon |
+
+The bundled `postgram-memory` skill connects Talon's agent to Postgram
+over MCP — the agent gets `search` / `store` / `recall` / task tools and
+guidance on when to use them.
+
+## Requirements
+
+- Docker (Engine on Linux, or Docker Desktop on macOS/Windows) with `docker compose`
+- An OpenAI API key — Postgram uses it to embed knowledge for semantic search
+- An AI provider for Talon itself (Claude API key by default)
+- A Telegram bot token (from [@BotFather](https://t.me/BotFather))
+
+## Quickstart
+
+```bash
+# 1. Download and extract
+curl -fsSL https://github.com/ivo-toby/talon/releases/latest/download/talon-postgram-stack.tar.gz | tar xz
+cd talon-postgram-stack
+
+# 2. Install the talonctl helper (optional, no sudo)
+./install.sh
+
+# 3. Configure
+cp .env.example .env                              # POSTGRES_PASSWORD, OPENAI_API_KEY,
+                                                  # ANTHROPIC_API_KEY, TELEGRAM_BOT_TOKEN
+cp config/talond.example.yaml config/talond.yaml  # set allowedChatIds
+
+# 4. Bring up the stack
+./bootstrap.sh
+```
+
+Then message your Telegram bot. Ask it to remember something, start a
+fresh conversation, and ask it to recall — it goes through Postgram.
+
+## Why `bootstrap.sh` instead of `docker compose up`
+
+Postgram API keys must be **minted after** its server is running — you
+can't pre-set one in `.env`. `bootstrap.sh` handles the ordering:
+
+1. Starts `postgres` + `postgram`, waits until Postgram is healthy.
+2. Mints a Postgram API key via its admin CLI
+   (`docker compose exec postgram pgm-admin key create …`).
+3. Writes the key into `.env` and renders it into the `postgram-memory`
+   skill's MCP definition (`skills/postgram-memory/mcp/postgram.json`).
+4. Starts `talond`.
+
+It's safe to re-run — if `PGM_API_KEY` is already set it skips step 2.
+
+## How the agent uses Postgram
+
+`skills/postgram-memory/` is a Talon skill with two parts:
+
+- `mcp/postgram.json` — the MCP client pointing at `http://postgram:3100/mcp`
+  (rendered from `.template` by `bootstrap.sh` with your API key).
+- `SKILL.md` — usage guidance, marked `eager: true` so it's always in the
+  agent's system prompt. Memory use is reflexive — the agent shouldn't
+  have to decide to "load" it.
+
+The `assistant` persona in `config/talond.yaml` lists `postgram-memory`
+in its `skills:`, so the agent gets the Postgram tools and the guidance.
+
+## Configuration
+
+| File or dir | Purpose |
+| --- | --- |
+| `.env` | Secrets. `bootstrap.sh` fills in `PGM_API_KEY`. Never commit. |
+| `config/talond.yaml` | Talon config — channels, persona, provider. |
+| `personas/<name>/system.md` | Persona system prompts. |
+| `skills/postgram-memory/` | The skill wiring Talon ↔ Postgram. |
+| `userdata/` | Files for the agent to read (bind-mounted at `/userdata`). |
+| `data/` | Talon's SQLite DB + state. Postgram's data is in the `pgdata` volume. |
+
+To use a non-Claude provider for Talon, see
+[the provider cookbook](https://github.com/ivo-toby/talon/blob/main/starter/docs/providers.md).
+
+## Common operations
+
+```bash
+docker compose ps                       # all four services
+docker compose logs -f talond           # Talon logs
+docker compose logs -f postgram         # Postgram logs
+talonctl status                         # daemon health
+docker compose down                     # stop (data persists in volumes)
+docker compose pull && ./bootstrap.sh   # update images, re-run bootstrap
+```
+
+## Troubleshooting
+
+**`bootstrap.sh` says Postgram didn't become healthy** — check
+`docker compose logs postgram`. Most common cause: `OPENAI_API_KEY`
+missing or invalid (Postgram needs it for embeddings).
+
+**Agent doesn't seem to remember** — confirm the skill's MCP file was
+rendered: `skills/postgram-memory/mcp/postgram.json` should exist and
+contain a real key, not `__PGM_API_KEY__`. Re-run `./bootstrap.sh` if not.
+Check `docker compose logs talond` for MCP connection errors.
+
+**Telegram errors** — see the
+[troubleshooting guide](https://github.com/ivo-toby/talon/blob/main/starter/docs/troubleshooting.md).
+
+## License
+
+AGPL-3.0-only, same as the parent projects.

--- a/starter-stack/bin/talonctl
+++ b/starter-stack/bin/talonctl
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# talonctl — host-side wrapper around the in-container CLI.
+#
+# Usage:
+#   talonctl status
+#   talonctl list-channels
+#   talonctl chat
+#
+# Forwards all arguments and stdin/stdout to `node dist/cli/index.js` inside
+# the running talond container. Allocates a TTY only when stdin and stdout are
+# both terminals, so piping works:
+#
+#   talonctl list-channels | jq
+#
+# Container name defaults to `talond`. Override with TALOND_CONTAINER.
+
+set -euo pipefail
+
+CONTAINER="${TALOND_CONTAINER:-talond}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "talonctl: docker not found on PATH." >&2
+  exit 127
+fi
+
+if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
+  echo "talonctl: container '$CONTAINER' not found." >&2
+  echo "  Is the daemon running? Try: docker compose up -d" >&2
+  echo "  Or set TALOND_CONTAINER to the right container name." >&2
+  exit 1
+fi
+
+state="$(docker inspect -f '{{.State.Status}}' "$CONTAINER" 2>/dev/null || echo unknown)"
+if [ "$state" != "running" ]; then
+  echo "talonctl: container '$CONTAINER' is $state, not running." >&2
+  echo "  Start it with: docker compose up -d" >&2
+  exit 1
+fi
+
+# Config path resolution: the CLI honors $TALOND_CONFIG_PATH (set by the
+# bundled docker-compose.yaml to /config/talond.yaml), so we don't need to
+# pass --config explicitly. Override per-command if needed:
+#   talonctl status --config /some/other/path.yaml
+if [ -t 0 ] && [ -t 1 ]; then
+  exec docker exec -it "$CONTAINER" node /opt/talond/dist/cli/index.js "$@"
+else
+  exec docker exec -i  "$CONTAINER" node /opt/talond/dist/cli/index.js "$@"
+fi

--- a/starter-stack/bootstrap.sh
+++ b/starter-stack/bootstrap.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# bootstrap.sh — first-run setup for the Talon + Postgram stack.
+#
+# Postgram API keys must be minted *after* its server is running, so this
+# can't be a single `docker compose up`. This script does the ordering:
+#
+#   1. Bring up postgres + postgram, wait until Postgram is healthy.
+#   2. Mint a Postgram API key via its admin CLI.
+#   3. Write that key into .env (PGM_API_KEY) and render it into the
+#      postgram-memory skill's MCP definition.
+#   4. Bring up talond.
+#
+# Safe to re-run: if PGM_API_KEY is already set it skips key creation.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+ENV_FILE="$HERE/.env"
+MCP_TEMPLATE="$HERE/skills/postgram-memory/mcp/postgram.json.template"
+MCP_RENDERED="$HERE/skills/postgram-memory/mcp/postgram.json"
+
+# --- prerequisites ----------------------------------------------------------
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "bootstrap: docker not found on PATH." >&2
+  exit 127
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "bootstrap: .env not found. Run: cp .env.example .env  — then fill it in." >&2
+  exit 1
+fi
+
+# Pull values from .env without sourcing it (avoids surprises with quoting).
+get_env() { grep -E "^$1=" "$ENV_FILE" | head -1 | cut -d= -f2-; }
+
+for required in POSTGRES_PASSWORD OPENAI_API_KEY TELEGRAM_BOT_TOKEN; do
+  if [ -z "$(get_env "$required")" ]; then
+    echo "bootstrap: $required is empty in .env — fill it in first." >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$HERE/data" "$HERE/userdata"
+
+# --- step 1: data services --------------------------------------------------
+
+echo "==> Starting postgres + postgram ..."
+docker compose up -d postgres postgram
+
+echo "==> Waiting for Postgram to become healthy ..."
+for _ in $(seq 1 60); do
+  status="$(docker compose ps postgram --format '{{.Health}}' 2>/dev/null || echo '')"
+  [ "$status" = "healthy" ] && break
+  sleep 3
+done
+if [ "${status:-}" != "healthy" ]; then
+  echo "bootstrap: Postgram did not become healthy in time." >&2
+  echo "  Check: docker compose logs postgram" >&2
+  exit 1
+fi
+echo "    Postgram is healthy."
+
+# --- step 2: mint an API key (idempotent) -----------------------------------
+
+existing_key="$(get_env PGM_API_KEY)"
+if [ -n "$existing_key" ]; then
+  echo "==> PGM_API_KEY already set in .env — skipping key creation."
+  api_key="$existing_key"
+else
+  echo "==> Minting a Postgram API key for Talon ..."
+  key_json="$(docker compose exec -T postgram pgm-admin key create \
+    --name talon \
+    --scopes read,write,delete \
+    --visibility personal \
+    --json)"
+  api_key="$(printf '%s' "$key_json" | grep -oE '"plaintextKey"[[:space:]]*:[[:space:]]*"[^"]+"' | sed -E 's/.*"plaintextKey"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+  if [ -z "$api_key" ]; then
+    echo "bootstrap: could not parse plaintextKey from pgm-admin output:" >&2
+    printf '%s\n' "$key_json" >&2
+    exit 1
+  fi
+  # Write it back into .env (replace the empty PGM_API_KEY= line).
+  tmp="$(mktemp)"
+  sed "s|^PGM_API_KEY=.*|PGM_API_KEY=$api_key|" "$ENV_FILE" > "$tmp"
+  mv "$tmp" "$ENV_FILE"
+  echo "    Wrote PGM_API_KEY to .env"
+fi
+
+# --- step 3: render the skill's MCP definition ------------------------------
+
+if [ ! -f "$MCP_TEMPLATE" ]; then
+  echo "bootstrap: MCP template missing: $MCP_TEMPLATE" >&2
+  exit 1
+fi
+sed "s|__PGM_API_KEY__|$api_key|" "$MCP_TEMPLATE" > "$MCP_RENDERED"
+echo "==> Rendered postgram-memory MCP definition."
+
+# --- step 4: talond ---------------------------------------------------------
+
+if [ ! -f "$HERE/config/talond.yaml" ]; then
+  echo "bootstrap: config/talond.yaml not found." >&2
+  echo "  Run: cp config/talond.example.yaml config/talond.yaml  — then edit allowedChatIds." >&2
+  exit 1
+fi
+
+echo "==> Starting talond ..."
+docker compose up -d talond
+
+echo
+echo "Done. The stack is up:"
+docker compose ps
+echo
+echo "Next: message your Telegram bot. Check logs with:"
+echo "  docker compose logs -f talond"

--- a/starter-stack/config/talond.example.yaml
+++ b/starter-stack/config/talond.example.yaml
@@ -1,0 +1,87 @@
+# talond.yaml — Talon + Postgram stack config
+#
+# Copy to talond.yaml and edit `allowedChatIds` at minimum. The
+# `postgram-memory` skill (bundled in skills/) wires the agent to the
+# Postgram knowledge store running alongside this daemon.
+
+storage:
+  type: sqlite
+  path: data/talond.sqlite
+
+# ---------------------------------------------------------------------------
+# Channels
+# ---------------------------------------------------------------------------
+channels:
+  - type: telegram
+    name: personal-telegram
+    enabled: true
+    config:
+      botToken: ${TELEGRAM_BOT_TOKEN}
+      # Restrict who can message the bot. Find your Telegram user ID via
+      # @userinfobot. Values must be strings, not numbers.
+      allowedChatIds:
+        - "123456789"
+      pollingTimeoutSec: 30
+
+# ---------------------------------------------------------------------------
+# Personas
+# ---------------------------------------------------------------------------
+personas:
+  - name: assistant
+    model: claude-sonnet-4-6
+    provider: claude-code
+    systemPromptFile: personas/assistant/system.md
+    # The postgram-memory skill is eager — its usage guidance is always
+    # in the system prompt, and it carries the Postgram MCP server
+    # definition (skills/postgram-memory/mcp/postgram.json, rendered by
+    # bootstrap.sh with your API key).
+    skills:
+      - postgram-memory
+    subagents: []
+    capabilities:
+      allow:
+        - channel.send:*
+        - memory.access:*
+    maxConcurrent: 1
+
+# ---------------------------------------------------------------------------
+# Bindings
+# ---------------------------------------------------------------------------
+bindings:
+  - persona: assistant
+    channel: personal-telegram
+    isDefault: true
+
+# ---------------------------------------------------------------------------
+# Agent runtime
+# ---------------------------------------------------------------------------
+agentRunner:
+  defaultProvider: claude-code
+  providers:
+    claude-code:
+      enabled: true
+      command: claude
+      contextWindowTokens: 200000
+
+backgroundAgent:
+  enabled: false
+  defaultProvider: claude-code
+  providers:
+    claude-code:
+      enabled: true
+      command: claude
+      contextWindowTokens: 200000
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+# Default: api_key — reads $ANTHROPIC_API_KEY from .env. To use a
+# different provider (OpenAI-compatible, Gemini, Codex) see
+# https://github.com/ivo-toby/talon/blob/main/starter/docs/providers.md
+auth:
+  mode: api_key
+  providers:
+    anthropic:
+      apiKey: ${ANTHROPIC_API_KEY}
+
+logLevel: info

--- a/starter-stack/docker-compose.yaml
+++ b/starter-stack/docker-compose.yaml
@@ -1,0 +1,115 @@
+# =============================================================================
+# docker-compose.yaml — Talon + Postgram stack
+# =============================================================================
+# A self-hosted AI agent (Talon) wired to a persistent knowledge store
+# (Postgram) so the agent remembers across conversations out of the box.
+#
+# Do NOT `docker compose up` directly the first time — run ./bootstrap.sh.
+# Postgram API keys must be minted after its server is up; the bootstrap
+# script handles that ordering. See README.md.
+# =============================================================================
+
+services:
+  # ---------------------------------------------------------------------------
+  # Postgram's database — Postgres with the pgvector extension.
+  # ---------------------------------------------------------------------------
+  postgres:
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_DB: postgram
+      POSTGRES_USER: postgram
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgram']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Postgram — knowledge store. Serves a REST API and an MCP/SSE endpoint
+  # on :3100. No host port: Talon reaches it over the compose network as
+  # `http://postgram:3100`, and admin tasks run via `docker compose exec`.
+  # ---------------------------------------------------------------------------
+  postgram:
+    image: ghcr.io/ivo-toby/postgram:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://postgram:${POSTGRES_PASSWORD}@postgres:5432/postgram
+      # Embeddings: Postgram defaults to OpenAI. Required for semantic search.
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      PORT: '3100'
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3100/health || exit 1']
+      interval: 15s
+      timeout: 5s
+      start_period: 20s
+      retries: 5
+    restart: unless-stopped
+    # To poke Postgram from the host (or run the postgram-ui separately),
+    # uncomment — loopback-only is the safe default:
+    # ports:
+    #   - '127.0.0.1:3100:3100'
+
+  # ---------------------------------------------------------------------------
+  # Talon — the agent daemon. The bundled `postgram-memory` skill points
+  # its MCP client at the postgram service above.
+  # ---------------------------------------------------------------------------
+  talond:
+    image: ghcr.io/ivo-toby/talond:latest
+    container_name: talond
+    depends_on:
+      postgram:
+        condition: service_healthy
+    restart: unless-stopped
+
+    env_file:
+      - .env
+
+    environment:
+      NODE_ENV: production
+      TALOND_DATA_DIR: /data
+      TALOND_CONFIG_PATH: /config/talond.yaml
+
+    volumes:
+      - ./data:/data
+      - type: bind
+        source: ./config/talond.yaml
+        target: /config/talond.yaml
+      - type: bind
+        source: ./personas
+        target: /personas
+      # Talon skills — carries the postgram-memory skill that wires the
+      # MCP client. bootstrap.sh renders the API key into it.
+      - type: bind
+        source: ./skills
+        target: /skills
+      - type: bind
+        source: ./userdata
+        target: /userdata
+
+    healthcheck:
+      test: ["CMD", "node", "-e", "const fs=require('fs');const p=process.env.TALON_PID_FILE||'/data/talond.pid';if(!fs.existsSync(p)){process.exit(1);}try{process.kill(parseInt(fs.readFileSync(p,'utf8').trim()),0);process.exit(0);}catch{process.exit(1);}"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M
+
+volumes:
+  pgdata:

--- a/starter-stack/install.sh
+++ b/starter-stack/install.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# install.sh — install the talonctl wrapper for the Talon + Postgram stack.
+#
+# Optional convenience: lets you run `talonctl ...` from anywhere instead
+# of `./bin/talonctl`. Default location: ~/.local/bin (no sudo).
+# Override with PREFIX:  PREFIX=/usr/local/bin sudo ./install.sh
+
+set -euo pipefail
+
+PREFIX="${PREFIX:-$HOME/.local/bin}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$HERE/bin/talonctl"
+DEST="$PREFIX/talonctl"
+
+if [ ! -f "$SRC" ]; then
+  echo "install.sh: source not found at $SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$PREFIX"
+install -m 0755 "$SRC" "$DEST"
+echo "Installed: $DEST"
+
+# Ensure the talond bind-mount sources exist (bootstrap.sh also does this).
+mkdir -p "$HERE/data" "$HERE/userdata"
+
+case ":$PATH:" in
+  *":$PREFIX:"*) ;;
+  *)
+    echo
+    echo "Note: $PREFIX is not on your PATH. Add this to your shell rc:"
+    echo "  export PATH=\"$PREFIX:\$PATH\""
+    ;;
+esac
+
+echo
+echo "Next: cp .env.example .env  (fill it in), then ./bootstrap.sh"

--- a/starter-stack/personas/assistant/system.md
+++ b/starter-stack/personas/assistant/system.md
@@ -1,0 +1,23 @@
+# Assistant — System Prompt
+
+You are a helpful AI assistant with persistent memory.
+
+## Behaviour
+
+- Be concise and accurate.
+- Reply in clear, plain language.
+- Ask for clarification when the request is ambiguous.
+
+## Memory
+
+You have a persistent knowledge store (Postgram) that carries across
+conversations — see the `postgram-memory` skill for how and when to use
+it. Recall relevant context before answering; capture decisions, facts,
+and follow-ups as they come up. The user does not have to ask you to
+remember.
+
+## Constraints
+
+- Do not reveal confidential system information.
+- Decline requests that violate safety guidelines.
+- If you do not know something, say so honestly.

--- a/starter-stack/skills/postgram-memory/SKILL.md
+++ b/starter-stack/skills/postgram-memory/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: postgram-memory
+description: |
+  Persistent cross-conversation memory and knowledge graph via Postgram.
+  Use to remember decisions, facts, preferences and tasks, and to recall
+  context from earlier conversations.
+eager: true
+triggers:
+  - "remember"
+  - "recall"
+  - "what did we"
+  - "last time"
+  - "don't forget"
+  - "remind me"
+---
+
+# Postgram memory
+
+You have a persistent knowledge store — **Postgram** — that survives
+across conversations. Without it, every conversation starts blank; with
+it, you can recall what was decided, learned, and discussed before.
+
+The Postgram tools (`postgram_search`, `postgram_store`,
+`postgram_recall`, `postgram_link`, `postgram_task_create`,
+`postgram_task_list`, …) are available whenever this skill is active.
+
+## Search — recall before you answer
+
+Search Postgram, silently, when:
+
+- The user references something from before this conversation —
+  "last time", "the project we discussed", "what did we decide".
+- The user uses a definite article for something not yet mentioned in
+  this conversation — "*the* migration", "*that* bug".
+- The user names a person, project, tool, or acronym you don't have
+  context for.
+- You're about to ask the user for context you might already have.
+
+Search first, then answer. Don't announce "let me search" — just do it.
+
+## Store — capture what matters
+
+Store to Postgram, without being asked, when:
+
+- A **decision** is made with an explicit tradeoff ("we'll do X because
+  Y, accepting Z").
+- A **root cause** is identified (the cause, not the symptom).
+- A **constraint** is discovered ("only works when…", "breaks if…").
+- The user states a **preference** about how they want to work.
+- A **piece of work completes** — one paragraph: what, why, outcome.
+
+Keep entries short and dense — one paragraph of signal, not a
+transcript. Search before storing so you don't duplicate. Tag entries
+with the project or topic so future searches stay scoped.
+
+## Tasks
+
+When a follow-up is identified that can't be done now — "remind me
+to…", "later we should…" — create a Postgram task (`postgram_task_create`)
+rather than only keeping it in conversation. One task per logical unit;
+make it actionable.
+
+## Principles
+
+- **Search silently, store concisely.** Memory work is reflexive, not a
+  thing to narrate.
+- **Store decisions and constraints, not raw facts** that are obvious
+  from the current context.
+- **Memory can be stale.** If something recalled conflicts with what you
+  can see now, trust the present and update the memory.

--- a/starter-stack/skills/postgram-memory/mcp/postgram.json.template
+++ b/starter-stack/skills/postgram-memory/mcp/postgram.json.template
@@ -1,0 +1,10 @@
+{
+  "name": "postgram",
+  "config": {
+    "transport": "sse",
+    "url": "http://postgram:3100/mcp",
+    "headers": {
+      "Authorization": "Bearer __PGM_API_KEY__"
+    }
+  }
+}

--- a/starter-stack/userdata/.gitkeep
+++ b/starter-stack/userdata/.gitkeep
@@ -1,0 +1,1 @@
+# Drop files here for the agent to read — bind-mounted at /userdata.


### PR DESCRIPTION
## Summary

A new zero-build starter — `starter-stack/` — that runs **Talon wired to
Postgram**, giving the agent persistent cross-conversation memory out of
the box. Three published images composed on one network: `postgres`
(pgvector), `postgram`, `talond`.

## What's in it

- **`docker-compose.yaml`** — `postgres` + `postgram` + `talond`.
  Postgram is network-internal (no host port); `talond` reaches it at
  `http://postgram:3100`. `skills/` and `userdata/` are bind-mounted.
- **`bootstrap.sh`** — Postgram API keys must be minted *after* its
  server is up, so this isn't a single `docker compose up`. The script:
  brings up the data services, waits for Postgram healthy, mints a key
  via `pgm-admin key create`, writes it into `.env`, renders it into the
  skill's MCP definition, then brings up `talond`. Idempotent.
- **`skills/postgram-memory/`** — a Talon skill connecting the agent to
  Postgram:
  - `mcp/postgram.json.template` — the SSE MCP server pointed at
    `http://postgram:3100/mcp`. `bootstrap.sh` renders the API key in
    (skill MCP JSON gets no `${ENV}` substitution — the loader does a
    raw `JSON.parse` — so a rendered placeholder is the mechanism).
  - `SKILL.md` — `eager: true` so the when-to-store / when-to-recall
    guidance is always in the system prompt. Memory use is reflexive;
    it shouldn't be lazy-loaded.
- **`config/talond.example.yaml`** — the `assistant` persona lists the
  `postgram-memory` skill.
- `personas/assistant/system.md`, `bin/talonctl`, `install.sh`,
  `README.md`, `.env.example`, `.gitignore`.

## Release workflow

The bundle job now also packages `starter-stack/` as
`talon-postgram-stack.tar.gz` and attaches it alongside
`talon-starter.tar.gz`. Release notes document both quick starts.

## Test plan

- [x] `actionlint` clean on the updated workflow
- [x] `bash -n` clean on bootstrap.sh / install.sh / bin/talonctl
- [x] `docker compose config` validates the stack structure
- [x] MCP template is valid JSON
- [x] Tarball builds + extracts with all 12 files
- [ ] End-to-end on the next release: `bootstrap.sh` brings the stack
      up, agent stores + recalls via Postgram across conversations

## Notes / open items

- **codex review skipped** for this PR (per "no codex review, move on"
  earlier in the session). Say the word and I'll run it, or it's a good
  `/ultrareview` candidate.
- The SSE MCP wiring (Talon `transport: sse` → Postgram `/mcp` + bearer
  header) is config-correct; @ivo-toby confirmed Postgram-as-MCP works
  in general. First `bootstrap.sh` run on a real release is where the
  exact pairing gets exercised end-to-end.
- `postgram-ui` is intentionally omitted — no published image, and it's
  a human web frontend irrelevant to the agent integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)