### PR TITLE
[codex] fix context rotation usage and provider options

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ agentRunner:
         baseUrl: http://mac.local:11434/v1
         defaultModel: qwen3-coder:30b
         providerId: ollama-mac
+        providerOptions:
+          chat_template_kwargs:
+            enable_thinking: false
 
 backgroundAgent:
   enabled: true
@@ -186,6 +189,9 @@ backgroundAgent:
         baseUrl: http://mac.local:11434/v1
         defaultModel: qwen3-coder:30b
         providerId: ollama-mac
+        providerOptions:
+          chat_template_kwargs:
+            enable_thinking: false
 ```
 
 ### Infrastructure
@@ -1458,6 +1464,8 @@ personas:
 
 **Important:** Personas only load sub-agents explicitly listed in their `subagents` config. Without `session-observer` and `session-reflector` in the list, the context-roller won't find them at runtime. You can remove `session-summarizer` from personas using OM since it won't be called.
 
+For multi-step agent providers that expose both cumulative and final-step usage, Talon keeps cumulative usage for accounting and Langfuse, but gates context rotation on the final model step. Codex CLI provides this through its `token_count.last_token_usage` events; this prevents tool-heavy turns from rotating simply because cumulative billed input crossed the threshold.
+
 ### Provider Support
 
 Sub-agents can use any supported AI provider. Configure API keys in `talond.yaml`:
@@ -1788,6 +1796,8 @@ npx talonctl test-provider --name gemini-cli
 ```
 
 For `openai-compatible` (**experimental**), use the canonical provider name `openai-compatible` or add an alias with `type: openai-compatible` when you need multiple endpoints at once. Credentials are looked up under `auth.providers.<options.providerId>.{apiKey,baseURL}` (e.g. `auth.providers.ollama`, `auth.providers.ollama-mac`, `auth.providers.groq`), so the same slot can be reused by the matching sub-agent provider. If no entry matches `providerId`, the provider falls back to `auth.providers.openai-compatible.{apiKey,baseURL}`. The provider streams text deltas, tool calls, and tool results via a Mastra-backed wrapper CLI, so users see incremental responses and tool activity in the connected channel (no "Thinking..." placeholder).
+
+OpenAI-compatible entries may set a flat `options.providerOptions` record for vendor-specific request body knobs. Talon wraps it under `options.providerId` before calling Mastra, so disabling Qwen thinking on an `ollama-mac` alias is `providerOptions.chat_template_kwargs.enable_thinking: false`, not a nested `providerOptions.openai` block.
 
 > **Experimental provider.** `openai-compatible` uses a Mastra-backed wrapper with several workarounds for Mastra/AI-SDK gaps: fetch-level `stream_options` injection for usage reporting, `maxSteps` override for tool-call limits, and workspace tool output caps to prevent stalls from large directory listings. These workarounds may break with future Mastra versions. If you encounter issues, pin your `@mastra/core` version and report the problem.
 

--- a/config/talond.example.yaml
+++ b/config/talond.example.yaml
@@ -208,6 +208,12 @@ agentRunner:
         defaultModel: qwen3-coder:30b
         providerId: ollama-mac
         toolOutputCap: 4000
+        # Flat vendor-specific request body fields. Talon wraps this under
+        # providerId before calling Mastra, so this becomes
+        # providerOptions: { "ollama-mac": { chat_template_kwargs: ... } }.
+        providerOptions:
+          chat_template_kwargs:
+            enable_thinking: false
 
 backgroundAgent:
   enabled: true
@@ -254,6 +260,9 @@ backgroundAgent:
         baseUrl: http://mac.local:11434/v1
         defaultModel: qwen3-coder:30b
         providerId: ollama-mac
+        providerOptions:
+          chat_template_kwargs:
+            enable_thinking: false
 
 scheduler:
   tickIntervalMs: 5000

