### PR TITLE
Fix daemon bootstrap test mock for HostToolsBridge wiring

### DIFF
--- a/tests/unit/daemon/daemon-bootstrap.test.ts
+++ b/tests/unit/daemon/daemon-bootstrap.test.ts
@@ -131,6 +131,7 @@ vi.mock('../../../src/subagents/background/background-agent-manager.js', () => (
   BackgroundAgentManager: vi.fn().mockImplementation(() => ({
     recoverOrphanedTasks: vi.fn(),
     shutdown: vi.fn(),
+    setHostToolsBridge: vi.fn(),
   })),
 }));
 


### PR DESCRIPTION
## Root Cause

The daemon-bootstrap tests mock `BackgroundAgentManager` with a minimal shape that predates the new `setHostToolsBridge()` dependency wiring added in bootstrap flow. In real code, bootstrap constructs a `HostToolsBridge` and calls `backgroundAgentManager?.setHostToolsBridge(hostToolsBridge)`, but the test mock only implemented `recoverOrphanedTasks` and `shutdown`, so the call threw `TypeError: backgroundAgentManager?.setHostToolsBridge is not a function`.

## Fix

Add `setHostToolsBridge` (no-op `vi.fn()`) to the `BackgroundAgentManager` mock in `tests/unit/daemon/daemon-bootstrap.test.ts` so the mock matches production constructor interface.

## Verification

- `npx vitest run tests/unit/daemon/daemon-bootstrap.test.ts`
- `npm run build`
- `node scripts/select-pr-tests.mjs --base origin/main --head HEAD --command-file .ci-test-command && bash .ci-test-command` (generated no-op: "No Vitest targets selected.")

## Notes

- PR validation workflow helper generated `.ci-test-command`; it was cleaned up after run.
- A separate GPT-5.4 review step was requested by repo instructions; codex review helper is not available in this environment.
