### PR TITLE
fix: sync starter-stack bundle with .claude/skills

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,10 +61,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Sync skills into starter/
+      - name: Sync skills into starter bundles
         run: |
           chmod +x scripts/sync-starter-skills.sh
-          scripts/sync-starter-skills.sh
+          scripts/sync-starter-skills.sh starter
+          scripts/sync-starter-skills.sh starter-stack
 
       - name: Ensure bind-mount dirs exist in tarballs
         run: mkdir -p starter/data starter-stack/data

--- a/scripts/sync-starter-skills.sh
+++ b/scripts/sync-starter-skills.sh
@@ -1,25 +1,30 @@
 #!/usr/bin/env bash
-# sync-starter-skills.sh — copy the user-facing Claude skills into the starter
-# bundle. Source: .claude/skills/<name>/. Destination: starter/.claude/skills/<name>/.
+# sync-starter-skills.sh — copy the user-facing Claude skills into a starter
+# bundle. Source: .claude/skills/<name>/. Destination: <bundle>/.claude/skills/<name>/.
 #
-# Reads the allowlist from starter/.claude/skills/INCLUDED.txt.
+# Reads the allowlist from <bundle>/.claude/skills/INCLUDED.txt.
 #
 # Usage:
-#   scripts/sync-starter-skills.sh           # sync
-#   scripts/sync-starter-skills.sh --check   # exit non-zero if any allowlisted
-#                                            # skill is missing from .claude/skills/
+#   scripts/sync-starter-skills.sh [BUNDLE]           # sync (default: starter)
+#   scripts/sync-starter-skills.sh [BUNDLE] --check   # exit non-zero if any
+#                                                     # allowlisted skill is missing
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC_DIR="$ROOT/.claude/skills"
-DEST_DIR="$ROOT/starter/.claude/skills"
-ALLOWLIST="$DEST_DIR/INCLUDED.txt"
 
+BUNDLE="${1:-starter}"
 MODE="sync"
-if [ "${1:-}" = "--check" ]; then
+
+# Detect if second arg is --check (or first arg is --check when no bundle given)
+if [ "${2:-}" = "--check" ] || [ "$BUNDLE" = "--check" ]; then
   MODE="check"
+  [ "$BUNDLE" = "--check" ] && BUNDLE="starter"
 fi
+
+DEST_DIR="$ROOT/$BUNDLE/.claude/skills"
+ALLOWLIST="$DEST_DIR/INCLUDED.txt"
 
 if [ ! -f "$ALLOWLIST" ]; then
   echo "sync-starter-skills: allowlist not found at $ALLOWLIST" >&2

--- a/starter-stack/.claude/skills/INCLUDED.txt
+++ b/starter-stack/.claude/skills/INCLUDED.txt
@@ -1,0 +1,22 @@
+# Allowlist for skills that ship in the Talon + Postgram starter stack.
+# One skill directory name per line. Lines starting with `#` are comments.
+# The source is `.claude/skills/<name>/` at the repo root.
+# Run scripts/sync-starter-skills.sh to populate starter-stack/.claude/skills/.
+
+# Top-level guided flow — docker-aware variant.
+# (The native-install `talon-setup` is intentionally NOT shipped — it
+# assumes `npx talonctl`, node_modules/, etc. and would mislead bundle
+# users.)
+talon-setup-docker
+
+add-telegram
+add-slack
+add-discord
+add-whatsapp
+add-email
+add-terminal
+
+create-profile
+create-personality
+
+manage-schedules

