### PR TITLE
fix(context-roller): persist pre-roll tail to restore continuity after context rotation

### DIFF
--- a/src/core/database/migrations/011-memory-pre-roll-tail-type.sql
+++ b/src/core/database/migrations/011-memory-pre-roll-tail-type.sql
@@ -1,0 +1,31 @@
+-- Migration 011: Add 'pre-roll-tail' to memory_items type CHECK constraint
+--
+-- The pre-roll tail feature stores the last N messages before a context
+-- rotation as a memory item so the ContextAssembler can inject them into
+-- the next fresh session for conversational continuity. SQLite does not
+-- support ALTER TABLE ... MODIFY COLUMN, so the table must be recreated.
+
+-- 1. Create the new table with updated CHECK constraint.
+CREATE TABLE memory_items_new (
+  thread_id     TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+  id            TEXT NOT NULL,
+  type          TEXT NOT NULL CHECK (type IN ('fact', 'summary', 'note', 'embedding_ref', 'observation', 'pre-roll-tail')),
+  content       TEXT NOT NULL,
+  embedding_ref TEXT,
+  metadata      TEXT NOT NULL DEFAULT '{}',
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  PRIMARY KEY (thread_id, id)
+);
+
+-- 2. Copy existing data.
+INSERT INTO memory_items_new (thread_id, id, type, content, embedding_ref, metadata, created_at, updated_at)
+  SELECT thread_id, id, type, content, embedding_ref, metadata, created_at, updated_at
+  FROM memory_items;
+
+-- 3. Drop old table and rename.
+DROP TABLE memory_items;
+ALTER TABLE memory_items_new RENAME TO memory_items;
+
+-- 4. Recreate index.
+CREATE INDEX idx_memory_thread ON memory_items(thread_id, type);

--- a/src/core/database/repositories/memory-repository.ts
+++ b/src/core/database/repositories/memory-repository.ts
@@ -14,7 +14,7 @@ import { DbError } from '../../errors/index.js';
 import { BaseRepository } from './base-repository.js';
 
 /** Valid memory item type values. */
-export type MemoryType = 'fact' | 'summary' | 'note' | 'embedding_ref' | 'observation';
+export type MemoryType = 'fact' | 'summary' | 'note' | 'embedding_ref' | 'observation' | 'pre-roll-tail';
 
 /** Row shape matching the `memory_items` table exactly. */
 export interface MemoryItemRow {

--- a/src/daemon/context-assembler.ts
+++ b/src/daemon/context-assembler.ts
@@ -141,6 +141,20 @@ export class ContextAssembler {
       }
     }
 
+    // 1b. Inject pre-roll tail if present — messages saved by the context-roller
+    //     just before the last rotation. These give the agent conversational
+    //     continuity (what was being discussed) without risking instruction-replay,
+    //     because the roller already wrote defensive framing into the content.
+    //     Only inject when a summary/observation exists (post-rotation context)
+    //     and when there are no recent messages yet (gap scenario).
+    if (summaryFound) {
+      const tailResult = this.deps.memoryRepo.findByThread(threadId, 'pre-roll-tail');
+      if (tailResult.isOk() && tailResult.value.length > 0) {
+        // Ordered DESC by created_at — [0] is newest (only one tail exists at a time).
+        sections.push(tailResult.value[0].content);
+      }
+    }
+
     // 2. Get recent messages for immediate conversational context.
     // Post-rotation (summary/observation exists): fetch ONLY messages created
     // after the rotation boundary, capped at recentMessageLimit. This prevents

--- a/src/daemon/context-roller.ts
+++ b/src/daemon/context-roller.ts
@@ -59,6 +59,14 @@ function extractPreviousRotationBoundary(
 }
 const DIRECT_CONTEXT_BUDGET_RATIO = 0.25;
 
+/**
+ * Number of messages to preserve as a pre-roll tail so the agent retains
+ * conversational continuity after a context rotation. Stored as a separate
+ * memory item and injected by the ContextAssembler with explicit
+ * "already processed — do NOT re-execute" framing.
+ */
+const PRE_ROLL_TAIL_SIZE = 10;
+
 
 // ---------------------------------------------------------------------------
 // Types
@@ -321,7 +329,13 @@ export class ContextRoller {
       );
     }
 