--- a/src/providers/codex-cli-provider.ts
+++ b/src/providers/codex-cli-provider.ts
@@ -37,6 +37,7 @@ interface CodexParsedOutput {
   hasTurnCompleted: boolean;
   threadId?: string;
   usage?: AgentUsage;
+  lastStepUsage?: AgentUsage;
 }
 
 interface RenderedCodexConfig {
@@ -378,6 +379,7 @@ export class CodexCliProvider implements AgentProvider {
         output: parsed.output,
         sessionId: parsedJsonl.threadId,
         usage: parsed.usage ?? { inputTokens: 0, outputTokens: 0 },
+        ...(parsed.lastStepUsage ? { lastStepUsage: parsed.lastStepUsage } : {}),
         isError: parsed.exitCode !== 0 || parsed.timedOut,
       },
     };
@@ -460,6 +462,7 @@ export class CodexCliProvider implements AgentProvider {
           exitCode: raw.exitCode,
           timedOut: raw.timedOut,
           usage: parsed.usage,
+          ...(parsed.lastStepUsage ? { lastStepUsage: parsed.lastStepUsage } : {}),
         };
       }
 
@@ -469,6 +472,7 @@ export class CodexCliProvider implements AgentProvider {
         exitCode: 1,
         timedOut: raw.timedOut,
         usage: parsed.usage,
+        ...(parsed.lastStepUsage ? { lastStepUsage: parsed.lastStepUsage } : {}),
       };
     }
 
@@ -478,6 +482,7 @@ export class CodexCliProvider implements AgentProvider {
       exitCode: raw.exitCode,
       timedOut: raw.timedOut,
       usage: parsed.usage,
+      ...(parsed.lastStepUsage ? { lastStepUsage: parsed.lastStepUsage } : {}),
     };
   }
 
@@ -499,29 +504,7 @@ export class CodexCliProvider implements AgentProvider {
         continue;
       }
 
-      if (event.type === 'thread.started' && typeof event.thread_id === 'string') {
-        result.hasThreadStarted = true;
-        result.threadId = event.thread_id;
-      } else if (event.type === 'thread.started') {
-        result.hasThreadStarted = true;
-      }
-
-      if (event.type === 'turn.completed') {
-        result.hasTurnCompleted = true;
-        if (typeof event.usage === 'object' && event.usage !== null) {
-          const usage = event.usage as {
-            input_tokens?: unknown;
-            cached_input_tokens?: unknown;
-            output_tokens?: unknown;
-          };
-          result.usage = {
-            inputTokens: typeof usage.input_tokens === 'number' ? usage.input_tokens : 0,
-            cacheReadTokens:
-              typeof usage.cached_input_tokens === 'number' ? usage.cached_input_tokens : undefined,
-            outputTokens: typeof usage.output_tokens === 'number' ? usage.output_tokens : 0,
-          };
-        }
-      }
+      this.updateParsedState(result, event);
     }
 
     return result;