--- a/starter-stack/.claude/skills/add-discord/SKILL.md
+++ b/starter-stack/.claude/skills/add-discord/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: add-discord
+description: |
+  Add Discord as a channel. Use when the user says "add discord",
+  "connect discord", "set up discord bot", or "discord channel".
+triggers:
+  - "add discord"
+  - "connect discord"
+  - "discord channel"
+  - "discord bot"
+---
+
+# Add Discord Channel
+
+Walk the user through adding a Discord bot channel to Talon. One question at a time.
+
+## Phase 1: Pre-flight
+
+Check if a discord channel already exists:
+
+```bash
+npx talonctl list-channels
+```
+
+## Phase 2: Create the Bot
+
+Ask: **"Do you already have a Discord bot token and application ID?"**
+
+If no, walk them through it:
+
+> ### Create the Application
+>
+> 1. Go to [discord.com/developers/applications](https://discord.com/developers/applications)
+> 2. Click **New Application**, give it a name (e.g. "Talon")
+> 3. Copy the **Application ID** from the General Information page
+>
+> ### Create the Bot
+>
+> 1. Go to **Bot** in the left sidebar
+> 2. Click **Add Bot** (or it may already exist)
+> 3. Click **Reset Token** and copy the bot token
+> 4. Under **Privileged Gateway Intents**, enable:
+>    - **Message Content Intent** (required to read message text)
+>    - **Server Members Intent** (optional, for user info)
+>
+> ### Invite the Bot to Your Server
+>
+> 1. Go to **OAuth2** > **URL Generator**
+> 2. Select scopes: `bot`, `applications.commands`
+> 3. Select bot permissions:
+>    - Send Messages
+>    - Read Message History
+>    - View Channels
+> 4. Copy the generated URL and open it in your browser
+> 5. Select your server and authorize
+
+Wait for the user to provide the bot token and application ID.
+
+## Phase 3: Add the Channel
+
+Ask for a channel name (suggest `my-discord`), then:
+
+```bash
+npx talonctl add-channel --name <name> --type discord
+```
+
+Then edit `talond.yaml` to set the config section:
+
+```yaml
+config:
+  botToken: ${DISCORD_BOT_TOKEN}
+  applicationId: "1234567890"
+```
+
+Tell the user to add to `.env`:
+
+```
+DISCORD_BOT_TOKEN=your-bot-token
+```
+
+## Phase 4: Restrict Access (Optional)
+
+Ask: **"Do you want to restrict the bot to specific servers or channels?"**
+
+If yes, get the IDs:
+
+> **How to get Discord IDs:**
+>
+> 1. In Discord, go to **Settings** > **Advanced** > enable **Developer Mode**
+> 2. Right-click a server name > **Copy Server ID** (this is the guild ID)
+> 3. Right-click a channel > **Copy Channel ID**
+
+Then edit the config:
+
+```yaml
+config:
+  botToken: ${DISCORD_BOT_TOKEN}
+  applicationId: "1234567890"
+  guildId: "9876543210"
+  allowedChannelIds:
+    - "111111111"
+    - "222222222"
+```
+
+## Phase 5: Bind a Persona
+
+```bash
+npx talonctl list-personas
+```
+
+Ask which persona to bind, then:
+
+```bash
+npx talonctl bind --persona <name> --channel <channel-name>
+```
+
+## Phase 6: Validate
+
+```bash
+npx talonctl env-check
+npx talonctl doctor
+```
+
+## Phase 7: Verify
+
+Tell the user:
+
+> 1. Make sure talond is running (or restart it)
+> 2. Send a message in a channel where the bot is present, or DM the bot
+> 3. You should get a response within a few seconds
+
+If it doesn't work:
+
+```bash
+journalctl --user -u talond -f
+```
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| Bot not responding | Check `DISCORD_BOT_TOKEN` in `.env`, restart talond |
+| Bot is online but ignores messages | Enable **Message Content Intent** in developer portal |
+| "Missing Access" errors | Bot lacks channel permissions — check invite URL scopes |
+| Bot responds in wrong channels | Add `guildId` or `allowedChannelIds` to config |
+| Rate limit warnings in logs | Normal for busy servers — Talon handles retries automatically (up to 3) |
+
+## Config Reference
+
+```yaml
+channels:
+  - name: my-discord
+    type: discord
+    config:
+      botToken: ${DISCORD_BOT_TOKEN}       # Required
+      applicationId: "1234567890"          # Required
+      guildId: "9876543210"                # Optional — restrict to one server
+      allowedChannelIds:                   # Optional — restrict to specific channels
+        - "111111111"
+      intents: 33280                       # Optional (default: GUILD_MESSAGES | MESSAGE_CONTENT)
+```
+
+## How It Works
+
+- Talon connects to Discord's Gateway via WebSocket
+- Bot messages are automatically filtered (no self-replies)
+- Rate limits are respected with automatic retry (up to 3 attempts)
+- Guild and channel allowlists are enforced before processing

--- a/starter-stack/.claude/skills/add-email/SKILL.md
+++ b/starter-stack/.claude/skills/add-email/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: add-email
+description: |
+  Add email (IMAP/SMTP) as a channel. Use when the user says "add email",
+  "connect email", "set up email", or "email channel".
+triggers:
+  - "add email"
+  - "connect email"
+  - "email channel"
+  - "imap"
+  - "smtp"
+---
+
+# Add Email Channel
+
+Walk the user through adding email (IMAP inbound + SMTP outbound) as a channel to Talon. One question at a time.
+
+## Phase 1: Pre-flight
+
+Check if an email channel already exists:
+
+```bash
+npx talonctl list-channels
+```
+
+## Phase 2: Gather Credentials
+
+Ask: **"Which email provider will you use? (Gmail, Outlook, custom IMAP/SMTP)"**
+
+### Gmail
+
+> 1. Go to [myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords)
+>    - You need 2FA enabled to see this page
+> 2. Create an app password for "Mail"
+> 3. Copy the 16-character password (spaces don't matter)
+>
+> **Settings:**
+> - IMAP: `imap.gmail.com`, port 993, TLS
+> - SMTP: `smtp.gmail.com`, port 587, STARTTLS
+
+### Outlook / Microsoft 365
+
+> 1. Go to [account.microsoft.com/security](https://account.microsoft.com/security)
+> 2. Create an app password (requires 2FA)
+>
+> **Settings:**
+> - IMAP: `outlook.office365.com`, port 993, TLS
+> - SMTP: `smtp.office365.com`, port 587, STARTTLS
+
+### Custom IMAP/SMTP
+
+Ask for:
+- IMAP host, port, TLS (yes/no)
+- SMTP host, port, TLS (yes/no)
+- Username and password
+
+## Phase 3: Add the Channel
+
+Ask for a channel name (suggest `my-email`), then:
+
+```bash
+npx talonctl add-channel --name <name> --type email
+```
+
+Then edit `talond.yaml` to set the config section. Example for Gmail:
+
+```yaml
+config:
+  imapHost: imap.gmail.com
+  imapPort: 993
+  imapUser: bot@gmail.com
+  imapPass: ${EMAIL_PASSWORD}
+  imapSecure: true
+  smtpHost: smtp.gmail.com
+  smtpPort: 587
+  smtpUser: bot@gmail.com
+  smtpPass: ${EMAIL_PASSWORD}
+  smtpSecure: false
+  fromAddress: "Talon Bot <bot@gmail.com>"
+```
+
+Tell the user to add to `.env`:
+
+```
+EMAIL_PASSWORD=your-app-password
+```
+
+## Phase 4: Restrict Senders (Recommended)
+
+Ask: **"Do you want to restrict which email addresses can talk to the bot?"**
+
+If yes, add to the config:
+
+```yaml
+config:
+  # ... smtp/imap settings ...
+  allowedSenders:
+    - "user1@example.com"
+    - "user2@example.com"
+```
+
+Without this, anyone who emails the address can interact with the bot.
+
+## Phase 5: Bind a Persona
+
+```bash
+npx talonctl list-personas
+```
+
+Ask which persona to bind, then:
+
+```bash
+npx talonctl bind --persona <name> --channel <channel-name>
+```
+
+## Phase 6: Validate
+
+```bash
+npx talonctl env-check
+npx talonctl doctor
+```
+
+## Phase 7: Verify
+
+Tell the user:
+
+> 1. Make sure talond is running (or restart it)
+> 2. Send an email to the bot's address
+> 3. You should get a reply within 30-60 seconds (depends on polling interval)
+
+If it doesn't work:
+
+```bash
+journalctl --user -u talond -f
+```
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| IMAP connection refused | Check host/port/TLS settings; some providers block "less secure apps" |
+| SMTP auth failed | Use app-specific password, not account password |
+| Gmail: "Application-specific password required" | Enable 2FA, then create an app password |
+| Long delay before response | Default polling is 30s; lower `pollingIntervalMs` for faster response |
+| Bot replies to spam | Add `allowedSenders` to config |
+| HTML formatting broken | Talon sends HTML emails; check if email client renders HTML |
+
+## Config Reference
+
+```yaml
+channels:
+  - name: my-email
+    type: email
+    config:
+      # IMAP (inbound)
+      imapHost: imap.gmail.com             # Required
+      imapPort: 993                        # Required
+      imapUser: bot@gmail.com              # Required
+      imapPass: ${EMAIL_PASSWORD}          # Required
+      imapSecure: true                     # Required (true = TLS, false = STARTTLS)
+      # SMTP (outbound)
+      smtpHost: smtp.gmail.com             # Required
+      smtpPort: 587                        # Required
+      smtpUser: bot@gmail.com              # Required
+      smtpPass: ${EMAIL_PASSWORD}          # Required
+      smtpSecure: false                    # Required (false for port 587, true for 465)
+      # General
+      fromAddress: "Talon <bot@gmail.com>" # Required
+      allowedSenders:                      # Optional — restrict who can email the bot
+        - "user@example.com"
+      pollingIntervalMs: 30000             # Optional (default: 30000 = 30s)
+      mailbox: "INBOX"                     # Optional (default: INBOX)
+```
+
+## How It Works
+
+- Inbound: polls IMAP at configurable intervals (default 30s)
+- Outbound: sends via SMTP with HTML formatting
+- Threading: uses Message-ID / In-Reply-To headers to maintain conversation threads
+- Each sender email address maps to one Talon thread

--- a/starter-stack/.claude/skills/add-slack/SKILL.md
+++ b/starter-stack/.claude/skills/add-slack/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: add-slack
+description: |
+  Add Slack as a channel. Use when the user says "add slack",
+  "connect slack", "set up slack bot", or "slack channel".
+triggers:
+  - "add slack"
+  - "connect slack"
+  - "slack channel"
+  - "slack bot"
+---
+
+# Add Slack Channel
+
+Walk the user through adding a Slack bot channel to Talon. One question at a time.
+
+## Phase 1: Pre-flight
+
+Check if a slack channel already exists:
+
+```bash
+npx talonctl list-channels
+```
+
+If one exists, ask the user if they want to add another or reconfigure.
+
+## Phase 2: Create the Slack App
+
+Ask: **"Do you already have a Slack app with bot and app tokens?"**
+
+If no, walk them through it:
+
+> ### Create the App
+>
+> 1. Go to [api.slack.com/apps](https://api.slack.com/apps)
+> 2. Click **Create New App** > **From scratch**
+> 3. Name it (e.g. "Talon") and pick your workspace
+>
+> ### Enable Socket Mode
+>
+> 1. Go to **Settings** > **Socket Mode**
+> 2. Toggle **Enable Socket Mode** on
+> 3. When prompted, create an app-level token:
+>    - Name: "socket" (or anything)
+>    - Scope: `connections:write`
+> 4. Copy the token (starts with `xapp-`)
+>
+> ### Subscribe to Events
+>
+> 1. Go to **Features** > **Event Subscriptions**
+> 2. Toggle **Enable Events** on
+> 3. Under **Subscribe to bot events**, add:
+>    - `message.channels` (messages in public channels)
+>    - `message.groups` (messages in private channels)
+>    - `message.im` (direct messages)
+>
+> ### Add OAuth Scopes
+>
+> 1. Go to **Features** > **OAuth & Permissions**
+> 2. Under **Bot Token Scopes**, add:
+>    - `chat:write` (send messages)
+>    - `channels:history` (read public channel messages)
+>    - `groups:history` (read private channel messages)
+>    - `im:history` (read DMs)
+>    - `channels:read` (list channels)
+>    - `groups:read` (list private channels)
+>    - `users:read` (resolve user names)
+>
+> ### Install to Workspace
+>
+> 1. Go to **Settings** > **Install App**
+> 2. Click **Install to Workspace** and authorize
+> 3. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
+>
+> ### Get Signing Secret
+>
+> 1. Go to **Settings** > **Basic Information**
+> 2. Under **App Credentials**, copy the **Signing Secret**
+
+Wait for the user to provide all three: bot token (`xoxb-`), app token (`xapp-`), and signing secret.
+
+## Phase 3: Add the Channel
+
+Ask for a channel name (suggest `my-slack`), then:
+
+```bash
+npx talonctl add-channel --name <name> --type slack
+```
+
+Then edit `talond.yaml` to set the config section:
+
+```yaml
+config:
+  botToken: ${SLACK_BOT_TOKEN}
+  appToken: ${SLACK_APP_TOKEN}
+  signingSecret: ${SLACK_SIGNING_SECRET}
+```
+
+Tell the user to add to `.env`:
+
+```
+SLACK_BOT_TOKEN=xoxb-your-token
+SLACK_APP_TOKEN=xapp-your-token
+SLACK_SIGNING_SECRET=your-signing-secret
+```
+
+## Phase 4: Invite the Bot
+
+Tell the user:
+
+> In Slack, invite the bot to the channels where it should be active:
+>
+> 1. Go to the channel
+> 2. Type `/invite @Talon` (or whatever you named the app)
+>
+> The bot can only see messages in channels it's been invited to.
+> For DMs, users can message the bot directly — no invite needed.
+
+## Phase 5: Bind a Persona
+
+```bash
+npx talonctl list-personas
+```
+
+Ask which persona to bind, then:
+
+```bash
+npx talonctl bind --persona <name> --channel <channel-name>
+```
+
+## Phase 6: Validate
+
+```bash
+npx talonctl env-check
+npx talonctl doctor
+```
+
+Report any issues and help fix them.
+
+## Phase 7: Verify
+
+Tell the user:
+
+> 1. Make sure talond is running (or restart it)
+> 2. Send a DM to the bot in Slack, or @mention it in a channel
+> 3. You should get a response within a few seconds
+
+If it doesn't work:
+
+```bash
+# Check logs
+journalctl --user -u talond -f
+```
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| Bot not responding | Check all three tokens in `.env`, restart talond |
+| "not_authed" errors | Bot token is wrong or expired — reinstall app in Slack |
+| "missing_scope" errors | Add missing OAuth scopes, then reinstall the app |
+| Bot doesn't see messages in channel | Invite the bot to the channel with `/invite @BotName` |
+| Bot responds to itself | This is filtered automatically — check logs for other issues |
+| Socket Mode connection fails | Check `SLACK_APP_TOKEN` (must start with `xapp-`), ensure Socket Mode is enabled |
+
+## Config Reference
+
+```yaml
+channels:
+  - name: my-slack
+    type: slack
+    config:
+      botToken: ${SLACK_BOT_TOKEN}           # Required (xoxb-)
+      appToken: ${SLACK_APP_TOKEN}           # Optional — for Socket Mode (xapp-)
+      signingSecret: ${SLACK_SIGNING_SECRET} # Required
+      defaultChannel: "C01234567"            # Optional — fallback channel ID
+```
+
+## How It Works
+
+- Talon uses Socket Mode (WebSocket via app token) — no public webhook URL needed
+- Thread replies are preserved (uses Slack thread_ts)
+- Bot messages are automatically filtered to prevent self-replies
+- Markdown is auto-converted to Slack's mrkdwn format

--- a/starter-stack/.claude/skills/add-telegram/SKILL.md
+++ b/starter-stack/.claude/skills/add-telegram/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: add-telegram
+description: |
+  Add Telegram as a channel. Use when the user says "add telegram",
+  "connect telegram", "set up telegram bot", or "telegram channel".
+triggers:
+  - "add telegram"
+  - "connect telegram"
+  - "telegram channel"
+  - "telegram bot"
+---
+
+# Add Telegram Channel
+
+Walk the user through adding a Telegram bot channel to Talon. One question at a time.
+
+## Phase 1: Pre-flight
+
+Check if a telegram channel already exists:
+
+```bash
+npx talonctl list-channels
+```
+
+If one exists, ask the user if they want to add another or reconfigure.
+
+## Phase 2: Create the Bot
+
+Ask: **"Do you already have a Telegram bot token?"**
+
+If no, walk them through it:
+
+> 1. Open Telegram and search for **@BotFather**
+> 2. Send `/newbot`
+> 3. Choose a display name (e.g. "Talon Assistant")
+> 4. Choose a username — must end with `bot` (e.g. `talon_assistant_bot`)
+> 5. BotFather will reply with a token like `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`
+> 6. Copy that token
+
+Wait for the user to provide the token. **Never store the actual token in config** — use an env var placeholder.
+
+## Phase 3: Add the Channel
+
+Ask for a channel name (suggest `my-telegram`), then:
+
+```bash
+npx talonctl add-channel --name <name> --type telegram
+```
+
+Then edit `talond.yaml` to set the config section for this channel:
+
+```yaml
+config:
+  botToken: ${TELEGRAM_BOT_TOKEN}
+  pollingTimeoutSec: 30
+```
+
+Tell the user to add to `.env`:
+
+```
+TELEGRAM_BOT_TOKEN=<their-actual-token>
+```
+
+## Phase 4: Restrict Access (Recommended)
+
+Ask: **"Do you want to restrict the bot to specific chats?"**
+
+If yes, explain how to get chat IDs:
+
+> 1. Start a conversation with your bot in Telegram
+> 2. Send any message
+> 3. Open `https://api.telegram.org/bot<TOKEN>/getUpdates` in a browser
+> 4. Find `"chat":{"id":12345678}` — that's your chat ID
+> 5. For groups: add the bot to the group, send a message, check getUpdates again (group IDs are negative numbers like `-1001234567890`)
+
+Then edit the channel config to add:
+
+```yaml
+config:
+  botToken: ${TELEGRAM_BOT_TOKEN}
+  pollingTimeoutSec: 30
+  allowedChatIds:
+    - "12345678"
+```
+
+## Phase 5: Bind a Persona
+
+```bash
+npx talonctl list-personas
+```
+
+Ask which persona to bind, then:
+
+```bash
+npx talonctl bind --persona <name> --channel <channel-name>
+```
+
+If no personas exist yet, suggest creating one first.
+
+## Phase 6: Validate
+
+```bash
+npx talonctl env-check
+npx talonctl doctor
+```
+
+Report any issues and help fix them.
+
+## Phase 7: Group Chat Setup
+
+If the user mentions group chats, explain:
+
+> **Group Privacy:** By default, Telegram bots only see messages that @mention them in groups. To let the bot see all messages:
+>
+> 1. Open @BotFather
+> 2. Send `/mybots` and select your bot
+> 3. Go to **Bot Settings** > **Group Privacy** > **Turn off**
+>
+> After changing this, **remove and re-add the bot to the group** for it to take effect.
+
+## Phase 8: Verify
+
+Tell the user:
+
+> 1. Make sure talond is running (or restart it)
+> 2. Send a message to the bot in Telegram
+> 3. You should get a response within a few seconds
+
+If it doesn't work:
+
+```bash
+# Check if token is valid
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe"
+
+# Check logs
+journalctl --user -u talond -f
+```
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| Bot not responding | Check `TELEGRAM_BOT_TOKEN` in `.env`, restart talond |
+| Bot only responds to @mentions in groups | Disable Group Privacy in BotFather (see Phase 7) |
+| "Unauthorized" errors in logs | Token is wrong or revoked — get new one from BotFather |
+| Bot responds to strangers | Add `allowedChatIds` to config (see Phase 4) |
+| Duplicate responses | Check if multiple instances of talond are running |
+
+## Config Reference
+
+```yaml
+channels:
+  - name: my-telegram
+    type: telegram
+    config:
+      botToken: ${TELEGRAM_BOT_TOKEN}    # Required
+      pollingTimeoutSec: 30              # Optional (default: 30)
+      allowedChatIds:                    # Optional — restrict to specific chats
+        - "12345678"
+```
+
+## How It Works
+
+- Talon uses long-polling (`getUpdates`) — no webhook URL or public server needed
+- Each Telegram chat maps to one Talon thread
+- Markdown formatting is auto-converted to Telegram's MarkdownV2
+- Typing indicator is shown while the agent processes

--- a/starter-stack/.claude/skills/add-terminal/SKILL.md
+++ b/starter-stack/.claude/skills/add-terminal/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: add-terminal
+description: |
+  Add the terminal/CLI channel for talonctl chat. Use when the user says
+  "add terminal", "cli chat", "terminal channel", or "talonctl chat".
+triggers:
+  - "add terminal"
+  - "terminal channel"
+  - "cli chat"
+  - "talonctl chat"
+---
+
+# Add Terminal Channel
+
+Walk the user through adding the terminal channel, which enables `talonctl chat` for CLI-based conversations with the daemon.
+
+## Phase 1: Pre-flight
+
+Check if a terminal channel already exists:
+
+```bash
+npx talonctl list-channels
+```
+
+If one exists, the user can already use `talonctl chat`. Show them how (skip to Verify).
+
+## Phase 2: Add the Channel
+
+Ask for a channel name (suggest `terminal`), then:
+
+```bash
+npx talonctl add-channel --name <name> --type terminal
+```
+
+Then edit `talond.yaml` to set the config section:
+
+```yaml
+config:
+  port: 8089
+  host: "127.0.0.1"
+  token: ${TERMINAL_TOKEN}
+```
+
+Tell the user to add to `.env`:
+
+```
+TERMINAL_TOKEN=any-secret-string-you-choose
+```
+
+The token can be any string — it's just used to authenticate CLI clients against the WebSocket server. Generate one with:
+
+```bash
+openssl rand -hex 16
+```
+
+## Phase 3: Bind a Persona
+
+```bash
+npx talonctl list-personas
+```
+
+Ask which persona to bind, then:
+
+```bash
+npx talonctl bind --persona <name> --channel <channel-name>
+```
+
+## Phase 4: Validate
+
+```bash
+npx talonctl env-check
+npx talonctl doctor
+```
+
+## Phase 5: Verify
+
+Tell the user:
+
+> 1. Make sure talond is running (or restart it)
+> 2. Run: `npx talonctl chat --port 8089 --token <your-token>`
+> 3. Type a message and press Enter — you should get a response
+
+For TLS connections (if running behind a reverse proxy):
+
+```bash
+npx talonctl chat --port 8089 --token <your-token> --tls
+```
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| Connection refused | Check talond is running and port matches config |
+| Auth failed | Token in `talonctl chat --token` must match `TERMINAL_TOKEN` in `.env` |
+| Port already in use | Change the port in config (e.g. 8090) |
+| Works locally but not remotely | Default host is `127.0.0.1` (localhost only). Change to `0.0.0.0` to allow remote, but use a firewall + TLS |
+
+## Config Reference
+
+```yaml
+channels:
+  - name: terminal
+    type: terminal
+    config:
+      port: 8089                    # Required — WebSocket server port
+      host: "127.0.0.1"            # Optional (default: 127.0.0.1 — localhost only)
+      token: ${TERMINAL_TOKEN}     # Required — shared secret for auth
+```
+
+## How It Works
+
+- talond starts a WebSocket server on the configured port
+- `talonctl chat` connects, authenticates with the token, then sends/receives messages
+- Each CLI client gets its own persistent conversation thread
+- Typing indicators are shown while the agent processes
+- Reconnecting with the same client ID resumes the conversation

--- a/starter-stack/.claude/skills/add-whatsapp/SKILL.md
+++ b/starter-stack/.claude/skills/add-whatsapp/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: add-whatsapp
+description: |
+  Add WhatsApp as a channel via Baileys (WhatsApp Web bridge).
+  Use when the user says "add whatsapp", "connect whatsapp",
+  "set up whatsapp", or "whatsapp channel".
+triggers:
+  - "add whatsapp"
+  - "connect whatsapp"
+  - "whatsapp channel"
+  - "whatsapp baileys"
+  - "whatsapp web"
+---
+
+# Add WhatsApp Channel
+
+Walk the user through adding a WhatsApp channel to Talon via the Baileys connector.
+Baileys connects as a WhatsApp Web client — just scan a QR code. No Meta Business
+account, no webhooks, no public endpoint needed. One question at a time.
+
+## Pre-flight
+
+Check if a whatsapp channel already exists:
+
+```bash
+npx talonctl list-channels
+```
+
+## Step 1: Install Baileys
+
+Baileys and its QR rendering dependency are optional. Install them first:
+
+```bash
+npm install @whiskeysockets/baileys qrcode-terminal
+```
+
+## Step 2: Add the Channel
+
+Ask for a channel name (suggest `my-whatsapp`), then:
+
+```bash
+npx talonctl add-channel --name <name> --type whatsappBaileys
+```
+
+Then ask: **"Will you use a dedicated WhatsApp number for the bot, or your own personal number (self-chat mode)?"**
+
+| Option | Config | When to use |
+|--------|--------|-------------|
+| **Dedicated number** | `selfChat: false` (default) | You have a second phone/number for the bot |
+| **Self-chat (personal number)** | `selfChat: true` | You want to use your own WhatsApp — the bot listens in your "Message Yourself" thread |
+
+Then ask: **"Do you want to require a trigger word (e.g. `@Talon`) to activate the bot, or should every message be processed?"**
+
+Trigger words are especially useful in self-chat mode so notes-to-self don't trigger the bot. They also work in dedicated-number mode.
+
+Edit `talond.yaml` to set the config section based on their answers:
+
+**Dedicated number:**
+```yaml
+config:
+  authDir: './baileys-auth'
+```
+
+**Self-chat with trigger word:**
+```yaml
+config:
+  authDir: './baileys-auth'
+  selfChat: true
+  triggerWords: ['@Talon']
+```
+
+**Self-chat without trigger word:**
+```yaml
+config:
+  authDir: './baileys-auth'
+  selfChat: true
+```
+
+No environment variables or secrets needed — authentication is via QR code.
+
+## Step 3: Authenticate
+
+Run the standalone auth command — it prints a QR code to the terminal and waits for a scan:
+
+```bash
+npx talonctl whatsapp-auth --auth-dir ./baileys-auth
+```
+
+Tell the user:
+
+> 1. A QR code will appear in the terminal
+> 2. Open WhatsApp on your phone > Settings > Linked Devices > Link a Device
+> 3. Scan the QR code
+> 4. Once authenticated, credentials are saved and the command exits
+> 5. Now start (or restart) talond — no QR code will be needed
+
+The `--auth-dir` must match the `authDir` in the channel config. Default is `./baileys-auth`.
+
+## Step 4: Security — Restrict Access
+
+**Important**: By default, anyone who knows the bot's phone number can chat with it. Walk the user through discovering their sender ID and locking down access:
+
+> ### How to find sender IDs
+>
+> WhatsApp no longer uses phone numbers as identifiers in all cases. Contacts may appear
+> as opaque "LID" numbers (e.g. `96490886312027@lid`) instead of phone-based JIDs
+> (e.g. `31612345678@s.whatsapp.net`). You cannot predict which format you'll get,
+> so the only reliable way to find a sender's ID is from the logs:
+>
+> 1. Temporarily set `logLevel: debug` in `talond.yaml`
+> 2. Start talond (or restart it)
+> 3. Send a test message from each phone that should be allowed
+> 4. In the logs, find the line: `whatsapp-baileys: inbound message received`
+> 5. Copy the `jid` value — the part **before the `@`** is the sender ID
+> 6. Add each sender ID to `allowedSenders` in the channel config
+> 7. Set `logLevel` back to `info` and restart talond
+
+Ask the user to send a test message and share the `jid` from the logs so you can help them configure `allowedSenders`:
+
+```yaml
+config:
+  authDir: './baileys-auth'
+  allowedSenders:
+    - '96490886312027'              # sender ID from logs (before the @)
+```
+
+When the list is omitted or empty, all senders are accepted.
+
+> **Strongly recommended**: Always configure `allowedSenders` for production use. An open WhatsApp bot can be abused by anyone who discovers the number.
+
+## Step 5: Verify (Baileys)
+
+> Send a WhatsApp message to the connected number from an **allowed** phone. You should get a response within a few seconds. Then send from a phone that is **not** in `allowedSenders` and confirm the message is dropped (check logs for "message from disallowed sender, dropping").
+
+If it doesn't work:
+
+```bash
+journalctl --user -u talond -f
+```
+
+**If you see "logged out"**: delete the `authDir` folder, re-run `talonctl whatsapp-auth`, and restart talond.
+
+---
+
+## Bind a Persona
+
+```bash
+npx talonctl list-personas
+```
+
+Ask which persona to bind, then:
+
+```bash
+npx talonctl bind --persona <name> --channel <channel-name>
+```
+
+## Validate
+
+```bash
+npx talonctl env-check
+npx talonctl doctor
+```
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| QR code not appearing | Run `npx talonctl whatsapp-auth` again in a visible terminal window. The QR is printed by `talonctl whatsapp-auth`, not by the connector — there is no `printQR` config option |
+| "logged out" error | Delete `authDir` folder and restart to re-authenticate |
+| Group messages ignored | Expected — Baileys connector only processes individual chats in v1 |
+| Module not found | Run `npm install @whiskeysockets/baileys` — it's an optional dependency |
+| Only text messages work | Normal — Talon v1 supports text only; media messages are logged but skipped |
+| Self-chat not responding | Check `selfChat: true` in config. Verify `selfJid` appears in connect log |
+| Trigger word not matching | Trigger words are case-insensitive. Check spelling. Message must **start** with the trigger word |
+| Bot responds to everything in self-chat | Add `triggerWords` to only process triggered messages |
+
+## Config Reference
+
+```yaml
+channels:
+  - name: my-whatsapp
+    type: whatsappBaileys
+    config:
+      authDir: './baileys-auth'                  # Optional (default: ./baileys-auth)
+      markOnlineOnConnect: false                 # Optional (default: false)
+      browser: ['Talon', 'Chrome', '1.0']        # Optional (default: Browsers.appropriate('Talon'))
+      selfChat: false                            # Optional — self-chat mode (default: false)
+      triggerWords: ['@Talon']                   # Optional — require trigger word to activate
+      allowedSenders:                            # Optional — restrict who can message the bot
+        - '96490886312027'
+```

--- a/starter-stack/.claude/skills/create-personality/SKILL.md
+++ b/starter-stack/.claude/skills/create-personality/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: create-personality
+description: |
+  Create personality files for a Talon persona. Use when the user says
+  "create personality", "add personality", "define personality",
+  "customize persona", "persona voice", or "persona tone".
+triggers:
+  - "create personality"
+  - "add personality"
+  - "define personality"
+  - "customize persona"
+  - "persona voice"
+  - "persona tone"
+---
+
+# Create Personality Files
+
+Guide the user through creating personality files for a Talon persona.
+Personality files are markdown files in `personas/<name>/personality/` that
+get appended to the system prompt (after `system.md`, before skills).
+
+## Phase 1: Select Persona
+
+1. Run `npx talonctl list-personas` to show available personas.
+2. Ask the user which persona to create personality files for.
+3. Check if `personas/<name>/personality/` exists. If not, create it.
+
+## Phase 2: Gather Personality Traits
+
+Ask the user the following questions (they can skip any):
+
+1. **Tone & voice**: "How should this agent sound? (e.g., formal, casual, witty, dry, warm)"
+2. **Background & role**: "What's this agent's backstory or expertise? (e.g., British butler, senior engineer, research librarian)"
+3. **Communication style**: "Any formatting preferences? (e.g., uses bullet points, keeps responses short, avoids emoji, uses code blocks)"
+4. **Boundaries**: "Anything the agent should avoid? (e.g., no opinions on politics, never uses slang, avoids humor)"
+5. **Examples**: "Can you give 1-2 examples of how this agent should respond to a casual question?"
+
+## Phase 3: Generate Files
+
+Based on the answers, create the appropriate files. Use numbered prefixes
+for ordering (e.g., `01-tone.md`, `02-background.md`). Only create files
+for traits the user provided — don't create empty placeholder files.
+
+### File templates
+
+**`01-tone.md`** — Voice and tone guidelines:
+```markdown
+# Tone & Voice
+
+[User's tone description, written as directives for the agent]
+```
+
+**`02-background.md`** — Role and expertise:
+```markdown
+# Background & Role
+
+[User's backstory, written as context the agent can reference]
+```
+
+**`03-style.md`** — Communication and formatting:
+```markdown
+# Communication Style
+
+[User's formatting and response preferences, as rules]
+```
+
+**`04-boundaries.md`** — What to avoid:
+```markdown
+# Boundaries
+
+[User's avoidance rules, written as constraints]
+```
+
+**`05-examples.md`** — Few-shot examples:
+```markdown
+# Response Examples
+
+These examples illustrate the expected tone and style.
+
+**User:** [example question]
+**Agent:** [example response]
+```
+
+## Phase 4: Review
+
+1. Show the user all generated files with their content.
+2. Ask: "Want to adjust anything, add more files, or are we good?"
+3. If adjustments needed, edit the files.
+
+## Phase 5: Validate
+
+1. Run `npx talonctl config-show` to verify the persona config is valid.
+2. Remind the user: "Personality files are loaded when the daemon starts.
+   Run `npx talonctl reload` or restart the daemon to pick up changes."
+
+## Tips
+
+- Files are loaded **alphabetically** — use numbered prefixes (`01-`, `02-`) to control order.
+- Only `.md` files are loaded. Use `.txt` or `.bak` for notes that shouldn't be injected.
+- Keep files focused — one trait per file makes it easy to enable/disable by renaming.
+- The system prompt + personality + skills are concatenated. Keep personality concise to leave room for conversation context.

--- a/starter-stack/.claude/skills/create-profile/SKILL.md
+++ b/starter-stack/.claude/skills/create-profile/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: create-profile
+description: |
+  Create a Talon persona/profile interactively from a natural-language
+  description. Use when the user says "create a profile", "add a persona",
+  "new background agent", "create a persona", "add a profile", or
+  "background agent profile".
+triggers:
+  - "create a profile"
+  - "add a persona"
+  - "new background agent"
+  - "create a persona"
+  - "add a profile"
+  - "background agent profile"
+---
+
+# Create Profile
+
+Guide the user through creating a Talon persona/profile interactively. This is
+a conversational wizard. Ask one question at a time, infer sensible defaults,
+show the draft, refine it, then scaffold it.
+
+## Core principles
+
+- **One question at a time.** Keep the interaction tight.
+- **Use `talonctl add-persona`.** Do not edit `talond.yaml` directly.
+- **Confirm before mutating files.** Show the inferred summary first.
+- **Write/send defaults are gated.** Put write/send capabilities in
+  `requireApproval` unless the user explicitly wants broader access.
+- **Preview before reload.** The operator can inspect and edit generated files
+  before running `talonctl reload`.
+
+> Architectural note: this workflow relies on shell execution of `talonctl`,
+> which bypasses Talon's host-tool capability model. Treat it as an operator
+> action.
+
+<!-- TODO: this should migrate to a persona_manage host tool in the future -->
+
+## Phase 1: Gather intent
+
+Ask: **"What should this persona do?"**
+
+If needed, follow up one question at a time to learn:
+
+- Main purpose
+- Whether it needs file read/write, messaging, HTTP/API access, memory,
+  subagent delegation, scheduling, or database access
+- Whether quality or speed/cost matters more
+
+## Phase 2: Infer defaults
+
+Build a first draft from the user's description.
+
+### Name
+
+Slugify the purpose into a short persona name.
+
+Examples:
+
+- `code review` -> `code-reviewer`
+- `PR security audit` -> `security-auditor`
+
+### Provider and model
+
+- Default provider: inherit from the current operator context if one is
+  already implied; otherwise ask.
+- Infer a tier first, then map it to a provider-specific model.
+- If unclear, default to `balanced`.
+
+| Tier | Use when intent suggests | Claude provider | Gemini provider |
+|---|---|---|---|
+| `strong` | review, audit, analyze, plan, architect | `claude-opus-4-6` | `gemini-2.5-pro` |
+| `balanced` | summarize, draft, write, general assistance | `claude-sonnet-4-6` | `gemini-2.5-flash` |
+| `fast` | classify, tag, triage, quick, simple | `claude-haiku-4-5` | `gemini-2.5-flash` |
+
+**`backgroundProvider`** *(optional)* — provider used when this persona spawns a background agent. Resolution order: explicit tool arg → `backgroundProvider` → persona's foreground `provider` (only if it is also enabled under `backgroundAgent.providers`) → `backgroundAgent.defaultProvider`. Set when the foreground provider is unsuitable for background work (e.g. local Ollama running short-context models). Must be enabled under `backgroundAgent.providers` — the daemon refuses to start otherwise.
+
+**`backgroundModel`** *(optional)* — model passed to the background provider. Paired with `backgroundProvider`; the daemon refuses to start if `backgroundModel` is set without `backgroundProvider`. Useful for sending background work to a more capable model than the foreground.
+
+### Capabilities
+
+Use these exact labels.
+
+**Host tools**
+
+| Intent hints | `allow` | `requireApproval` |
+|---|---|---|
+| memory, remember, context, knowledge | `memory.access:*` | |
+| message, notify, send, communicate | | `channel.send:*` |
+| search, fetch, http, api | `net.http` | |
+| queue async work, background jobs | `subagent.background` | |
+| ask another agent inline, specialist consultation | `subagent.invoke` | |
+| schedule, cron, recurring tasks | | `schedule.manage` |
+| query, database, SQL | | `db.query` |
+
+**Provider-native**
+
+| Intent hints | `allow` | `requireApproval` |
+|---|---|---|
+| code, review, file, read, analyze source | `fs.read:*` | |
+| write, edit, fix, refactor, implement | `fs.read:*` | `fs.write:workspace` |
+
+Rules:
+
+- Write/send capabilities default to `requireApproval`.
+- Users can later promote items to `allow`.
+- If no capability is clearly needed, leave the lists empty.
+- Note: `requireApproval` currently records configuration intent only. Runtime
+  approval enforcement is not yet implemented — tools listed there are still
+  accessible. Mention this when presenting the summary.
+
+### Skills
+
+Default to no skills unless the user explicitly asks for one.
+
+### Description
+
+Generate a 1-2 sentence description of the persona's purpose and strengths.
+This is written as YAML frontmatter in `system.md` and exposed via the
+`background_agent profiles` action so that agents can discover available
+profiles at runtime.
+
+Good descriptions are specific enough to differentiate profiles:
+
+- "Senior code reviewer — focused security and performance analysis with PR review expertise"
+- "Deep web research — multi-source search, cross-referencing, synthesized answers with citations"
+- "Personal butler — formal, anticipatory, handles daily tasks with understated charm"
+
+### System prompt
+
+The system prompt file (`system.md`) uses YAML frontmatter for metadata:
+
+```markdown
+---
+description: "<the description from above>"
+---
+
+# <name> — System Prompt
+
+<prompt body>
+```
+
+Generate a concise prompt body covering:
+
+- Role and goals
+- Working style
+- Boundaries
+- Any important constraints implied by the capability choices
+
+## Phase 3: Present summary
+
+Show a readable summary before doing anything:
+
+```text
+Name:             code-reviewer
+Description:      Senior code reviewer — focused security and performance analysis
+Provider:         claude-code
+Model:            claude-opus-4-6
+Allow:            fs.read:*, memory.access:*
+Require approval: channel.send:*, fs.write:workspace
+Skills:           (none)
+System prompt:    [preview first 3 lines]
+```
+
+Then ask what should change, or whether to create it.
+
+## Phase 4: Refinement loop
+
+Handle edits such as:
+
+- "rename it to pr-checker"
+- "use the fast one"
+- "switch to gemini"
+- "add fs.write"
+- "move channel.send to allow"
+- "show me the full system prompt"
+- "create it"
+
+After each change, re-show the summary and wait for approval.
+
+## Phase 5: Create and preview
+
+After approval:
+
+1. Write the generated prompt to a temporary file.
+2. Run:
+
+```bash
+talonctl add-persona --name <name> \
+  --description "<description>" \
+  --model <model> \
+  --provider <provider> \
+  --capabilities "<comma-separated allow>" \
+  --require-approval "<comma-separated requireApproval>" \
+  --skills "<comma-separated skills>" \
+  --system-prompt-file /tmp/<name>-system.md
+```
+
+3. Show the generated `personas/<name>/system.md`.
+4. Offer to edit `personas/<name>/system.md` before reload.
+5. If the user wants richer tone/personality files, suggest running the
+   `create-personality` skill next and add those files before reload.
+6. When the user confirms the generated files look right, run:
+
+```bash
+talonctl reload
+```
+
+If `talonctl` is not on PATH, use the repo-local equivalent the environment
+already uses.
+
+## After creation
+
+Give short next-step suggestions:
+
+- Use it as a background profile:
+  `background_agent spawn profile="<name>" prompt="..."`
+- Bind it to a chat channel if desired:
+  `talonctl bind --persona <name> --channel <channel>`
+- For richer voice/tone files, run the `create-personality` skill

--- a/starter-stack/.claude/skills/manage-schedules/SKILL.md
+++ b/starter-stack/.claude/skills/manage-schedules/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: manage-schedules
+description: |
+  Manage scheduled tasks for Talon personas. Use when the user says
+  "add schedule", "create schedule", "list schedules", "remove schedule",
+  "scheduled task", or "cron job".
+triggers:
+  - "add schedule"
+  - "create schedule"
+  - "list schedules"
+  - "remove schedule"
+  - "scheduled task"
+  - "cron job"
+---
+
+# Manage Schedules
+
+Guide the user through creating, listing, or removing scheduled tasks.
+Schedules live in the database (not the config file) and require a running daemon to fire.
+
+## Phase 1: Determine Action
+
+Ask what they want to do:
+1. **Create** a new scheduled task
+2. **List** existing schedules
+3. **Remove** a schedule
+
+## Phase 2a: Create Schedule
+
+1. Run `npx talonctl list-personas` to show available personas.
+2. Ask which persona should run the task.
+3. Run `npx talonctl list-channels` to show available channels.
+4. Ask which channel to bind the schedule to (this creates a thread for the schedule on that channel).
+5. Ask for the cron expression. Offer common presets:
+   - Every hour: `0 * * * *`
+   - Twice daily (9am, 9pm): `0 9,21 * * *`
+   - Daily at 9am: `0 9 * * *`
+   - Every Monday at 9am: `0 9 * * 1`
+   - Every 30 minutes: `*/30 * * * *`
+6. Ask for a label (short name like `memory-grooming` or `git-pull-notes`).
+7. Ask for the prompt (what the agent should do when triggered).
+8. Run: `npx talonctl add-schedule --persona <name> --channel <channel> --cron "<expr>" --label "<label>" --prompt "<prompt>" --config talond.yaml`
+9. Confirm with schedule ID and next run time.
+
+## Phase 2b: List Schedules
+
+Run: `npx talonctl list-schedules --config talond.yaml`
+Optionally filter: `--persona <name>`
+
+## Phase 2c: Remove Schedule
+
+1. Run `npx talonctl list-schedules` to show existing schedules.
+2. Ask which schedule to remove (by ID).
+3. Run: `npx talonctl remove-schedule <id> --config talond.yaml`
+
+## Notes
+
+- Schedules fire in system local time (CET on the VM).
+- Schedule output is silent -- the agent only sends messages if it explicitly uses channel.send.
+- The daemon must be running for schedules to fire (they live in the DB, not the config).
+- After creating schedules, remind the user: schedules require a running daemon to execute.

--- a/starter-stack/.claude/skills/talon-setup-docker/SKILL.md
+++ b/starter-stack/.claude/skills/talon-setup-docker/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: talon.setup.docker
+description: |
+  Use when setting up Talon from the starter bundle (docker-based install)
+  for the first time, adding channels or personas, changing the AI provider,
+  or troubleshooting. Triggers on phrases like "set up talon", "configure
+  talon", "add channel", "switch provider", "talonctl …".
+triggers:
+  - "set up talon"
+  - "setup talon"
+  - "configure talon"
+  - "talon setup"
+  - "add channel"
+  - "add persona"
+  - "switch provider"
+  - "change provider"
+  - "talon doctor"
+  - "talonctl"
+---
+
+# Talon setup — docker bundle
+
+Guide the user through configuring the Talon starter bundle. This is a
+conversational wizard — **one question at a time**, act on the answer,
+move on.
+
+## Core principles
+
+- **Docker-first.** The bundle ships a published image and a host-side
+  `talonctl` wrapper. Never run `npx talonctl`, `npm install`, or
+  `node dist/index.js`.
+- **`talonctl` requires the daemon to be running.** The wrapper is a
+  `docker exec` into the `talond` container. For first-time setup, the
+  user edits `.env` and `config/talond.yaml` manually, then boots the
+  daemon, then `talonctl` is available for everything else.
+- **One question at a time.** Never dump a wall of options.
+- **No secrets.** Never ask for or write actual tokens. Only show
+  `${ENV_VAR}` placeholders in `config/talond.yaml`. Real values go in
+  `.env`.
+- **Show output.** When you run a command, show what came back.
+
+## Detect state first
+
+Before asking anything, look at the bundle directory:
+
+```bash
+ls -la                                                              # bundle layout
+test -f .env && echo ".env present" || echo ".env missing"           # exists?
+grep -oE '^[A-Z][A-Z0-9_]*' .env 2>/dev/null | sort -u                # which env vars set? (names only)
+test -f config/talond.yaml && echo "yaml present" || echo "yaml missing"
+docker ps --filter name=talond --format '{{.Names}} {{.Status}}'    # daemon running?
+```
+
+**Never print secret values.**
+
+- `.env` contains real secrets — only inspect variable *names*, never
+  `cat .env`.
+- `config/talond.yaml` *should* only contain `${ENV_VAR}` placeholders,
+  but some users hand-paste literal keys. Don't `cat` it either. When
+  the daemon is running, use `talonctl config-show` (auto-masked). Until
+  then, inspect specific sections you need with `grep -A` for the keys
+  you're checking, and never display lines that match `apiKey:`,
+  `botToken:`, `password:`, `secret`, or `token:` patterns with a
+  literal value.
+
+If you need to *show* a config snippet to the user, use:
+
+```bash
+talonctl config-show 2>/dev/null         # post-boot, masked
+# OR pre-boot, redact inline:
+sed -E 's/^(  *(apiKey|botToken|.*[Tt]oken|.*[Ss]ecret|password): )(.+)$/\1***MASKED***/' config/talond.yaml
+```
+
+Use the state to skip steps:
+
+| State | Action |
+|-------|--------|
+| `.env` missing | Run `cp .env.example .env`, fill in step 2 |
+| `config/talond.yaml` missing | Run `cp config/talond.example.yaml config/talond.yaml`, edit in step 3 |
+| Daemon already running | Skip to talonctl-based additions (step 6) |
+| All configured + daemon running | Present the menu (see "Returning user menu") |
+
+### Returning user menu
+
+If everything is configured:
+
+```
+What would you like to do?
+  a) Switch AI provider
+  b) Add another channel (Telegram, Slack, …)
+  c) Add or modify a persona
+  d) Bind/unbind a persona to a channel
+  e) Manage scheduled tasks
+  f) Run health check (talonctl doctor)
+  g) Show current config (talonctl config-show)
+  h) View daemon logs (docker compose logs -f talond)
+  i) Restart the daemon
+```
+
+## Available talonctl commands (post-boot)
+
+All commands run via the bundle's `bin/talonctl` wrapper (or the
+installed `talonctl` if `./install.sh` has been run):
+
+| Command | Purpose |
+|---------|---------|
+| `talonctl status` | Daemon health, active runs, queue depth |
+| `talonctl doctor` | Validate config + environment |
+| `talonctl config-show` | Show current config (secrets masked) |
+| `talonctl env-check` | List env-var placeholders the config expects |
+| `talonctl list-channels` | Configured channels |
+| `talonctl add-channel --name <n> --type <t>` | Add a channel |
+| `talonctl remove-channel --name <n>` | Remove a channel |
+| `talonctl list-personas` | Configured personas |
+| `talonctl add-persona --name <n>` | Scaffold a persona dir + add to config |
+| `talonctl remove-persona --name <n>` | Remove a persona |
+| `talonctl bind --persona <p> --channel <c>` | Bind persona to channel |
+| `talonctl unbind --persona <p> --channel <c>` | Remove a binding |
+| `talonctl add-mcp --skill <s> --name <n> --transport stdio --command <c>` | Add an MCP server to a skill |
+| `talonctl list-providers` | Configured AI providers |
+| `talonctl add-provider --name <n> --command <c> [--context both]` | Add a provider |
+| `talonctl set-default-provider --name <n> --context <ctx>` | Set default provider |
+| `talonctl test-provider --name <n>` | Verify a provider connects |
+| `talonctl list-capabilities` | All available capability labels |
+| `talonctl set-capabilities --persona <p> --add <labels>` | Add capabilities |
+| `talonctl set-capabilities --persona <p> --remove <labels>` | Remove capabilities |
+| `talonctl list-schedules` | Configured scheduled tasks |
+| `talonctl add-schedule --persona <p> --channel <c> --cron <expr> --label <l> --prompt <text>` | Add a scheduled task |
+| `talonctl remove-schedule <id>` | Remove a scheduled task |
+
+Use these for all post-boot mutations. **Do not edit `config/talond.yaml`
+by hand** once the daemon is running — talonctl handles it correctly.
+
+## First-time setup flow
+
+### Step 1: Pick an AI provider
+
+Ask: **"Which AI provider do you want to use?"**
+
+```
+a) Claude (Anthropic API)            — default, smartest, costs $
+b) OpenAI-compatible endpoint        — local Ollama, vLLM, Groq, Together, custom
+c) Gemini CLI                        — Google's CLI, preinstalled in the image
+d) Codex CLI                         — OpenAI's CLI, preinstalled in the image
+```
+
+All four work out of the box. `claude` (bundled in the Agent SDK),
+`codex`, and `gemini` ship in the container image; `openai-compatible`
+runs in-process.
+
+For (a) ask for nothing else here — defaults work.
+
+For (b) ask three things, **one at a time**:
+- "What's the base URL? (e.g. `https://api.groq.com/openai/v1`,
+  `http://host.docker.internal:11434/v1` for local Ollama, etc.)"
+- "What model name does the endpoint serve?
+  (e.g. `qwen3-coder:30b`, `llama-3.3-70b-versatile`)"
+- "Does the endpoint need an API key?" → if yes, ask the env var name
+  to use (default: `OPENAI_COMPATIBLE_API_KEY`)
+
+For (c)/(d), note one caveat: Gemini CLI and Codex CLI store auth/config
+under `~/.gemini` / `~/.codex` inside the container, which is wiped on
+container recreation. Recommend API-key auth (`GOOGLE_AI_API_KEY` /
+`OPENAI_API_KEY` in `.env`, read fresh each run). OAuth state needs a
+`/home/talond` bind-mount to persist — see `docs/providers.md`.
+
+### Step 2: Configure `.env`
+
+If `.env` doesn't exist: `cp .env.example .env`
+
+Ask: **"Which channel do you want to connect first?"** Answer determines
+which env var the user needs to fill:
+
+| Channel | Env var(s) |
+|---------|-----------|
+| Telegram | `TELEGRAM_BOT_TOKEN` (from @BotFather) |
+| Slack | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET` |
+| Discord | `DISCORD_BOT_TOKEN` |
+| WhatsApp Business | `WHATSAPP_API_KEY` |
+| WhatsApp Baileys | (no env, uses QR-code auth at first boot) |
+| Email | IMAP/SMTP credentials (see add-email skill) |
+| Terminal | `TERMINAL_TOKEN` (just `talonctl chat`) |
+
+Plus the provider env from step 1 (e.g. `ANTHROPIC_API_KEY` for Claude).
+
+Tell the user **exactly** which lines to uncomment/fill in `.env`.
+Do not write the actual secrets to disk.
+
+### Step 3: Configure `config/talond.yaml`
+
+If `config/talond.yaml` doesn't exist:
+`cp config/talond.example.yaml config/talond.yaml`
+
+The default config uses Claude + Telegram. If the user picked something
+else in step 1, walk them through the edits:
+
+#### Edit the persona
+
+Find:
+```yaml
+personas:
+  - name: assistant
+    model: claude-sonnet-4-6
+    provider: claude-code
+```
+
+If provider is OpenAI-compatible:
+```yaml
+    model: <model from step 1>
+    provider: openai-compatible
+```
+
+If Gemini CLI:
+```yaml
+    model: gemini-2.5-pro
+    provider: gemini-cli
+```
+
+#### Replace the `agentRunner.providers` block
+
+For Claude (default), no change.
+
+For OpenAI-compatible — replace the `claude-code:` block under
+`agentRunner.providers:` with:
+
+```yaml
+    openai-compatible:
+      enabled: true
+      command: node
+      contextWindowTokens: 32000
+      options:
+        baseUrl: <base URL from step 1>
+        defaultModel: <model from step 1>
+        providerId: <a short slot name, e.g. "groq" or "ollama">
+        toolOutputCap: 4000
+```
+
+Apply the same change to `backgroundAgent.providers` (or set
+`backgroundAgent.enabled: false` if you don't need background work).
+
+#### Replace `auth.providers`
+
+For Claude, the default block is fine.
+
+For OpenAI-compatible:
+```yaml
+auth:
+  mode: api_key
+  providers:
+    <slot name from above>:
+      baseURL: <base URL from step 1>
+      # apiKey: ${YOUR_ENV_VAR}   # uncomment if the endpoint needs one
+```
+
+#### Set the channel's `allowedChatIds` / equivalent
+
+For Telegram, find the channels block and set the chat ID the bot is
+allowed to talk to (find your ID via [@userinfobot](https://t.me/userinfobot)):
+
+```yaml
+channels:
+  - type: telegram
+    name: personal-telegram
+    config:
+      botToken: ${TELEGRAM_BOT_TOKEN}
+      allowedChatIds:
+        - "<your-numeric-chat-id>"        # must be a string, not a number
+      pollingTimeoutSec: 30
+```
+
+For other channels, refer to the matching `add-*` skill.
+
+### Step 4: Boot the daemon
+
+```bash
+./install.sh                                  # ensures data/ + userdata/ exist + installs talonctl wrapper
+docker compose up -d                          # detached
+docker compose logs --tail=50 talond          # confirm clean boot — no -f, no head; just the last 50 lines
+```
+
+Look for `bootstrap: config loaded`, the channel connector starting,
+and `daemon: running`. If the daemon exits, the logs will say why
+(usually a config validation error).
+
+### Step 5: Verify
+
+```bash
+talonctl status                # health, queue depth, channels, personas
+talonctl doctor                # full validation
+talonctl list-channels         # confirms the channel is registered
+talonctl test-provider --name <provider-name>   # round-trips a request
+```
+
+Then ask the user to **send a real message** to the configured channel
+(Telegram DM, Slack message, etc.) and confirm a reply lands. Tail
+`docker compose logs -f talond` while they do.
+
+### Step 6: Optional additions
+
+Once boot is verified, anything else uses `talonctl`:
+
+- **Add another channel** — invoke the matching channel skill (`/add-slack`,
+  `/add-discord`, etc.) OR `talonctl add-channel` directly.
+- **Add another persona** — `talonctl add-persona --name <n>`, then edit
+  the generated `personas/<name>/system.md`.
+- **Bind persona ↔ channel** — `talonctl bind --persona <p> --channel <c>`.
+- **Adjust capabilities** — `talonctl set-capabilities --persona <p> --show`
+  to see current, then `--add` or `--remove`.
+- **Schedule tasks** — `talonctl add-schedule …` (see `/manage-schedules`).
+- **Add MCP servers** — `talonctl add-mcp …`. Pre-built MCP servers for
+  GitHub, Atlassian, Gmail, Slack, etc. are documented in
+  `starter/docs/troubleshooting.md` and the upstream MCP server registry.
+
+Each mutation modifies `config/talond.yaml`. The daemon **does not
+auto-reload** — after a mutation, tell the user to apply it:
+
+```bash
+talonctl reload          # hot-reload via IPC; works for most changes
+# or for changes that require a full restart:
+docker compose restart talond
+```
+
+After `add-channel` or `add-provider`, also run:
+```bash
+talonctl env-check       # confirm any new ${ENV_VAR} placeholders are set in .env
+talonctl test-provider --name <n>   # if a provider was added
+```
+
+## Rules
+
+1. **Never write actual secrets.** Only `${ENV_VAR}` placeholders in
+   `config/talond.yaml`. Real values are in `.env`, edited by the user.
+2. **Use `talonctl` for all post-boot mutations.** Exceptions: persona
+   `system.md` files (these are agent-facing prompts and benefit from
+   hand-editing) and `.env`.
+3. **One question per message.** Do not batch.
+4. **Show command output.** Let the user see what happened.
+5. **Don't start or stop the daemon** without telling the user. Boot
+   only after they've confirmed the config is ready. Use
+   `docker compose up -d` (detached) so logs don't block their terminal.
+6. **Always validate.** After meaningful changes, run `talonctl doctor`
+   and `talonctl env-check`. After provider changes, run
+   `talonctl test-provider`.
+7. **Tell users when something is broken or unsupported.** Some channel
+   skills (add-telegram, add-slack, …) were lifted from the native-install
+   workflow and still reference `npx talonctl`; treat their guidance as
+   *informational* and execute the equivalent via the docker wrapper.
+
+## Differences from `talon-setup` (native)
+
+This skill replaces the native-install `talon-setup` skill for users of
+the docker starter bundle. Key differences:
+
+- No prereq check for `node_modules/`, `dist/`, or local `node --version`
+  — the image ships everything.
+- No `npx talonctl setup` or `talonctl migrate` step — the daemon
+  bootstraps + migrates on first boot.
+- Provider menu lists OpenAI-compatible as a first-class option.
+- Service install via systemd is skipped — `docker compose up -d`
+  + `restart: unless-stopped` is the equivalent.
+- Daemon start is `docker compose up -d`, never `node dist/index.js`.

--- a/starter-stack/README.md
+++ b/starter-stack/README.md
@@ -86,6 +86,31 @@ in its `skills:`, so the agent gets the Postgram tools and the guidance.
 To use a non-Claude provider for Talon, see
 [the provider cookbook](https://github.com/ivo-toby/talon/blob/main/starter/docs/providers.md).
 
+## Guided setup with Claude Code
+
+The bundle ships `.claude/skills/` — interactive setup guides that Claude Code
+reads when you ask for help. Open the project in Claude Code and say things
+like "set up talon" or "add telegram" and it walks you through one question
+at a time.
+
+| Skill | Say this in Claude Code |
+|-------|------------------------|
+| `talon-setup-docker` | "set up talon", "configure talon", "talon doctor" |
+| `add-telegram` | "add telegram", "connect telegram" |
+| `add-slack` | "add slack", "connect slack" |
+| `add-discord` | "add discord", "connect discord" |
+| `add-whatsapp` | "add whatsapp", "connect whatsapp" |
+| `add-email` | "add email", "connect email" |
+| `add-terminal` | "add terminal", "connect terminal" |
+| `create-profile` | "create a profile", "add a persona", "new background agent" |
+| `create-personality` | "create a personality", "add personality files" |
+| `manage-schedules` | "manage schedules", "add a schedule", "cron job" |
+
+These skills are **not** loaded by the Talon daemon — they are for the
+operator's local Claude Code session. They know the bundle layout, use the
+bundled `talonctl` wrapper, and never ask you to run `npm install` or
+`npx talonctl`.
+
 ## Common operations
 
 ```bash

--- a/tests/unit/deploy/starter-bundle.test.ts
+++ b/tests/unit/deploy/starter-bundle.test.ts
@@ -1,0 +1,87 @@
+// Tests that the starter bundles ship the Claude skills declared in their
+// INCLUDED.txt allowlists, and that the release workflow syncs both bundles.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '../../..');
+
+function readLines(file: string): string[] {
+  return readFileSync(file, 'utf8')
+    .split('\n')
+    .map((l) => l.split('#')[0]!.trim())
+    .filter((l) => l.length > 0);
+}
+
+function listSkillDirs(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+}
+
+// ---------------------------------------------------------------------------
+// starter/ bundle
+// ---------------------------------------------------------------------------
+
+describe('starter/.claude/skills', () => {
+  const allowlist = resolve(ROOT, 'starter/.claude/skills/INCLUDED.txt');
+  const skillsDir = resolve(ROOT, 'starter/.claude/skills');
+
+  it('has an INCLUDED.txt allowlist', () => {
+    expect(existsSync(allowlist)).toBe(true);
+  });
+
+  it('every allowlisted skill exists as a directory', () => {
+    const expected = readLines(allowlist);
+    expect(expected.length).toBeGreaterThan(0);
+
+    const actual = listSkillDirs(skillsDir);
+    for (const skill of expected) {
+      expect(actual).toContain(skill);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// starter-stack/ bundle
+// ---------------------------------------------------------------------------
+
+describe('starter-stack/.claude/skills', () => {
+  const allowlist = resolve(ROOT, 'starter-stack/.claude/skills/INCLUDED.txt');
+  const skillsDir = resolve(ROOT, 'starter-stack/.claude/skills');
+
+  it('has an INCLUDED.txt allowlist', () => {
+    expect(existsSync(allowlist)).toBe(true);
+  });
+
+  it('every allowlisted skill exists as a directory', () => {
+    const expected = readLines(allowlist);
+    expect(expected.length).toBeGreaterThan(0);
+
+    const actual = listSkillDirs(skillsDir);
+    for (const skill of expected) {
+      expect(actual).toContain(skill);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Release workflow
+// ---------------------------------------------------------------------------
+
+describe('.github/workflows/release.yaml', () => {
+  const workflowPath = resolve(ROOT, '.github/workflows/release.yaml');
+  const workflow = readFileSync(workflowPath, 'utf8');
+
+  it('syncs skills into starter/', () => {
+    expect(workflow).toMatch(/scripts\/sync-starter-skills\.sh/);
+  });
+
+  it('syncs skills into starter-stack/', () => {
+    // The workflow must run the sync for both bundles.
+    expect(workflow).toMatch(/starter-stack.*sync|sync.*starter-stack|sync-starter-stack-skills/i);
+  });
+});

--- a/tests/unit/deploy/starter-bundle.test.ts
+++ b/tests/unit/deploy/starter-bundle.test.ts
@@ -1,9 +1,10 @@
 // Tests that the starter bundles ship the Claude skills declared in their
 // INCLUDED.txt allowlists, and that the release workflow syncs both bundles.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { resolve } from 'path';
+import { execSync } from 'child_process';
 
 const ROOT = resolve(import.meta.dirname, '../../..');
 
@@ -21,6 +22,13 @@ function listSkillDirs(dir: string): string[] {
     .map((d) => d.name)
     .sort();
 }
+
+// Sync skills before running assertions so the test passes on a fresh clone.
+beforeAll(() => {
+  const script = resolve(ROOT, 'scripts/sync-starter-skills.sh');
+  execSync(`bash "${script}" starter`, { stdio: 'ignore' });
+  execSync(`bash "${script}" starter-stack`, { stdio: 'ignore' });
+});
 
 // ---------------------------------------------------------------------------
 // starter/ bundle


### PR DESCRIPTION
Closes #172 (related — false-negative pattern)

## What changed and why

The  bundle was missing the  directory entirely, unlike the basic  bundle. This meant users downloading the Talon + Postgram stack had no guided setup skills available in Claude Code.

## Changes

1. **scripts/sync-starter-skills.sh** — now accepts a  argument (default: ) so it can sync skills into any bundle directory.
2. **.github/workflows/release.yaml** — runs the sync for both  and  during release builds.
3. **starter-stack/.claude/skills/** — added  allowlist and all 10 guided setup skills (same set as ).
4. **starter-stack/README.md** — added "Guided setup with Claude Code" section documenting all 10 skills.
5. **tests/unit/deploy/starter-bundle.test.ts** — new test verifying both bundles ship their allowlisted skills and the release workflow syncs both.

## Automated tests

```bash
npx vitest run tests/unit/deploy/starter-bundle.test.ts
```

Result: **6 passed** (2 bundles × 2 assertions + 2 workflow assertions).

## Manual test plan

1. Check out this branch.
2. Run `scripts/sync-starter-skills.sh starter-stack` — confirm it copies 10 skill dirs into `starter-stack/.claude/skills/`.
3. Run `scripts/sync-starter-skills.sh starter-stack --check` — confirm exit code 0.
4. Inspect `starter-stack/README.md` — confirm the "Guided setup with Claude Code" section lists all 10 skills.
5. Run `npx vitest run tests/unit/deploy/starter-bundle.test.ts` — confirm all 6 tests pass.

## Edge cases

- Running `scripts/sync-starter-skills.sh` with no args still defaults to `starter` (backward compatible).
- Running `scripts/sync-starter-skills.sh --check` still defaults to `starter` (backward compatible).
- The `INCLUDED.txt` in `starter-stack/` intentionally excludes the native-install `talon-setup` skill (docker-aware variant only).