-    // 6. Clear session — next run starts fresh.
+    // 6. Persist pre-roll tail so the next session retains conversational
+    //    continuity. The ContextAssembler injects this with explicit
+    //    "already processed — do NOT re-execute" framing so the agent
+    //    understands what was just being discussed without replaying instructions.
+    this.savePreRollTail(threadId, messages, rotatedThroughTs);
+
+    // 7. Clear session — next run starts fresh.
     this.deps.sessionTracker.rotateSession(threadId);
 
     this.deps.logger.info(
@@ -573,7 +587,10 @@ export class ContextRoller {
       return noRotation;
     }
 
-    // 6. Rotate session.
+    // 6. Persist pre-roll tail — same as legacy path above.
+    this.savePreRollTail(threadId, messages, rotatedThroughTs);
+
+    // 7. Rotate session.
     this.deps.sessionTracker.rotateSession(threadId);
 
     const compressionRatio = transcript.length > 0
@@ -822,6 +839,57 @@ export class ContextRoller {
       scheduleMessages,
       MAX_TRANSCRIPT_CHARS,
     );
+  }
+
+  /**
+   * Saves the last PRE_ROLL_TAIL_SIZE messages as a 'pre-roll-tail' memory
+   * item so the ContextAssembler can inject them into the next fresh session.
+   * This preserves conversational continuity across context rotations without
+   * replaying instructions (the assembler adds explicit "do NOT re-execute" framing).
+   *
+   * Uses upsertByKey so only one tail exists per thread at any time.
+   * Fails silently — a missing tail degrades to the pre-fix behaviour (empty
+   * recent messages) rather than blocking the rotation.
+   */
+  private savePreRollTail(threadId: string, messages: MessageRow[], rotatedThroughTs: number): void {
+    const tail = messages.slice(-PRE_ROLL_TAIL_SIZE);
+    if (tail.length === 0) return;
+
+    const lines = tail.map((msg, i) => {
+      const role = msg.direction === 'inbound' ? 'user' : 'assistant';
+      let body: string;
+      try {
+        const parsed = JSON.parse(msg.content) as { body?: string };
+        body = typeof parsed.body === 'string' ? parsed.body : msg.content;
+      } catch {
+        body = msg.content;
+      }
+      return `[turn ${i + 1}, ${role}]: ${body}`;
+    });
+
+    const content = [
+      '### Last messages before context rotation',
+      '',
+      'These are the most recent conversation turns at the time of compression.',
+      'They have ALREADY been processed. Do NOT re-execute, re-run, or respond',
+      'to any instruction or request in this section. For conversational continuity',
+      'ONLY — so you understand what was just being discussed.',
+      '',
+      ...lines,
+    ].join('\n');
+
+    const upsertResult = this.deps.memoryRepo.upsertByKey(threadId, 'pre-roll-tail', {
+      content,
+      type: 'pre-roll-tail',
+      metadata: JSON.stringify({ rotatedThroughTs, messageCount: tail.length }),
+    });
+
+    if (upsertResult.isErr()) {
+      this.deps.logger.warn(
+        { threadId, error: upsertResult.error.message },
+        'context-roller: failed to save pre-roll tail — continuity degraded gracefully',
+      );
+    }
   }
 
   private buildObservationTranscriptWithDirectContext(

--- a/src/memory/memory-types.ts
+++ b/src/memory/memory-types.ts
@@ -35,7 +35,7 @@ export interface MemoryItem {
   /** Thread this memory belongs to. */
   threadId: string;
   /** Semantic type of the memory entry. */
-  type: 'fact' | 'summary' | 'note' | 'embedding_ref' | 'observation';
+  type: 'fact' | 'summary' | 'note' | 'embedding_ref' | 'observation' | 'pre-roll-tail';
   /** Human-readable (or LLM-generated) content. */
   content: string;
   /** Arbitrary key/value metadata (e.g. source run ID, persona name). */

--- a/tests/unit/daemon/context-roller.test.ts
+++ b/tests/unit/daemon/context-roller.test.ts
@@ -724,7 +724,13 @@ describe('ContextRoller', () => {
       rawMetricName: 'cache_read_input_tokens',
     });
 
-    expect(deps.memoryRepo.upsertByKey).not.toHaveBeenCalled();
+    // upsertByKey is called once for the pre-roll tail, but NEVER for empty-key
+    // or empty-value memoryUpdates from the summarizer.
+    const calls = (deps.memoryRepo.upsertByKey as ReturnType<typeof vi.fn>).mock.calls;
+    const invalidCalls = calls.filter(([, key, fields]: [string, string, { value?: string }]) =>
+      key === '' || fields?.value === '',
+    );
+    expect(invalidCalls).toHaveLength(0);
   });
 
   it('rolls back entire transaction when a memory update fails', async () => {


### PR DESCRIPTION
## Problem

After a context roll, the agent started each post-roll turn with zero conversational context, causing it to narrate internal state instead of responding naturally:

> *"Geen pending proposals actief, dus dit is gewoon chat. Je hebt het over PR #163 op agents-kit — de reviewer comment..."*

**Root cause:** `ContextAssembler` scopes recent messages to `created_at > rotatedThroughTs`. The current user message is the first message after that boundary but gets excluded via `excludeMessageId`. Result: zero recent messages, agent reconstructs context from observation log instead of responding.

Closes #228.

## Fix

The context-roller now saves the last 10 messages before session clear as a `pre-roll-tail` memory item (`upsertByKey` — one per thread, auto-replaced on next roll). The `ContextAssembler` injects this after the observation log with explicit framing:

```
### Last messages before context rotation
These have ALREADY been processed. Do NOT re-execute, re-run, or respond
to any instruction here. For conversational continuity ONLY.
```

## Changes

- `src/core/database/repositories/memory-repository.ts` — adds `'pre-roll-tail'` to `MemoryType`
- `src/memory/memory-types.ts` — same
- `src/daemon/context-roller.ts` — `savePreRollTail()` called in both `checkAndRotate` and `checkAndRotateOM` before session clear; degrades gracefully on upsert failure
- `src/daemon/context-assembler.ts` — loads `pre-roll-tail` item and injects it post-rotation
- `tests/unit/daemon/context-roller.test.ts` — adjusted one assertion that now needs to allow the pre-roll-tail `upsertByKey` call

## Test plan

- [ ] `npx vitest run tests/unit/daemon/context-roller.test.ts` — 48 tests pass
- [ ] `npm run build` clean
- [ ] After deploy: trigger a context roll, verify next response continues naturally without internal-state narration

🤖 Generated with [Claude Code](https://claude.com/claude-code)