@@ -561,20 +544,67 @@ export class CodexCliProvider implements AgentProvider {
 
     if (event.type === 'turn.completed') {
       parsed.hasTurnCompleted = true;
-      if (typeof event.usage === 'object' && event.usage !== null) {
-        const usage = event.usage as {
-          input_tokens?: unknown;
-          cached_input_tokens?: unknown;
-          output_tokens?: unknown;
-        };
-        parsed.usage = {
-          inputTokens: typeof usage.input_tokens === 'number' ? usage.input_tokens : 0,
-          cacheReadTokens:
-            typeof usage.cached_input_tokens === 'number' ? usage.cached_input_tokens : undefined,
-          outputTokens: typeof usage.output_tokens === 'number' ? usage.output_tokens : 0,
-        };
+      const usage = this.parseTokenUsage(event.usage);
+      if (usage) {
+        parsed.usage = usage;
       }
     }
+
+    const tokenCountInfo = this.readTokenCountInfo(event);
+    if (!tokenCountInfo) {
+      return;
+    }
+
+    const totalUsage = this.parseTokenUsage(tokenCountInfo.total_token_usage);
+    if (totalUsage) {
+      parsed.usage = totalUsage;
+    }
+
+    const lastUsage = this.parseTokenUsage(tokenCountInfo.last_token_usage);
+    if (lastUsage) {
+      parsed.lastStepUsage = lastUsage;
+    }
+  }
+
+  private readTokenCountInfo(event: Record<string, unknown>): Record<string, unknown> | null {
+    if (event.type === 'token_count' && typeof event.info === 'object' && event.info !== null) {
+      return event.info as Record<string, unknown>;
+    }
+
+    if (event.type !== 'event_msg' || typeof event.payload !== 'object' || event.payload === null) {
+      return null;
+    }
+
+    const payload = event.payload as Record<string, unknown>;
+    if (
+      payload.type !== 'token_count' ||
+      typeof payload.info !== 'object' ||
+      payload.info === null
+    ) {
+      return null;
+    }
+
+    return payload.info as Record<string, unknown>;
+  }
+
+  private parseTokenUsage(value: unknown): AgentUsage | undefined {
+    if (typeof value !== 'object' || value === null) {
+      return undefined;
+    }
+
+    const usage = value as Record<string, unknown>;
+    const inputTokens = this.readNumber(usage.input_tokens);
+    const cacheReadTokens = this.readNumber(usage.cached_input_tokens);
+    const outputTokens = this.readNumber(usage.output_tokens);
+    if (inputTokens === undefined && cacheReadTokens === undefined && outputTokens === undefined) {
+      return undefined;
+    }
+
+    return {
+      inputTokens: inputTokens ?? 0,
+      ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+      outputTokens: outputTokens ?? 0,
+    };
   }
 
   private extractTextEvents(
@@ -707,6 +737,10 @@ export class CodexCliProvider implements AgentProvider {
 
   private readBoolean(value: unknown): boolean | undefined {
     return typeof value === 'boolean' ? value : undefined;
+  }
+
+  private readNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
   }
 
   private buildValidationError(

--- a/src/providers/openai-compatible-provider.ts
+++ b/src/providers/openai-compatible-provider.ts
@@ -35,6 +35,7 @@ interface WrapperPayload {
   baseUrl: string;
   apiKey?: string;
   providerId: string;
+  providerOptions?: Record<string, Record<string, unknown>>;
   headers?: Record<string, string>;
   mcpServers: Record<string, Exclude<CanonicalMcpServer, { transport: 'sdk' }>>;
   /**
@@ -470,14 +471,17 @@ export class OpenAiCompatibleProvider implements AgentProvider {
     }
 
     const scriptArgs = this.resolveWrapperArgs();
+    const providerId = this.readStringOption('providerId') ?? 'openai-compatible';
+    const providerOptions = this.readUnknownRecordOption('providerOptions');
     const payload: WrapperPayload = {
       prompt: input.prompt,
       systemPrompt: input.systemPrompt,
       cwd: input.cwd,
       model,
       baseUrl,
-      providerId: this.readStringOption('providerId') ?? 'openai-compatible',
+      providerId,
       ...(this.runtime.apiKey ? { apiKey: this.runtime.apiKey } : {}),
+      ...(providerOptions ? { providerOptions: { [providerId]: providerOptions } } : {}),
       ...(this.readRecordOption('headers') ? { headers: this.readRecordOption('headers') } : {}),
       mcpServers: this.toSerializableMcpServers(input.mcpServers),
       streamEvents: options.streamEvents,
@@ -518,6 +522,15 @@ export class OpenAiCompatibleProvider implements AgentProvider {
 
     const entries = Object.entries(value).filter(([, entry]) => typeof entry === 'string');
     return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+
+  private readUnknownRecordOption(name: string): Record<string, unknown> | undefined {
+    const value = this.config.options?.[name];
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return undefined;
+    }
+
+    return Object.keys(value).length > 0 ? (value as Record<string, unknown>) : undefined;
   }
 
   private resolveWrapperArgs(): string[] {

--- a/src/providers/openai-compatible/agent-cli/index.ts
+++ b/src/providers/openai-compatible/agent-cli/index.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from 'node:fs';
+import type { JSONObject } from '@ai-sdk/provider';
 import { Agent } from '@mastra/core/agent';
 import { createTool, type Tool } from '@mastra/core/tools';
 import { Workspace, LocalFilesystem, LocalSandbox, type WorkspaceToolsConfig } from '@mastra/core/workspace';
@@ -28,6 +29,7 @@ interface WrapperInput {
   baseUrl: string;
   apiKey?: string;
   providerId?: string;
+  providerOptions?: ProviderOptionsPayload;
   headers?: Record<string, string>;
   mcpServers: Record<string, SerializableMcpServer>;
   streamEvents?: boolean;
@@ -54,6 +56,8 @@ type SerializableMcpServer =
       url: string;
       headers?: Record<string, string>;
     };
+
+type ProviderOptionsPayload = Record<string, JSONObject>;
 
 type WrapperEvent =
   | { type: 'text'; content: string }
@@ -245,7 +249,10 @@ async function main(): Promise<void> {
     // Mastra's default stopWhen is stepCountIs(5), which stalls the stream
     // after ~5 tool calls. Match the agent-runner's maxTurns (default 25)
     // so the agent can do meaningful multi-tool work.
-    const stream = await agent.stream(input.prompt, { maxSteps: 25 });
+    const stream = await agent.stream(input.prompt, {
+      maxSteps: 25,
+      ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+    });
     const shouldStream = input.streamEvents !== false;
     // Track per-step and cumulative usage in SEPARATE accumulators so we
     // can surface each to the right consumer downstream:
@@ -468,6 +475,7 @@ function parseInput(raw: string): WrapperInput {
     baseUrl: parsed.baseUrl,
     ...(parsed.apiKey ? { apiKey: parsed.apiKey } : {}),
     ...(parsed.providerId ? { providerId: parsed.providerId } : {}),
+    ...(parsed.providerOptions ? { providerOptions: parsed.providerOptions } : {}),
     ...(parsed.headers ? { headers: parsed.headers } : {}),
     mcpServers: parsed.mcpServers ?? {},
     ...(typeof parsed.streamEvents === 'boolean' ? { streamEvents: parsed.streamEvents } : {}),
@@ -692,6 +700,10 @@ function isWrapperInput(value: unknown): value is WrapperInput {
     return false;
   }
 
+  if (value.providerOptions !== undefined && !isProviderOptions(value.providerOptions)) {
+    return false;
+  }
+
   if (!isRecord(value.mcpServers)) {
     return false;
   }
@@ -705,6 +717,10 @@ function isWrapperInput(value: unknown): value is WrapperInput {
   }
 
   return Object.values(value.mcpServers).every(isSerializableMcpServer);
+}
+
+function isProviderOptions(value: unknown): value is ProviderOptionsPayload {
+  return isRecord(value) && Object.values(value).every(isRecord);
 }
 
 void main();

--- a/tests/unit/providers/codex-cli-provider.test.ts
+++ b/tests/unit/providers/codex-cli-provider.test.ts
@@ -85,6 +85,7 @@ describe('CodexCliProvider', () => {
           yield '{"type":"item.completed","item":{"type":"assistant_message","content":[{"type":"output_text","text":"Hello "} ]}}\n';
           yield '{"type":"item.completed","item":{"type":"mcp_tool_call","server_name":"brave","name":"search","call_id":"tool-1","arguments":{"q":"latest"}}}\n';
           yield '{"type":"item.completed","item":{"type":"assistant_message","content":[{"type":"output_text","text":"world"}]}}\n';
+          yield '{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":111,"cached_input_tokens":42,"output_tokens":7},"last_token_usage":{"input_tokens":55,"cached_input_tokens":30,"output_tokens":3},"model_context_window":258400}}}\n';
           yield '{"type":"turn.completed","usage":{"input_tokens":111,"cached_input_tokens":42,"output_tokens":7}}\n';
         }
         return {
@@ -204,6 +205,11 @@ describe('CodexCliProvider', () => {
               inputTokens: 111,
               cacheReadTokens: 42,
               outputTokens: 7,
+            },
+            lastStepUsage: {
+              inputTokens: 55,
+              cacheReadTokens: 30,
+              outputTokens: 3,
             },
             isError: false,
           },
@@ -499,6 +505,7 @@ describe('CodexCliProvider', () => {
       {
         stdout: [
           '{"type":"thread.started","thread_id":"codex-thread-009"}',
+          '{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":14813,"cached_input_tokens":9000,"output_tokens":16},"last_token_usage":{"input_tokens":7312,"cached_input_tokens":4096,"output_tokens":5},"model_context_window":258400}}}',
           '{"type":"turn.completed","usage":{"input_tokens":14813,"cached_input_tokens":9000,"output_tokens":16}}',
         ].join('\n'),
         stderr: '',
@@ -517,6 +524,11 @@ describe('CodexCliProvider', () => {
         inputTokens: 14813,
         cacheReadTokens: 9000,
         outputTokens: 16,
+      },
+      lastStepUsage: {
+        inputTokens: 7312,
+        cacheReadTokens: 4096,
+        outputTokens: 5,
       },
     });
   });

--- a/tests/unit/providers/openai-compatible-provider.test.ts
+++ b/tests/unit/providers/openai-compatible-provider.test.ts
@@ -116,6 +116,45 @@ describe('OpenAiCompatibleProvider', () => {
     expect(payload.toolOutputCap).toBe(2048);
   });
 
+  it('wraps options.providerOptions under the configured providerId', () => {
+    const provider = new OpenAiCompatibleProvider({
+      enabled: true,
+      type: 'openai-compatible',
+      command: 'node',
+      contextWindowTokens: 128_000,
+      options: {
+        defaultModel: 'qwen3-coder:30b',
+        baseUrl: 'http://mac.local:11434/v1',
+        providerId: 'ollama-mac',
+        providerOptions: {
+          chat_template_kwargs: {
+            enable_thinking: false,
+          },
+        },
+      },
+    });
+
+    const result = provider.prepareBackgroundInvocation({
+      prompt: 'hi',
+      systemPrompt: 's',
+      mcpServers: {},
+      cwd: '/tmp',
+      timeoutMs: 10_000,
+      model: 'qwen3-coder:30b',
+    });
+
+    expect(result.isOk()).toBe(true);
+    const payload = JSON.parse(result._unsafeUnwrap().stdin) as Record<string, unknown>;
+    expect(payload.providerId).toBe('ollama-mac');
+    expect(payload.providerOptions).toEqual({
+      'ollama-mac': {
+        chat_template_kwargs: {
+          enable_thinking: false,
+        },
+      },
+    });
+  });
+
   it('creates a stateless streaming SDK execution strategy for foreground runs', () => {
     const provider = makeProvider();
     const strategy = provider.createExecutionStrategy();


### PR DESCRIPTION
## Summary

- Use Codex CLI `token_count.last_token_usage` as `lastStepUsage` so context rotation gates on the final model step instead of cumulative agent-loop input.
- Preserve cumulative usage for run accounting and Langfuse telemetry.
- Add OpenAI-compatible `options.providerOptions` passthrough for `agentRunner` and `backgroundAgent` providers, wrapping the flat config under `options.providerId` before calling Mastra.
- Document the `ollama-mac` thinking-disable configuration and update the example config.

## Root Cause

Codex CLI exposes both cumulative token totals and final-step token usage, but Talon only parsed the cumulative `turn.completed.usage` shape. Tool-heavy agent loops could therefore exceed the context-roller threshold even when the final prompt was below it.

OpenAI-compatible foreground/background providers also did not forward request-level vendor knobs from provider config, unlike subagent model overrides.

## Validation

- `npx vitest run tests/unit/providers/codex-cli-provider.test.ts tests/unit/providers/openai-compatible-provider.test.ts`
- `npm run build`

Note: local ignored `talond.yaml` was updated to disable thinking for `ollama-mac`, but it is intentionally not committed because it is ignored operator config.