### PR TITLE
security: authenticate host-tools bridge requests

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -68,6 +68,11 @@ const DEFAULT_DATA_DIR = 'data';
 /** Subdirectories to create under dataDir. */
 const DATA_SUBDIRS = ['ipc', path.join('ipc', 'daemon'), 'backups', 'threads'];
 
+function getExplicitDatabaseDirectory(dbPath: string): string | null {
+  const dbDir = path.normalize(path.dirname(dbPath));
+  return dbDir === '.' ? null : dbDir;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -326,12 +331,14 @@ export async function runDatabaseMigrations(
 
   const dbPath = configResult.value.storage.path;
 
-  // Ensure the directory containing the database exists.
-  const dbDir = path.dirname(dbPath);
-  try {
-    await ensureOwnerOnlyDir(dbDir);
-  } catch {
-    // Ignore — directory may already exist.
+  const dbDir = getExplicitDatabaseDirectory(dbPath);
+
+  if (dbDir !== null) {
+    try {
+      await ensureOwnerOnlyDir(dbDir);
+    } catch {
+      // Ignore — directory may already exist.
+    }
   }
 
   const dbResult = createDatabase(dbPath);
@@ -340,7 +347,10 @@ export async function runDatabaseMigrations(
       name: 'Database migrations',
       status: 'failed',
       message: `Failed to open database "${dbPath}": ${dbResult.error.message}`,
-      hint: `Ensure the directory "${dbDir}" exists and is writable.`,
+      hint:
+        dbDir === null
+          ? 'Ensure the current working directory is writable.'
+          : `Ensure the directory "${dbDir}" exists and is writable.`,
     };
   }
 

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -29,6 +29,7 @@ import writeFileAtomic from 'write-file-atomic';
 import { loadConfigFromString } from '../../core/config/config-loader.js';
 import { createDatabase } from '../../core/database/connection.js';
 import { runMigrations } from '../../core/database/migrations/runner.js';
+import { ensureOwnerOnlyDir } from '../../core/fs/private-paths.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -218,7 +219,7 @@ export async function createDataDirectories(dataDir: string): Promise<SetupCheck
       continue;
     }
     try {
-      await fs.mkdir(dir, { recursive: true });
+      await ensureOwnerOnlyDir(dir);
       created.push(dir);
     } catch (cause) {
       return {
@@ -328,7 +329,7 @@ export async function runDatabaseMigrations(
   // Ensure the directory containing the database exists.
   const dbDir = path.dirname(dbPath);
   try {
-    await fs.mkdir(dbDir, { recursive: true });
+    await ensureOwnerOnlyDir(dbDir);
   } catch {
     // Ignore — directory may already exist.
   }

--- a/src/core/fs/private-paths.ts
+++ b/src/core/fs/private-paths.ts
@@ -1,0 +1,19 @@
+import { chmodSync, mkdirSync } from 'node:fs';
+import fs from 'node:fs/promises';
+
+export const OWNER_ONLY_DIR_MODE = 0o700;
+export const OWNER_ONLY_FILE_MODE = 0o600;
+
+export async function ensureOwnerOnlyDir(path: string): Promise<void> {
+  await fs.mkdir(path, { recursive: true, mode: OWNER_ONLY_DIR_MODE });
+  await fs.chmod(path, OWNER_ONLY_DIR_MODE);
+}
+
+export function ensureOwnerOnlyDirSync(path: string): void {
+  mkdirSync(path, { recursive: true, mode: OWNER_ONLY_DIR_MODE });
+  chmodSync(path, OWNER_ONLY_DIR_MODE);
+}
+
+export async function ensureOwnerOnlyFile(path: string): Promise<void> {
+  await fs.chmod(path, OWNER_ONLY_FILE_MODE);
+}

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -25,6 +25,10 @@ import type {
   CanonicalMcpServer,
 } from '../providers/provider-types.js';
 import type { StartedObservationHandle } from '../observability/langfuse/observability-types.js';
+import {
+  generateBridgeSecret,
+  TALOND_BRIDGE_SECRET_ENV,
+} from '../tools/host-tools-bridge-auth.js';
 
 /** Default maximum time (ms) a provider query (SDK or CLI) may run before being aborted. */
 const DEFAULT_QUERY_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -236,6 +240,13 @@ export class AgentRunner {
 
     const content = typeof item.payload.content === 'string' ? item.payload.content : '';
     let runFinalized = false;
+    const bridgeSecret = generateBridgeSecret();
+    this.ctx.hostToolsBridge.registerRunAuthentication?.({
+      runId,
+      threadId: item.threadId,
+      personaId,
+      bridgeSecret,
+    });
 
     const runInput = {
       content,
@@ -569,6 +580,7 @@ export class AgentRunner {
                       args: [join(import.meta.dirname, '../../dist/tools/host-tools-mcp-server.js')],
                       env: {
                         ...process.env,
+                        [TALOND_BRIDGE_SECRET_ENV]: bridgeSecret,
                         TALOND_SOCKET: this.ctx.hostToolsBridge.path,
                         TALOND_RUN_ID: runId,
                         TALOND_THREAD_ID: item.threadId,
@@ -596,6 +608,7 @@ export class AgentRunner {
                       args: [join(import.meta.dirname, '../../dist/tools/skill-loader-mcp-server.js')],
                       env: {
                         ...process.env,
+                        [TALOND_BRIDGE_SECRET_ENV]: bridgeSecret,
                         TALOND_SOCKET: this.ctx.hostToolsBridge.path,
                         TALOND_RUN_ID: runId,
                         TALOND_THREAD_ID: item.threadId,
@@ -1135,6 +1148,8 @@ export class AgentRunner {
         });
       }
       return err(error);
+    } finally {
+      this.ctx.hostToolsBridge.unregisterRunAuthentication?.(runId);
     }
   }
 

--- a/src/daemon/daemon-bootstrap.ts
+++ b/src/daemon/daemon-bootstrap.ts
@@ -716,6 +716,7 @@ export async function bootstrap(
   } as Omit<DaemonContext, 'hostToolsBridge'> & { hostToolsBridge?: HostToolsBridge };
 
   const hostToolsBridge = new HostToolsBridge(partialCtx as DaemonContext);
+  backgroundAgentManager?.setHostToolsBridge(hostToolsBridge);
   partialCtx.hostToolsBridge = hostToolsBridge;
   const ctx = partialCtx as DaemonContext;
 

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -30,6 +30,7 @@ import type { DaemonState, DaemonHealth } from './daemon-types.js';
 import { DaemonIpcServer } from '../ipc/daemon-ipc-server.js';
 import type { DaemonCommand, DaemonResponse } from '../ipc/daemon-ipc.js';
 import type { TalondConfig } from '../core/config/config-types.js';
+import { ensureOwnerOnlyDir } from '../core/fs/private-paths.js';
 
 // ---------------------------------------------------------------------------
 // TalondDaemon
@@ -126,6 +127,11 @@ export class TalondDaemon {
 
     // 8. Start IPC server.
     const ipcBase = join(this.ctx.dataDir, 'ipc/daemon');
+    await Promise.all([
+      ensureOwnerOnlyDir(join(ipcBase, 'input')),
+      ensureOwnerOnlyDir(join(ipcBase, 'output')),
+      ensureOwnerOnlyDir(join(ipcBase, 'errors')),
+    ]);
     this.ipcServer = new DaemonIpcServer({
       inputDir: join(ipcBase, 'input'),
       outputDir: join(ipcBase, 'output'),

--- a/src/ipc/daemon-ipc-client.ts
+++ b/src/ipc/daemon-ipc-client.ts
@@ -13,6 +13,7 @@ import writeFileAtomic from 'write-file-atomic';
 
 import { DaemonResponseSchema } from './daemon-ipc.js';
 import type { DaemonCommand, DaemonCommandType, DaemonResponse } from './daemon-ipc.js';
+import { ensureOwnerOnlyDir } from '../core/fs/private-paths.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -98,7 +99,7 @@ export class DaemonIpcClient {
   async send(command: DaemonCommand): Promise<DaemonResponse | null> {
     // --- Write command ---
     try {
-      await fs.mkdir(this.opts.inputDir, { recursive: true });
+      await ensureOwnerOnlyDir(this.opts.inputDir);
       const paddedTs = String(Date.now()).padStart(15, '0');
       const cleanId = command.id.replace(/-/g, '');
       const filename = `${paddedTs}-${cleanId}.json`;

--- a/src/ipc/daemon-ipc-server.ts
+++ b/src/ipc/daemon-ipc-server.ts
@@ -19,6 +19,7 @@ import type pino from 'pino';
 
 import { DaemonCommandSchema } from './daemon-ipc.js';
 import type { DaemonCommand, DaemonResponse } from './daemon-ipc.js';
+import { ensureOwnerOnlyDir } from '../core/fs/private-paths.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -242,7 +243,7 @@ export class DaemonIpcServer {
    */
   private async writeResponse(response: DaemonResponse): Promise<void> {
     try {
-      await fs.mkdir(this.opts.outputDir, { recursive: true });
+      await ensureOwnerOnlyDir(this.opts.outputDir);
 
       const paddedTs = String(Date.now()).padStart(15, '0');
       const cleanId = response.id.replace(/-/g, '');
@@ -270,7 +271,7 @@ export class DaemonIpcServer {
     reason: string,
   ): Promise<void> {
     try {
-      await fs.mkdir(this.opts.errorsDir, { recursive: true });
+      await ensureOwnerOnlyDir(this.opts.errorsDir);
 
       const basename = path.basename(filepath);
       const destPath = path.join(this.opts.errorsDir, basename);

--- a/src/subagents/background/background-agent-manager.ts
+++ b/src/subagents/background/background-agent-manager.ts
@@ -21,6 +21,11 @@ import type { ObservabilityService, StartedObservationHandle } from '../../obser
 import type { ExecutionEnvManager } from '../../execution-env/execution-env-manager.js';
 import type { OAuthTokenStore } from '../../auth/oauth-token-store.js';
 import { resolveMcpServers } from '../../mcp/resolve-mcp-servers.js';
+import type { HostToolsBridge } from '../../tools/host-tools-bridge.js';
+import {
+  generateBridgeSecret,
+  TALOND_BRIDGE_SECRET_ENV,
+} from '../../tools/host-tools-bridge-auth.js';
 
 export interface SpawnBackgroundAgentInput {
   prompt: string;
@@ -68,6 +73,7 @@ interface BackgroundAgentManagerDeps {
   observability?: ObservabilityService;
   executionEnvManager?: Pick<ExecutionEnvManager, 'create' | 'upload' | 'destroyOwnedByTask'> | null;
   hostToolsSocketPath?: string;
+  hostToolsBridge?: Pick<HostToolsBridge, 'registerRunAuthentication' | 'unregisterRunAuthentication'>;
   /**
    * Token store used to materialize `Authorization: Bearer …` headers on
    * HTTP MCP servers that declare `auth: { kind: 'oauth2' }`. Optional so
@@ -117,6 +123,12 @@ export class BackgroundAgentManager {
         return null;
       }
     });
+  }
+
+  setHostToolsBridge(
+    hostToolsBridge: Pick<HostToolsBridge, 'registerRunAuthentication' | 'unregisterRunAuthentication'>,
+  ): void {
+    (this.deps as { hostToolsBridge?: typeof hostToolsBridge }).hostToolsBridge = hostToolsBridge;
   }
 
   async spawn(input: SpawnBackgroundAgentInput): Promise<Result<string, BackgroundAgentError>> {
@@ -203,6 +215,7 @@ export class BackgroundAgentManager {
       : undefined;
 
     const childTraceparent = observation?.getTraceparent() ?? undefined;
+    const bridgeSecret = generateBridgeSecret();
 
     const systemPrompt = this.buildSystemPrompt({
       personaPrompt: input.personaPrompt,
@@ -231,6 +244,7 @@ export class BackgroundAgentManager {
       threadId: input.threadId,
       workerPersonaId: input.workerPersonaId,
       allowedMcpTools: input.allowedMcpTools,
+      bridgeSecret,
       ...(input.workingDirectory ? { workingDirectory: input.workingDirectory } : {}),
       traceparent: childTraceparent,
       sandboxContext,
@@ -272,7 +286,7 @@ export class BackgroundAgentManager {
 
     const createResult = this.deps.repository.create({
       id: taskId,
-      personaId: input.personaId,
+      personaId: input.workerPersonaId,
       providerName: providerEntry.provider.name,
       threadId: input.threadId,
       channelId: input.channelId,
@@ -321,8 +335,16 @@ export class BackgroundAgentManager {
       timeoutMs: invocation.timeoutMs,
     });
 
+    this.deps.hostToolsBridge?.registerRunAuthentication({
+      runId: taskId,
+      threadId: input.threadId,
+      personaId: input.workerPersonaId,
+      bridgeSecret,
+    });
+
     const startResult = processInstance.start();
     if (startResult.isErr()) {
+      this.deps.hostToolsBridge?.unregisterRunAuthentication(taskId);
       observation?.end();
       this.deps.repository.updateStatus(taskId, 'failed', undefined, startResult.error.message);
       this.cleanupPaths(cleanupPaths);
@@ -404,8 +426,6 @@ export class BackgroundAgentManager {
     if (managedProcess) {
       managedProcess.observation?.update({ statusMessage: 'Cancelled by user' });
       managedProcess.observation?.end();
-      this.cleanupPaths(managedProcess.cleanupPaths);
-      this.processes.delete(taskId);
     }
     const updateResult = this.deps.repository.updateStatus(
       taskId,
@@ -413,6 +433,7 @@ export class BackgroundAgentManager {
       undefined,
       'Cancelled by user',
     );
+    this.cleanupTask(taskId);
     await this.destroyOwnedExecutionEnv(taskId);
 
     return updateResult.isOk()
@@ -466,7 +487,7 @@ export class BackgroundAgentManager {
       process.observation?.update({ statusMessage: 'Daemon shutting down' });
       process.observation?.end();
       this.deps.repository.updateStatus(taskId, 'cancelled', undefined, 'Daemon shutting down');
-      this.cleanupPaths(process.cleanupPaths);
+      this.cleanupTask(taskId);
       await this.destroyOwnedExecutionEnv(taskId);
     }
     this.processes.clear();
@@ -641,6 +662,7 @@ export class BackgroundAgentManager {
   }
 
   private cleanupTask(taskId: string): void {
+    this.deps.hostToolsBridge?.unregisterRunAuthentication(taskId);
     const managedProcess = this.processes.get(taskId);
     if (managedProcess) {
       this.cleanupPaths(managedProcess.cleanupPaths);
@@ -703,6 +725,7 @@ export class BackgroundAgentManager {
     threadId: string;
     workerPersonaId: string;
     allowedMcpTools: string[];
+    bridgeSecret: string;
     workingDirectory?: string;
     traceparent?: string;
     sandboxContext: SandboxContext | null;
@@ -724,6 +747,7 @@ export class BackgroundAgentManager {
         args: [join(import.meta.dirname, '../../../dist/tools/host-tools-mcp-server.js')],
         env: {
           ...process.env,
+          [TALOND_BRIDGE_SECRET_ENV]: options.bridgeSecret,
           TALOND_SOCKET: this.deps.hostToolsSocketPath,
           TALOND_RUN_ID: options.taskId,
           TALOND_THREAD_ID: options.threadId,
@@ -751,11 +775,13 @@ export class BackgroundAgentManager {
         args: [join(import.meta.dirname, '../../../dist/tools/skill-loader-mcp-server.js')],
         env: {
           ...process.env,
+          [TALOND_BRIDGE_SECRET_ENV]: options.bridgeSecret,
           TALOND_SOCKET: this.deps.hostToolsSocketPath,
           TALOND_RUN_ID: options.taskId,
           TALOND_THREAD_ID: options.threadId,
           TALOND_PERSONA_ID: options.workerPersonaId,
           TALOND_TRACEPARENT: options.traceparent ?? '',
+          TALOND_BACKGROUND_TASK_ID: options.taskId,
         },
       };
     }

--- a/src/tools/host-tools-bridge-auth.ts
+++ b/src/tools/host-tools-bridge-auth.ts
@@ -1,0 +1,16 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+export const TALOND_BRIDGE_SECRET_ENV = 'TALOND_BRIDGE_SECRET';
+
+export function generateBridgeSecret(): string {
+  return randomBytes(32).toString('hex');
+}
+
+export function bridgeSecretsMatch(expected: string, actual: string): boolean {
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  const actualBuffer = Buffer.from(actual, 'utf8');
+  if (expectedBuffer.length !== actualBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedBuffer, actualBuffer);
+}

--- a/src/tools/host-tools-bridge.ts
+++ b/src/tools/host-tools-bridge.ts
@@ -7,7 +7,7 @@
  */
 
 import { unlinkSync, existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import net from 'node:net';
 import type Database from 'better-sqlite3';
 import type { DaemonContext } from '../daemon/daemon-context.js';
@@ -29,12 +29,18 @@ import { createDatabase } from '../core/database/connection.js';
 import type { ResolvedCapabilities } from '../personas/persona-types.js';
 import { formatMissingTalonSkillError } from '../skills/skill-runtime-text.js';
 import { getHostToolRequestTimeoutMs } from './tool-timeouts.js';
+import { bridgeSecretsMatch } from './host-tools-bridge-auth.js';
+import {
+  ensureOwnerOnlyDirSync,
+  ensureOwnerOnlyFile,
+} from '../core/fs/private-paths.js';
 
 /** NDJSON request shape from MCP server. */
 interface BridgeRequest {
   id: string;
   tool: string;
   args: Record<string, unknown>;
+  bridgeSecret?: string;
   context: ToolExecutionContext;
 }
 
@@ -48,10 +54,17 @@ interface BridgeResponse {
 /** Tool name mapping from MCP (underscores) to handler (dots). Derived from HOST_TOOL_REGISTRY. */
 const TOOL_NAME_MAP = Object.fromEntries(MCP_TO_INTERNAL);
 
+interface RegisteredBridgeAuth {
+  bridgeSecret: string;
+  threadId: string;
+  personaId: string;
+}
+
 export class HostToolsBridge {
   private server: net.Server | null = null;
   private readonly socketPath: string;
   private readonlyDb: Database.Database | null = null;
+  private readonly bridgeAuthByRunId = new Map<string, RegisteredBridgeAuth>();
   private scheduleHandler: ScheduleManageHandler;
   private channelHandler: ChannelSendHandler;
   private personaSendHandler: PersonaSendHandler | null = null;
@@ -165,9 +178,34 @@ export class HostToolsBridge {
     return this.socketPath;
   }
 
+  registerRunAuthentication(input: {
+    runId: string;
+    threadId: string;
+    personaId: string;
+    bridgeSecret: string;
+  }): void {
+    this.bridgeAuthByRunId.set(input.runId, {
+      bridgeSecret: input.bridgeSecret,
+      threadId: input.threadId,
+      personaId: input.personaId,
+    });
+  }
+
+  unregisterRunAuthentication(runId: string): void {
+    this.bridgeAuthByRunId.delete(runId);
+  }
+
   /** Starts listening on the Unix socket. Removes stale socket file if present. */
   start(): void {
     this.ctx.logger.info({ socketPath: this.socketPath }, 'host-tools-bridge: starting');
+    try {
+      ensureOwnerOnlyDirSync(dirname(this.socketPath));
+    } catch (err) {
+      this.ctx.logger.warn(
+        { err, socketPath: this.socketPath },
+        'host-tools-bridge: failed to enforce owner-only socket directory permissions',
+      );
+    }
 
     // Remove stale socket file from previous run.
     if (existsSync(this.socketPath)) {
@@ -179,6 +217,12 @@ export class HostToolsBridge {
     });
 
     this.server.listen(this.socketPath, () => {
+      void ensureOwnerOnlyFile(this.socketPath).catch((err) => {
+        this.ctx.logger.warn(
+          { err, socketPath: this.socketPath },
+          'host-tools-bridge: failed to enforce owner-only socket permissions',
+        );
+      });
       this.ctx.logger.info({ socketPath: this.socketPath }, 'host-tools-bridge: listening');
     });
 
@@ -260,6 +304,12 @@ export class HostToolsBridge {
         error: 'Missing required fields: id, tool, args, context',
       };
       this.sendResponse(socket, errorResponse);
+      return;
+    }
+
+    const authError = this.validateRequestAuthentication(request);
+    if (authError !== null) {
+      this.sendResponse(socket, { id, error: authError });
       return;
     }
 
@@ -359,6 +409,71 @@ export class HostToolsBridge {
 
   private sendResponse(socket: net.Socket, response: BridgeResponse): void {
     socket.write(JSON.stringify(response) + '\n');
+  }
+
+  private validateRequestAuthentication(request: BridgeRequest): string | null {
+    const { bridgeSecret, context } = request;
+    if (typeof bridgeSecret !== 'string' || bridgeSecret.length === 0) {
+      return 'Missing bridge secret';
+    }
+
+    const registered = this.bridgeAuthByRunId.get(context.runId);
+    if (!registered || !bridgeSecretsMatch(registered.bridgeSecret, bridgeSecret)) {
+      this.ctx.logger.warn(
+        {
+          runId: context.runId,
+          threadId: context.threadId,
+          personaId: context.personaId,
+        },
+        'host-tools-bridge: rejected request with invalid bridge secret',
+      );
+      return 'Invalid bridge secret';
+    }
+
+    if (registered.threadId !== context.threadId) {
+      return `Bridge thread mismatch for run "${context.runId}"`;
+    }
+    if (registered.personaId !== context.personaId) {
+      return `Bridge persona mismatch for run "${context.runId}"`;
+    }
+
+    return context.backgroundTaskId
+      ? this.validateBackgroundTaskContext(context.backgroundTaskId, context)
+      : this.validateRunContext(context);
+  }
+
+  private validateRunContext(context: ToolExecutionContext): string | null {
+    const runResult = this.ctx.repos.run.findById(context.runId);
+    if (runResult.isErr() || runResult.value === null) {
+      return `Run not found for bridge request: ${context.runId}`;
+    }
+    if (runResult.value.thread_id !== context.threadId) {
+      return `Bridge thread mismatch for run "${context.runId}"`;
+    }
+    if (runResult.value.persona_id !== context.personaId) {
+      return `Bridge persona mismatch for run "${context.runId}"`;
+    }
+    return null;
+  }
+
+  private validateBackgroundTaskContext(
+    backgroundTaskId: string,
+    context: ToolExecutionContext,
+  ): string | null {
+    const taskResult = this.ctx.repos.backgroundTask.findById(backgroundTaskId);
+    if (taskResult.isErr() || taskResult.value === null) {
+      return `Background task not found for bridge request: ${backgroundTaskId}`;
+    }
+    if (taskResult.value.id !== context.runId) {
+      return `Bridge run mismatch for background task "${backgroundTaskId}"`;
+    }
+    if (taskResult.value.threadId !== context.threadId) {
+      return `Bridge thread mismatch for background task "${backgroundTaskId}"`;
+    }
+    if (taskResult.value.personaId !== context.personaId) {
+      return `Bridge persona mismatch for background task "${backgroundTaskId}"`;
+    }
+    return null;
   }
 
   private resolveSkillContent(personaId: string, skillName: string): string | null {

--- a/src/tools/host-tools-mcp-server.ts
+++ b/src/tools/host-tools-mcp-server.ts
@@ -26,6 +26,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 
 import { MCP_TO_INTERNAL } from './tool-filter.js';
 import { getHostToolRequestTimeoutMs } from './tool-timeouts.js';
+import { TALOND_BRIDGE_SECRET_ENV } from './host-tools-bridge-auth.js';
 
 /** Tool name mapping from MCP (underscores) to handler (dots). Derived from HOST_TOOL_REGISTRY. */
 const TOOL_NAME_MAP = Object.fromEntries(MCP_TO_INTERNAL);
@@ -35,6 +36,7 @@ interface BridgeRequest {
   id: string;
   tool: string;
   args: Record<string, unknown>;
+  bridgeSecret: string;
   context: {
     runId: string;
     threadId: string;
@@ -140,6 +142,7 @@ class SocketClient {
   async sendRequest(
     tool: string,
     args: Record<string, unknown>,
+    bridgeSecret: string,
     context: {
       runId: string;
       threadId: string;
@@ -162,6 +165,7 @@ class SocketClient {
       id,
       tool,
       args,
+      bridgeSecret,
       context: {
         runId: context.runId,
         threadId: context.threadId,
@@ -593,6 +597,7 @@ async function main(): Promise<void> {
   const runId = getEnvRequired('TALOND_RUN_ID');
   const threadId = getEnvRequired('TALOND_THREAD_ID');
   const personaId = getEnvRequired('TALOND_PERSONA_ID');
+  const bridgeSecret = getEnvRequired(TALOND_BRIDGE_SECRET_ENV);
   const traceparent = process.env.TALOND_TRACEPARENT;
   const a2aTaskId = process.env.TALOND_A2A_TASK_ID;
   const rawA2aHopCount = process.env.TALOND_A2A_HOP_COUNT;
@@ -678,17 +683,23 @@ async function main(): Promise<void> {
     }
 
     try {
-      const result = await client.sendRequest(handlerName, args as Record<string, unknown>, {
-        runId,
-        threadId,
-        personaId,
-        traceparent,
-        ...(a2aTaskId ? { a2aTaskId } : {}),
-        ...(a2aHopCount !== undefined ? { a2aHopCount } : {}),
-        ...(backgroundTaskId ? { backgroundTaskId } : {}),
-        ...(primaryExecutionEnvId ? { primaryExecutionEnvId } : {}),
-        ...(allowedHostRoots ? { allowedHostRoots } : {}),
-      }, getHostToolRequestTimeoutMs(normalizedTool, args as Record<string, unknown>));
+      const result = await client.sendRequest(
+        handlerName,
+        args as Record<string, unknown>,
+        bridgeSecret,
+        {
+          runId,
+          threadId,
+          personaId,
+          traceparent,
+          ...(a2aTaskId ? { a2aTaskId } : {}),
+          ...(a2aHopCount !== undefined ? { a2aHopCount } : {}),
+          ...(backgroundTaskId ? { backgroundTaskId } : {}),
+          ...(primaryExecutionEnvId ? { primaryExecutionEnvId } : {}),
+          ...(allowedHostRoots ? { allowedHostRoots } : {}),
+        },
+        getHostToolRequestTimeoutMs(normalizedTool, args as Record<string, unknown>),
+      );
 
       if (!result) {
         return {

--- a/src/tools/skill-loader-mcp-server.ts
+++ b/src/tools/skill-loader-mcp-server.ts
@@ -23,18 +23,21 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { TALON_SKILL_LOAD_TOOL_DESCRIPTION } from '../skills/skill-runtime-text.js';
+import { TALOND_BRIDGE_SECRET_ENV } from './host-tools-bridge-auth.js';
 
 /** NDJSON request to bridge. */
 interface BridgeRequest {
   id: string;
   tool: string;
   args: Record<string, unknown>;
+  bridgeSecret: string;
   context: {
     runId: string;
     threadId: string;
     personaId: string;
     requestId: string;
     traceparent?: string;
+    backgroundTaskId?: string;
   };
 }
 
@@ -131,7 +134,14 @@ class SocketClient {
   async sendRequest(
     tool: string,
     args: Record<string, unknown>,
-    context: { runId: string; threadId: string; personaId: string; traceparent?: string },
+    bridgeSecret: string,
+    context: {
+      runId: string;
+      threadId: string;
+      personaId: string;
+      traceparent?: string;
+      backgroundTaskId?: string;
+    },
   ): Promise<BridgeResponse['result']> {
     if (!this.connected) {
       await this.connectedPromise;
@@ -142,12 +152,14 @@ class SocketClient {
       id,
       tool,
       args,
+      bridgeSecret,
       context: {
         runId: context.runId,
         threadId: context.threadId,
         personaId: context.personaId,
         requestId: randomUUID(),
         ...(context.traceparent ? { traceparent: context.traceparent } : {}),
+        ...(context.backgroundTaskId ? { backgroundTaskId: context.backgroundTaskId } : {}),
       },
     };
 
@@ -216,7 +228,9 @@ async function main(): Promise<void> {
   const runId = getEnvRequired('TALOND_RUN_ID');
   const threadId = getEnvRequired('TALOND_THREAD_ID');
   const personaId = getEnvRequired('TALOND_PERSONA_ID');
+  const bridgeSecret = getEnvRequired(TALOND_BRIDGE_SECRET_ENV);
   const traceparent = process.env.TALOND_TRACEPARENT;
+  const backgroundTaskId = process.env.TALOND_BACKGROUND_TASK_ID;
 
   console.error('[skill-loader-mcp] Starting with socket:', socketPath);
   console.error(
@@ -264,12 +278,18 @@ async function main(): Promise<void> {
     }
 
     try {
-      const result = await client.sendRequest('skill.load', args as Record<string, unknown>, {
-        runId,
-        threadId,
-        personaId,
-        traceparent,
-      });
+      const result = await client.sendRequest(
+        'skill.load',
+        args as Record<string, unknown>,
+        bridgeSecret,
+        {
+          runId,
+          threadId,
+          personaId,
+          traceparent,
+          ...(backgroundTaskId ? { backgroundTaskId } : {}),
+        },
+      );
 
       if (!result) {
         return {

--- a/tests/unit/cli/setup.test.ts
+++ b/tests/unit/cli/setup.test.ts
@@ -174,6 +174,25 @@ describe('createDataDirectories()', () => {
     const result = await createDataDirectories(dataDir);
     expect(result.name).toBe('Data directory structure');
   });
+
+  it('creates data directories with owner-only permissions on POSIX', async () => {
+    const dataDir = join(tmpDir, 'secure-data');
+    const result = await createDataDirectories(dataDir);
+
+    expect(result.status).toBe('passed');
+
+    for (const dir of [
+      dataDir,
+      join(dataDir, 'ipc'),
+      join(dataDir, 'ipc', 'daemon'),
+      join(dataDir, 'backups'),
+      join(dataDir, 'threads'),
+    ]) {
+      const stat = await import('node:fs').then(({ statSync }) => statSync(dir));
+      expect(stat.isDirectory()).toBe(true);
+      expect(stat.mode & 0o777).toBe(0o700);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/cli/setup.test.ts
+++ b/tests/unit/cli/setup.test.ts
@@ -7,7 +7,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -254,10 +261,15 @@ describe('generateDefaultConfig()', () => {
 describe('runDatabaseMigrations()', () => {
   let tmpDir: string;
   let migrationsDir: string;
+  const originalCwd = process.cwd();
 
   beforeEach(() => {
     tmpDir = makeTmpDir();
     migrationsDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
   });
 
   it('runs migrations when config is valid', async () => {
@@ -308,6 +320,55 @@ describe('runDatabaseMigrations()', () => {
 
     const result = await runDatabaseMigrations(configPath, migrationsDir);
     expect(result.name).toBe('Database migrations');
+  });
+
+  it('does not chmod the current directory for a bare database filename', async () => {
+    const workingDir = join(tmpDir, 'workspace');
+    mkdirSync(workingDir, { recursive: true });
+    chmodSync(workingDir, 0o755);
+    process.chdir(workingDir);
+
+    const configPath = join(workingDir, 'talond.yaml');
+    writeFileSync(configPath, 'storage:\n  path: "talond.sqlite"\nlogLevel: info\n');
+
+    const originalMode = statSync(workingDir).mode & 0o777;
+
+    const result = await runDatabaseMigrations(configPath, migrationsDir);
+
+    expect(result.status).toBe('passed');
+    expect(statSync(workingDir).mode & 0o777).toBe(originalMode);
+  });
+
+  it('does not chmod the current directory for an in-memory database', async () => {
+    const workingDir = join(tmpDir, 'workspace-memory');
+    mkdirSync(workingDir, { recursive: true });
+    chmodSync(workingDir, 0o755);
+    process.chdir(workingDir);
+
+    const configPath = join(workingDir, 'talond.yaml');
+    writeFileSync(configPath, 'storage:\n  path: ":memory:"\nlogLevel: info\n');
+
+    const originalMode = statSync(workingDir).mode & 0o777;
+
+    const result = await runDatabaseMigrations(configPath, migrationsDir);
+
+    expect(result.status).toBe('passed');
+    expect(statSync(workingDir).mode & 0o777).toBe(originalMode);
+  });
+
+  it('hardens an explicit database directory before running migrations', async () => {
+    const dbDir = join(tmpDir, 'explicit-db-dir');
+    mkdirSync(dbDir, { recursive: true });
+    chmodSync(dbDir, 0o755);
+
+    const dbPath = join(dbDir, 'talond.sqlite');
+    const configPath = join(tmpDir, 'talond.yaml');
+    writeFileSync(configPath, `storage:\n  path: "${dbPath}"\nlogLevel: info\n`);
+
+    const result = await runDatabaseMigrations(configPath, migrationsDir);
+
+    expect(result.status).toBe('passed');
+    expect(statSync(dbDir).mode & 0o777).toBe(0o700);
   });
 });
 

--- a/tests/unit/daemon/agent-runner.test.ts
+++ b/tests/unit/daemon/agent-runner.test.ts
@@ -2648,6 +2648,7 @@ describe('AgentRunner', () => {
         command: 'node',
         args: [expect.stringContaining('dist/tools/skill-loader-mcp-server.js')],
         env: expect.objectContaining({
+          TALOND_BRIDGE_SECRET: expect.any(String),
           TALOND_SOCKET: '/tmp/test-data/host-tools.sock',
           TALOND_RUN_ID: expect.any(String),
           TALOND_THREAD_ID: 'thread-001',
@@ -2655,6 +2656,17 @@ describe('AgentRunner', () => {
           TALOND_TRACEPARENT: GENERATION_TRACEPARENT,
         }),
       });
+    });
+
+    it('injects a per-run bridge secret into the host-tools MCP env', async () => {
+      await runner.run(makeQueueItem());
+
+      const queryCall = mockQuery.mock.calls[0]![0] as {
+        options: { mcpServers: Record<string, any> };
+      };
+      expect(queryCall.options.mcpServers.__talond_host_tools.env.TALOND_BRIDGE_SECRET).toEqual(
+        expect.any(String),
+      );
     });
   });
 

--- a/tests/unit/ipc/daemon-ipc-client.test.ts
+++ b/tests/unit/ipc/daemon-ipc-client.test.ts
@@ -185,6 +185,23 @@ describe('DaemonIpcClient', () => {
       expect(stat.isDirectory()).toBe(true);
     }, 10_000);
 
+    it('creates inputDir with owner-only permissions on POSIX', async () => {
+      const newInputDir = path.join(tmpDir, 'restricted-input');
+
+      const client = new DaemonIpcClient({
+        inputDir: newInputDir,
+        outputDir,
+        timeoutMs: 150,
+        pollIntervalMs: 50,
+      });
+
+      await client.sendCommand('status');
+
+      const stat = await fs.stat(newInputDir);
+      expect(stat.isDirectory()).toBe(true);
+      expect(stat.mode & 0o777).toBe(0o700);
+    }, 10_000);
+
     it('handles failure response from daemon', async () => {
       const client = new DaemonIpcClient({
         inputDir,

--- a/tests/unit/subagents/background/background-agent-manager.test.ts
+++ b/tests/unit/subagents/background/background-agent-manager.test.ts
@@ -57,6 +57,10 @@ describe('BackgroundAgentManager', () => {
   let processKill: ReturnType<typeof vi.fn>;
   let processFactory: ReturnType<typeof vi.fn>;
   let completionResolve: ((value: unknown) => void) | null;
+  let hostToolsBridge: {
+    registerRunAuthentication: ReturnType<typeof vi.fn>;
+    unregisterRunAuthentication: ReturnType<typeof vi.fn>;
+  };
 
   afterEach(() => {
     rmSync('/tmp/talon-bg-test', { recursive: true, force: true });
@@ -88,6 +92,10 @@ describe('BackgroundAgentManager', () => {
     }));
     completionResolve = null;
     processKill = vi.fn();
+    hostToolsBridge = {
+      registerRunAuthentication: vi.fn(),
+      unregisterRunAuthentication: vi.fn(),
+    };
     processStart = vi.fn().mockImplementation(() =>
       ok({
         pid: 4242,
@@ -154,6 +162,7 @@ describe('BackgroundAgentManager', () => {
       processFactory,
       isPidAlive: vi.fn().mockReturnValue(false),
       readProcessCommandLine: vi.fn().mockReturnValue('claude --print'),
+      hostToolsBridge,
       hostToolsSocketPath: '/tmp/test-host-tools.sock',
       ...overrides,
     });
@@ -250,6 +259,18 @@ describe('BackgroundAgentManager', () => {
     expect(task?.pid).toBe(4242);
   });
 
+  it('stores the worker persona on the background task when a profile persona differs', async () => {
+    const manager = createManager();
+    const result = await manager.spawn({
+      ...spawnInput,
+      personaId: 'persona-spawner',
+      workerPersonaId: 'persona-worker',
+    });
+
+    const task = repository.findById(result._unsafeUnwrap())._unsafeUnwrap();
+    expect(task?.personaId).toBe('persona-worker');
+  });
+
   it('includes __talond_skill_loader in MCP servers when hasSkills is true', async () => {
     const manager = createManager();
 
@@ -261,6 +282,7 @@ describe('BackgroundAgentManager', () => {
       transport: 'stdio',
       command: 'node',
       env: expect.objectContaining({
+        TALOND_BRIDGE_SECRET: expect.any(String),
         TALOND_SOCKET: '/tmp/test-host-tools.sock',
         TALOND_THREAD_ID: 'thread-1',
         TALOND_PERSONA_ID: 'persona-1',
@@ -296,6 +318,19 @@ describe('BackgroundAgentManager', () => {
     const mcpServers = prepareBackgroundInvocation.mock.calls[0]?.[0]?.mcpServers as Record<string, unknown>;
     expect(mcpServers['__talond_skill_loader']).toBeDefined();
     expect(mcpServers['__talond_host_tools']).toBeUndefined();
+  });
+
+  it('injects a per-task bridge secret into the host-tools MCP env', async () => {
+    const manager = createManager();
+
+    await manager.spawn({ ...spawnInput, allowedMcpTools: ['channel_send'] });
+
+    const mcpServers = prepareBackgroundInvocation.mock.calls[0]?.[0]?.mcpServers as Record<string, any>;
+    expect(mcpServers['__talond_host_tools']).toMatchObject({
+      env: expect.objectContaining({
+        TALOND_BRIDGE_SECRET: expect.any(String),
+      }),
+    });
   });
 
   it('builds the append-system-prompt from persona and task context', async () => {
@@ -717,6 +752,15 @@ describe('BackgroundAgentManager', () => {
     expect(repository.findById(taskId)._unsafeUnwrap()?.status).toBe('cancelled');
   });
 
+  it('revokes bridge auth immediately when a running task is cancelled', async () => {
+    const manager = createManager();
+    const taskId = (await manager.spawn(spawnInput))._unsafeUnwrap();
+
+    await manager.cancel(taskId);
+
+    expect(hostToolsBridge.unregisterRunAuthentication).toHaveBeenCalledWith(taskId);
+  });
+
   it('cleans up cancelled tasks immediately so shutdown does not clean them twice', async () => {
     const manager = createManager();
     const taskId = (await manager.spawn(spawnInput))._unsafeUnwrap();
@@ -760,6 +804,15 @@ describe('BackgroundAgentManager', () => {
     expect(processKill).toHaveBeenCalled();
     expect(repository.findById(taskId)._unsafeUnwrap()?.status).toBe('cancelled');
     expect(existsSync('/tmp/talon-bg-test')).toBe(false);
+  });
+
+  it('revokes bridge auth during shutdown for active tasks', async () => {
+    const manager = createManager();
+    const taskId = (await manager.spawn(spawnInput))._unsafeUnwrap();
+
+    await manager.shutdown();
+
+    expect(hostToolsBridge.unregisterRunAuthentication).toHaveBeenCalledWith(taskId);
   });
 
   it('returns error when providerRegistry.getDefault returns undefined', async () => {

--- a/tests/unit/tools/host-tools-bridge.test.ts
+++ b/tests/unit/tools/host-tools-bridge.test.ts
@@ -28,9 +28,13 @@ function sendRequest(
   socketPath: string,
   request: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
+  const requestWithDefaultSecret =
+    request.context !== undefined && request.bridgeSecret === undefined
+      ? { ...request, bridgeSecret: 'bridge-secret-001' }
+      : request;
   return new Promise((resolve, reject) => {
     const client = createConnection(socketPath, () => {
-      client.write(JSON.stringify(request) + '\n');
+      client.write(JSON.stringify(requestWithDefaultSecret) + '\n');
     });
 
     let data = '';
@@ -77,6 +81,16 @@ describe('HostToolsBridge', () => {
   let bridge: HostToolsBridge;
   let mockCtx: DaemonContext;
   let tempDir: string;
+  const validBridgeSecret = 'bridge-secret-001';
+
+  const registerActiveRunAuth = (): void => {
+    bridge.registerRunAuthentication({
+      runId: 'run-001',
+      threadId: 'thread-001',
+      personaId: 'persona-001',
+      bridgeSecret: validBridgeSecret,
+    });
+  };
 
   beforeEach(async () => {
     tempDir = join('/tmp', `host-tools-bridge-test-${randomUUID()}`);
@@ -116,7 +130,32 @@ describe('HostToolsBridge', () => {
         backgroundTask: {} as any,
         audit: {} as any,
         message: {} as any,
-        run: {} as any,
+        run: {
+          findById: vi.fn().mockImplementation((runId: string) => ok(
+            runId === 'run-001'
+              ? {
+                  id: 'run-001',
+                  thread_id: 'thread-001',
+                  persona_id: 'persona-001',
+                  provider_name: 'claude-code',
+                  sandbox_id: null,
+                  session_id: null,
+                  status: 'running',
+                  parent_run_id: null,
+                  queue_item_id: null,
+                  input_tokens: 0,
+                  output_tokens: 0,
+                  cache_read_tokens: 0,
+                  cache_write_tokens: 0,
+                  cost_usd: 0,
+                  error: null,
+                  started_at: 1,
+                  ended_at: null,
+                  created_at: 1,
+                }
+              : null,
+          )),
+        } as any,
         binding: {} as any,
         memory: {
           findById: vi.fn().mockReturnValue(ok(null)),
@@ -288,8 +327,115 @@ describe('HostToolsBridge', () => {
   });
 
   describe('dispatch', () => {
+    it('rejects direct bridge requests without a bridge secret', async () => {
+      bridge = new HostToolsBridge(mockCtx);
+      bridge.registerRunAuthentication({
+        runId: 'run-001',
+        threadId: 'thread-001',
+        personaId: 'persona-001',
+        bridgeSecret: validBridgeSecret,
+      });
+      bridge.start();
+      await waitForSocket(bridge.path);
+
+      const response = await new Promise<Record<string, unknown>>((resolve, reject) => {
+        const client = createConnection(bridge.path, () => {
+          client.write(JSON.stringify({
+            id: randomUUID(),
+            tool: 'memory_access',
+            args: {
+              operation: 'list',
+            },
+            context: {
+              runId: 'run-001',
+              threadId: 'thread-001',
+              personaId: 'persona-001',
+              requestId: 'req-001',
+            },
+          }) + '\n');
+        });
+
+        let data = '';
+        client.on('data', (chunk) => {
+          data += chunk.toString();
+          const idx = data.indexOf('\n');
+          if (idx !== -1) {
+            client.end();
+            resolve(JSON.parse(data.slice(0, idx)));
+          }
+        });
+
+        client.on('error', reject);
+        setTimeout(() => {
+          client.end();
+          reject(new Error('Timeout'));
+        }, 5000);
+      });
+
+      expect(response.error).toContain('bridge secret');
+    });
+
+    it('rejects requests whose persona does not match the authenticated run context', async () => {
+      bridge = new HostToolsBridge(mockCtx);
+      bridge.registerRunAuthentication({
+        runId: 'run-001',
+        threadId: 'thread-001',
+        personaId: 'persona-001',
+        bridgeSecret: validBridgeSecret,
+      });
+      bridge.start();
+      await waitForSocket(bridge.path);
+
+      const response = await sendRequest(bridge.path, {
+        id: randomUUID(),
+        tool: 'memory_access',
+        args: {
+          operation: 'list',
+        },
+        bridgeSecret: validBridgeSecret,
+        context: {
+          runId: 'run-001',
+          threadId: 'thread-001',
+          personaId: 'persona-999',
+          requestId: 'req-001',
+        },
+      });
+
+      expect(response.error).toContain('persona');
+    });
+
+    it('accepts authenticated wrapper requests for the active run context', async () => {
+      bridge = new HostToolsBridge(mockCtx);
+      bridge.registerRunAuthentication({
+        runId: 'run-001',
+        threadId: 'thread-001',
+        personaId: 'persona-001',
+        bridgeSecret: validBridgeSecret,
+      });
+      bridge.start();
+      await waitForSocket(bridge.path);
+
+      const response = await sendRequest(bridge.path, {
+        id: randomUUID(),
+        tool: 'memory_access',
+        args: {
+          operation: 'list',
+        },
+        bridgeSecret: validBridgeSecret,
+        context: {
+          runId: 'run-001',
+          threadId: 'thread-001',
+          personaId: 'persona-001',
+          requestId: 'req-001',
+        },
+      });
+
+      expect((response.result as any)?.status).toBe('success');
+    });
+
     it('dispatches schedule.manage create and returns success', async () => {
       bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
       bridge.start();
       await waitForSocket(bridge.path);
 
@@ -315,6 +461,7 @@ describe('HostToolsBridge', () => {
 
     it('dispatches background_agent spawn when the manager is present', async () => {
       bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
       bridge.start();
       await waitForSocket(bridge.path);
 
@@ -348,6 +495,7 @@ describe('HostToolsBridge', () => {
 
     it('dispatches execution_env destroy when the manager is present', async () => {
       bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
       bridge.start();
       await waitForSocket(bridge.path);
 
@@ -373,6 +521,7 @@ describe('HostToolsBridge', () => {
 
     it('returns error for unknown tool', async () => {
       bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
       bridge.start();
       await waitForSocket(bridge.path);
 
@@ -424,6 +573,7 @@ describe('HostToolsBridge', () => {
 
     it('dispatches memory.access to the memory handler', async () => {
       bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
       bridge.start();
       await waitForSocket(bridge.path);
 
@@ -445,6 +595,7 @@ describe('HostToolsBridge', () => {
 
     it('wraps tool dispatch in an observation using the incoming traceparent', async () => {
       bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
       bridge.start();
       await waitForSocket(bridge.path);
 
@@ -496,6 +647,7 @@ describe('HostToolsBridge', () => {
       ] as any;
 
       bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
 
       const socket = { write: vi.fn() } as unknown as ReturnType<typeof createConnection>;
       await (bridge as any).handleRequest(
@@ -505,6 +657,7 @@ describe('HostToolsBridge', () => {
           args: {
             name: 'brainstorming',
           },
+          bridgeSecret: validBridgeSecret,
           context: {
             runId: 'run-001',
             threadId: 'thread-001',
@@ -539,6 +692,7 @@ describe('HostToolsBridge', () => {
       ] as any;
 
       bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
 
       const socket = { write: vi.fn() } as unknown as ReturnType<typeof createConnection>;
       await (bridge as any).handleRequest(
@@ -548,6 +702,7 @@ describe('HostToolsBridge', () => {
           args: {
             name: 'missing-from-disk',
           },
+          bridgeSecret: validBridgeSecret,
           context: {
             runId: 'run-001',
             threadId: 'thread-001',
@@ -577,6 +732,7 @@ describe('HostToolsBridge', () => {
         }));
 
       bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
 
       const socket = { write: vi.fn() } as unknown as ReturnType<typeof createConnection>;
 
@@ -585,6 +741,7 @@ describe('HostToolsBridge', () => {
           id: 'req-001',
           tool: 'unknown_tool',
           args: {},
+          bridgeSecret: validBridgeSecret,
           context: {
             runId: 'run-001',
             threadId: 'thread-001',
@@ -624,6 +781,7 @@ describe('HostToolsBridge', () => {
           }));
 
         bridge = new HostToolsBridge(mockCtx);
+        registerActiveRunAuth();
 
         let resolveDispatch!: (result: unknown) => void;
         (bridge as any).dispatch = vi.fn().mockImplementation(
@@ -639,6 +797,7 @@ describe('HostToolsBridge', () => {
             id: 'req-timeout',
             tool: 'schedule_manage',
             args: { action: 'list' },
+            bridgeSecret: validBridgeSecret,
             context: {
               runId: 'run-001',
               threadId: 'thread-001',


### PR DESCRIPTION
## What changed
- added per-run bridge secrets and a bridge auth registry so only Talon-spawned MCP wrappers can call host tools for their registered run/task
- injected `TALOND_BRIDGE_SECRET` into both `__talond_host_tools` and `__talond_skill_loader`, including background-task skill loading
- made the bridge fail closed on missing/invalid secrets and on run/thread/persona mismatches, with persisted run/background-task validation
- hardened created IPC/data/socket paths to owner-only permissions and set the host-tools socket file to owner-only access
- fixed the background profile path so bridge validation follows the worker persona, and revoked bridge auth immediately on cancel/shutdown

## Why
Requests over `host-tools.sock` previously trusted caller-supplied run/thread/persona context. This change adds an unforgeable per-run secret plus context validation so raw local socket clients cannot execute host tools, while keeping the existing tool-filter checks as defense in depth.

## RED evidence
Initial focused RED runs failed before implementation:
- `rtk npx vitest run tests/unit/tools/host-tools-bridge.test.ts`
  - missing-secret request was not rejected
  - persona-mismatched request was not rejected
  - authenticated wrapper request did not succeed
- `rtk npx vitest run tests/unit/ipc/daemon-ipc-client.test.ts tests/unit/cli/setup.test.ts`
  - new permission tests expected `0o700` but observed `0o755` (`493`) for created directories
- environment bootstrap needed follow-up before the RED loop could run cleanly in this worktree:
  - `rtk npm ci`
  - `rtk npm run rebuild:sqlite`

## GREEN verification
- `rtk npm run build`
- `rtk npx vitest run tests/unit/tools/host-tools-bridge.test.ts tests/unit/tools/skill-loader-mcp-server.test.ts`
- `rtk npx vitest run tests/unit/daemon/agent-runner.test.ts tests/unit/subagents/background/background-agent-manager.test.ts tests/unit/ipc/daemon-ipc-client.test.ts tests/unit/cli/setup.test.ts`
- GPT-5.4 local review requested before commit; follow-up fixes landed for background profile persona handling and immediate auth revocation on cancel/shutdown

## Residual risk
- existing pre-created data/IPC directories are not chmod-remediated by `talonctl setup`; this change hardens directories and socket paths when Talon creates them, but does not rewrite already-present user-managed paths

## Docs
- no docs update was needed because this is internal daemon/MCP security hardening with no user-facing setup or workflow changes

Closes #232
