### PR TITLE
feat(lifecycle): add bounded interceptor engine

### DIFF
--- a/src/core/logging/audit-logger.ts
+++ b/src/core/logging/audit-logger.ts
@@ -143,6 +143,15 @@ export class AuditLogger {
     this.write('config.reload', entry);
   }
 
+  /**
+   * Record a bounded lifecycle interceptor decision. Callers must provide
+   * metadata only: never include intercepted content, tool arguments, model
+   * prompts, or raw handler errors in this durable audit record.
+   */
+  logLifecycleInterceptor(entry: AuditEntry): void {
+    this.write('lifecycle.interceptor', entry);
+  }
+
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------

--- a/src/lifecycle/contracts/event-contract.ts
+++ b/src/lifecycle/contracts/event-contract.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { types } from 'node:util';
 
 import {
   LifecycleContractVersionSchema,
@@ -34,20 +35,61 @@ export const LifecycleMetadataKeySchema = z
     message: 'lifecycle metadata keys must not have leading or trailing whitespace',
   });
 
-const LifecycleBoundedMetadataSchema = z
-  .record(LifecycleMetadataKeySchema, LifecycleBoundedScalarSchema)
-  .refine((metadata) => Object.keys(metadata).length <= MAX_LIFECYCLE_METADATA_ENTRIES, {
-    message: `lifecycle metadata may contain at most ${MAX_LIFECYCLE_METADATA_ENTRIES} entries`,
-  })
-  .refine(
-    (metadata) => {
-      const normalizedKeys = Object.keys(metadata).map((key) => key.normalize('NFKC'));
-      return new Set(normalizedKeys).size === normalizedKeys.length;
-    },
-    {
-      message: 'lifecycle metadata keys must not collide after Unicode normalization',
-    },
-  );
+function materializeLifecycleMetadata(
+  value: unknown,
+): Record<string, string | number | boolean | null> | undefined {
+  try {
+    if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value)) {
+      return undefined;
+    }
+    const prototype = Reflect.getPrototypeOf(value);
+    if (
+      (prototype !== Object.prototype && prototype !== null) ||
+      Object.getOwnPropertySymbols(value).length > 0
+    ) {
+      return undefined;
+    }
+    const keys = Object.keys(value);
+    if (keys.length > MAX_LIFECYCLE_METADATA_ENTRIES) return undefined;
+    const metadata = Object.create(null) as Record<string, string | number | boolean | null>;
+    const normalized = new Set<string>();
+    for (const key of keys) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (
+        !descriptor ||
+        !('value' in descriptor) ||
+        !descriptor.enumerable ||
+        normalized.has(key.normalize('NFKC'))
+      ) {
+        return undefined;
+      }
+      const parsed = LifecycleBoundedScalarSchema.safeParse(descriptor.value);
+      if (!parsed.success || !LifecycleMetadataKeySchema.safeParse(key).success) return undefined;
+      normalized.add(key.normalize('NFKC'));
+      Object.defineProperty(metadata, key, {
+        configurable: true,
+        enumerable: true,
+        value: parsed.data,
+        writable: true,
+      });
+    }
+    return metadata;
+  } catch {
+    return undefined;
+  }
+}
+
+const LifecycleBoundedMetadataSchema = z.unknown().transform((value, context) => {
+  const metadata = materializeLifecycleMetadata(value);
+  if (metadata === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'lifecycle metadata must be bounded scalar data',
+    });
+    return z.NEVER;
+  }
+  return metadata;
+});
 
 /** Durable payloads intentionally contain references and scalar metadata only. */
 export const LifecycleBoundedPayloadSchema = z

--- a/src/lifecycle/contracts/handler-contract.ts
+++ b/src/lifecycle/contracts/handler-contract.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { types } from 'node:util';
 
 import {
   LifecycleContractVersionSchema,
@@ -10,7 +11,7 @@ import {
   LifecycleVersionedTypeNameSchema,
 } from './common.js';
 import { LifecycleBudgetContractSchema } from './budget-contract.js';
-import { LifecycleEventEnvelopeSchema } from './event-contract.js';
+import { LifecycleEventEnvelopeSchema, LifecycleMetadataKeySchema } from './event-contract.js';
 import { LifecycleFailurePolicyContractSchema } from './failure-policy-contract.js';
 import {
   LifecycleAdvisoryInterceptorResultSchema,
@@ -86,6 +87,263 @@ export const LifecycleHandlerContractSchema = z
   });
 
 const LifecycleSignalEnvelopesSchema = z.array(LifecycleSignalEnvelopeSchema).max(32);
+
+const MAX_LIFECYCLE_HANDLER_SIGNALS = 32;
+const MAX_LIFECYCLE_HANDLER_METADATA_ENTRIES = 32;
+
+type SafeDataObject = Record<string, unknown>;
+
+function isSafePlainObject(value: unknown): value is object {
+  if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Reflect.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function safeDataDescriptor(value: object, key: string): PropertyDescriptor | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  return descriptor && 'value' in descriptor && descriptor.enumerable ? descriptor : undefined;
+}
+
+/**
+ * Materialize a fixed-shape ordinary v1 record without evaluating any of its
+ * properties. Strict contract schemas must see every own field: dropping an
+ * unknown field here would turn a hostile output into a valid one before Zod
+ * has a chance to reject it.
+ */
+function copyKnownObject(value: unknown, fields: readonly string[]): SafeDataObject | undefined {
+  if (!isSafePlainObject(value)) {
+    return undefined;
+  }
+  const allowedFields = new Set(fields);
+  const ownKeys = Reflect.ownKeys(value);
+  if (ownKeys.some((key) => typeof key !== 'string' || !allowedFields.has(key))) {
+    return undefined;
+  }
+  const copy = Object.create(null) as SafeDataObject;
+  for (const field of ownKeys) {
+    // `ownKeys` above established this as a string. Reading descriptors is
+    // safe after the proxy and prototype checks, and never invokes accessors.
+    const descriptor = safeDataDescriptor(value, field as string);
+    if (!descriptor) {
+      return undefined;
+    }
+    Object.defineProperty(copy, field as string, {
+      configurable: true,
+      enumerable: true,
+      value: descriptor.value,
+      writable: true,
+    });
+  }
+  return copy;
+}
+
+/** Handler-produced metadata remains the ordinary v1 record representation. */
+function materializeHandlerMetadata(value: unknown): SafeDataObject | undefined {
+  if (!isSafePlainObject(value)) {
+    return undefined;
+  }
+  if (Object.getOwnPropertySymbols(value).length > 0) return undefined;
+  const keys = Object.keys(value);
+  if (keys.length > MAX_LIFECYCLE_HANDLER_METADATA_ENTRIES) return undefined;
+  const metadata = Object.create(null) as SafeDataObject;
+  const normalizedKeys = new Set<string>();
+  for (const key of keys) {
+    const valueDescriptor = safeDataDescriptor(value, key);
+    const metadataValue: unknown = valueDescriptor?.value as unknown;
+    if (
+      !LifecycleMetadataKeySchema.safeParse(key).success ||
+      normalizedKeys.has(key.normalize('NFKC')) ||
+      !(
+        metadataValue === null ||
+        typeof metadataValue === 'boolean' ||
+        typeof metadataValue === 'number' ||
+        typeof metadataValue === 'string'
+      )
+    ) {
+      return undefined;
+    }
+    normalizedKeys.add(key.normalize('NFKC'));
+    Object.defineProperty(metadata, key, {
+      configurable: true,
+      enumerable: true,
+      value: metadataValue,
+      writable: true,
+    });
+  }
+  return metadata;
+}
+
+function materializeHandlerArray(
+  value: unknown,
+  maxLength: number,
+  materializeItem?: (item: unknown) => unknown,
+): unknown[] | undefined {
+  if (
+    !Array.isArray(value) ||
+    types.isProxy(value) ||
+    Reflect.getPrototypeOf(value) !== Array.prototype
+  ) {
+    return undefined;
+  }
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key === 'symbol')) return undefined;
+  const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length');
+  const length: unknown =
+    lengthDescriptor && 'value' in lengthDescriptor
+      ? (lengthDescriptor.value as unknown)
+      : undefined;
+  if (
+    !lengthDescriptor ||
+    !('value' in lengthDescriptor) ||
+    lengthDescriptor.enumerable ||
+    typeof length !== 'number' ||
+    !Number.isSafeInteger(length) ||
+    length < 0 ||
+    length > maxLength ||
+    keys.length !== length + 1
+  ) {
+    return undefined;
+  }
+  const result: unknown[] = [];
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (
+      !keys.includes(String(index)) ||
+      !descriptor ||
+      !('value' in descriptor) ||
+      !descriptor.enumerable
+    ) {
+      return undefined;
+    }
+    const item: unknown = descriptor.value;
+    const materialized = materializeItem ? materializeItem(item) : item;
+    if (materialized === undefined) return undefined;
+    result.push(materialized);
+  }
+  return result;
+}
+
+function materializeHandlerReference(value: unknown): SafeDataObject | undefined {
+  return copyKnownObject(value, ['type', 'id']);
+}
+
+function materializeOptionalArray(
+  target: SafeDataObject,
+  field: string,
+  materializeItem?: (item: unknown) => unknown,
+): boolean {
+  if (!Object.prototype.hasOwnProperty.call(target, field)) return true;
+  const materialized = materializeHandlerArray(
+    target[field],
+    MAX_LIFECYCLE_HANDLER_SIGNALS,
+    materializeItem,
+  );
+  if (!materialized) return false;
+  target[field] = materialized;
+  return true;
+}
+
+function materializeHandlerSignal(value: unknown): SafeDataObject | undefined {
+  const signal = copyKnownObject(value, [
+    'version',
+    'type',
+    'signalId',
+    'occurredAt',
+    'context',
+    'payload',
+  ]);
+  if (!signal) return undefined;
+  const context = copyKnownObject(signal.context, [
+    'aggregate',
+    'correlationId',
+    'causationId',
+    'recursion',
+    'provenance',
+  ]);
+  const payload = copyKnownObject(signal.payload, ['references', 'metadata']);
+  if (!context || !payload) return undefined;
+  const aggregate = copyKnownObject(context.aggregate, ['type', 'id']);
+  const recursion = copyKnownObject(context.recursion, ['depth', 'maxDepth']);
+  const provenance = copyKnownObject(context.provenance, [
+    'source',
+    'sourceEventIds',
+    'sourceReferences',
+  ]);
+  const hasMetadata = Object.prototype.hasOwnProperty.call(payload, 'metadata');
+  const metadata = hasMetadata ? materializeHandlerMetadata(payload.metadata) : undefined;
+  if (!aggregate || !recursion || !provenance || (hasMetadata && !metadata)) return undefined;
+  if (
+    !materializeOptionalArray(payload, 'references', materializeHandlerReference) ||
+    !materializeOptionalArray(provenance, 'sourceEventIds') ||
+    !materializeOptionalArray(provenance, 'sourceReferences', materializeHandlerReference)
+  ) {
+    return undefined;
+  }
+  signal.context = Object.assign(context, { aggregate, recursion, provenance });
+  signal.payload = metadata ? Object.assign(payload, { metadata }) : payload;
+  return signal;
+}
+
+function materializeHandlerSignals(value: unknown): unknown[] | undefined {
+  return materializeHandlerArray(value, MAX_LIFECYCLE_HANDLER_SIGNALS, materializeHandlerSignal);
+}
+
+function materializeLifecycleHandlerResult(value: unknown): SafeDataObject | undefined {
+  try {
+    const result = copyKnownObject(value, [
+      'outcome',
+      'outputContract',
+      'signals',
+      'result',
+      'code',
+      'message',
+      'retryable',
+    ]);
+    if (!result) return undefined;
+    if (Object.prototype.hasOwnProperty.call(result, 'signals')) {
+      const signals = materializeHandlerSignals(result.signals);
+      if (!signals) return undefined;
+      result.signals = signals;
+    }
+    if (Object.prototype.hasOwnProperty.call(result, 'result')) {
+      const interceptorResult = copyKnownObject(result.result, [
+        'outcome',
+        'signals',
+        'reason',
+        'approvalKey',
+        'transform',
+        'code',
+        'message',
+        'retryable',
+      ]);
+      if (!interceptorResult) return undefined;
+      if (Object.prototype.hasOwnProperty.call(interceptorResult, 'signals')) {
+        const signals = materializeHandlerSignals(interceptorResult.signals);
+        if (!signals) return undefined;
+        interceptorResult.signals = signals;
+      }
+      if (Object.prototype.hasOwnProperty.call(interceptorResult, 'transform')) {
+        const transform = copyKnownObject(interceptorResult.transform, [
+          'hook',
+          'content',
+          'provider',
+          'model',
+          'contextAdditions',
+          'arguments',
+          'argumentsPatch',
+        ]);
+        if (!transform) return undefined;
+        interceptorResult.transform = transform;
+      }
+      result.result = interceptorResult;
+    }
+    return result;
+  } catch {
+    return undefined;
+  }
+}
 
 export const LifecycleHandlerSuccessResultSchema = z
   .object({
@@ -325,9 +583,12 @@ export function resolveLifecycleHandlerContract(
     mode: definition.mode,
     ...(definition.requiredSafety ? { requiredSafety: definition.requiredSafety } : {}),
     parseInput,
-    acceptsOutput: Object.freeze(
-      (output: unknown) => safelyParseSchema(definition.output, output).success,
-    ),
+    acceptsOutput: Object.freeze((output: unknown) => {
+      const materialized = materializeLifecycleHandlerResult(output);
+      return (
+        materialized !== undefined && safelyParseSchema(definition.output, materialized).success
+      );
+    }),
   });
 }
 
@@ -368,7 +629,12 @@ export function parseLifecycleHandlerResult(
     return safelyParseHandlerResult({});
   }
 
-  const parsed = safelyParseHandlerResult(result);
+  // This is the hostile handler-output boundary. Signal metadata is
+  // materialized as a bounded ordinary v1 record before Zod sees it, so
+  // z.record never has to enumerate an unbounded user-controlled key set.
+  // Keep validating the original transport below through acceptsOutput.
+  const materializedResult = materializeLifecycleHandlerResult(result);
+  const parsed = safelyParseHandlerResult(materializedResult);
   if (!parsed.success || parsed.data.outcome === 'error') {
     return parsed;
   }
@@ -383,7 +649,7 @@ export function parseLifecycleHandlerResult(
 
   if (
     parsed.data.outputContract !== normalizedHandler.outputContract ||
-    !contract.acceptsOutput(parsed.data)
+    !contract.acceptsOutput(result)
   ) {
     // Reparse an intentionally incomplete result through the public result
     // schema so callers receive the same typed Zod failure shape as any other

--- a/src/lifecycle/contracts/index.ts
+++ b/src/lifecycle/contracts/index.ts
@@ -83,6 +83,7 @@ export {
   type LifecycleInterceptorContract,
   type LifecycleInterceptorEnvelope,
   type LifecycleInterceptorResult,
+  type LifecycleInterceptorTransform,
   type LifecycleAdvisoryInterceptorResult,
   type LifecycleEnforcingInterceptorResult,
 } from './interceptor-contract.js';

--- a/src/lifecycle/contracts/interceptor-contract.ts
+++ b/src/lifecycle/contracts/interceptor-contract.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { types } from 'node:util';
 
 import {
   LifecycleContractVersionSchema,
@@ -61,19 +62,33 @@ function materializeBoundedInterceptorJsonObject(
   value: unknown,
 ): LifecycleBoundedJsonObject | undefined {
   try {
-    if (!value || typeof value !== 'object' || Array.isArray(value) || !isPlainJsonObject(value)) {
+    // `types.isProxy` is intentionally the first operation on every object
+    // container. Array/prototype/descriptor reflection can execute Proxy
+    // traps, while this native predicate does not.
+    if (
+      !value ||
+      typeof value !== 'object' ||
+      types.isProxy(value) ||
+      Array.isArray(value) ||
+      !isPlainJsonObject(value)
+    ) {
       return undefined;
     }
 
     const seen = new WeakSet<object>();
-    const root = Object.create(null) as LifecycleBoundedJsonObject;
     const stack: Array<{
       value: unknown;
       depth: number;
-      isRoot: boolean;
       assign: (materialized: LifecycleBoundedJson) => void;
-    }> = [{ value, depth: 0, isRoot: true, assign: () => undefined }];
+    }> = [{ value, depth: 0, assign: () => undefined }];
+    let root: LifecycleBoundedJsonObject | undefined;
     let nodes = 0;
+    const consumeText = (text: string): boolean => {
+      if (text.length > MAX_LIFECYCLE_INTERCEPTOR_JSON_STRING_LENGTH) {
+        return false;
+      }
+      return true;
+    };
 
     while (stack.length > 0) {
       const current = stack.pop()!;
@@ -90,7 +105,7 @@ function materializeBoundedInterceptorJsonObject(
         continue;
       }
       if (typeof current.value === 'string') {
-        if (current.value.length > MAX_LIFECYCLE_INTERCEPTOR_JSON_STRING_LENGTH) {
+        if (!consumeText(current.value)) {
           return undefined;
         }
         current.assign(current.value);
@@ -106,12 +121,18 @@ function materializeBoundedInterceptorJsonObject(
       if (!current.value || typeof current.value !== 'object') {
         return undefined;
       }
+      if (types.isProxy(current.value)) {
+        return undefined;
+      }
       if (seen.has(current.value)) {
         return undefined;
       }
       seen.add(current.value);
 
       if (Array.isArray(current.value)) {
+        if (Reflect.getPrototypeOf(current.value) !== Array.prototype) {
+          return undefined;
+        }
         const keys = Reflect.ownKeys(current.value);
         if (keys.some((key) => typeof key === 'symbol')) {
           return undefined;
@@ -132,11 +153,13 @@ function materializeBoundedInterceptorJsonObject(
         }
         for (let index = 0; index < arrayLength; index += 1) {
           const key = String(index);
-          if (!keys.includes(key)) {
-            return undefined;
-          }
           const descriptor = Object.getOwnPropertyDescriptor(current.value, key);
-          if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
+          if (
+            !keys.includes(key) ||
+            !descriptor ||
+            !('value' in descriptor) ||
+            !descriptor.enumerable
+          ) {
             return undefined;
           }
         }
@@ -147,7 +170,6 @@ function materializeBoundedInterceptorJsonObject(
           stack.push({
             value: descriptor.value,
             depth: current.depth + 1,
-            isRoot: false,
             assign: (materialized) => {
               target[index] = materialized;
             },
@@ -159,23 +181,32 @@ function materializeBoundedInterceptorJsonObject(
         return undefined;
       }
 
-      const keys = Reflect.ownKeys(current.value);
-      if (keys.length > MAX_LIFECYCLE_INTERCEPTOR_JSON_COLLECTION_SIZE) {
+      if (Object.getOwnPropertySymbols(current.value).length > 0) {
         return undefined;
       }
-      for (const key of keys) {
-        if (typeof key !== 'string' || !LifecycleMetadataKeySchema.safeParse(key).success) {
-          return undefined;
-        }
-        const descriptor = Object.getOwnPropertyDescriptor(current.value, key);
-        if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
-          return undefined;
-        }
-      }
-      const target = current.isRoot ? root : (Object.create(null) as LifecycleBoundedJsonObject);
+      const keys = Object.keys(current.value);
+      if (keys.length > MAX_LIFECYCLE_INTERCEPTOR_JSON_COLLECTION_SIZE) return undefined;
+
+      const target = Object.create(null) as LifecycleBoundedJsonObject;
       current.assign(target);
-      for (const key of keys.reverse()) {
-        const descriptor = Object.getOwnPropertyDescriptor(current.value, key as string)!;
+      if (current.depth === 0) {
+        root = target;
+      }
+      const normalizedKeys = new Set<string>();
+      for (let index = keys.length - 1; index >= 0; index -= 1) {
+        const key = keys[index];
+        const valueDescriptor = Object.getOwnPropertyDescriptor(current.value, key);
+        if (
+          !valueDescriptor ||
+          !('value' in valueDescriptor) ||
+          !valueDescriptor.enumerable ||
+          !LifecycleMetadataKeySchema.safeParse(key).success ||
+          normalizedKeys.has(key.normalize('NFKC')) ||
+          !consumeText(key)
+        ) {
+          return undefined;
+        }
+        normalizedKeys.add(key.normalize('NFKC'));
         Object.defineProperty(target, key, {
           configurable: true,
           enumerable: true,
@@ -183,9 +214,8 @@ function materializeBoundedInterceptorJsonObject(
           writable: true,
         });
         stack.push({
-          value: descriptor.value,
+          value: valueDescriptor.value,
           depth: current.depth + 1,
-          isRoot: false,
           assign: (materialized) => {
             Object.defineProperty(target, key, {
               configurable: true,
@@ -198,8 +228,9 @@ function materializeBoundedInterceptorJsonObject(
       }
     }
 
-    const serialized = JSON.stringify(root);
-    return new TextEncoder().encode(serialized).byteLength <= MAX_LIFECYCLE_INTERCEPTOR_JSON_BYTES
+    return root &&
+      new TextEncoder().encode(JSON.stringify(root)).byteLength <=
+        MAX_LIFECYCLE_INTERCEPTOR_JSON_BYTES
       ? root
       : undefined;
   } catch {
@@ -392,3 +423,4 @@ export type LifecycleEnforcingInterceptorResult = z.infer<
   typeof LifecycleEnforcingInterceptorResultSchema
 >;
 export type LifecycleInterceptorResult = z.infer<typeof LifecycleInterceptorResultSchema>;
+export type LifecycleInterceptorTransform = z.infer<typeof LifecycleInterceptorTransformSchema>;

--- a/src/lifecycle/interceptors/interceptor-engine.ts
+++ b/src/lifecycle/interceptors/interceptor-engine.ts
@@ -1,0 +1,999 @@
+import { err, ok, type Result } from 'neverthrow';
+import { types } from 'node:util';
+
+import { LifecycleError } from '../../core/errors/error-types.js';
+import type { AuditLogger } from '../../core/logging/audit-logger.js';
+import {
+  LIFECYCLE_INTERCEPTOR_INPUT_CONTRACT,
+  parseLifecycleHandlerResult,
+  resolveLifecycleHandlerContract,
+  type LifecycleInterceptorEnvelope,
+  type LifecycleInterceptorTransform,
+  type LifecycleSignalEnvelope,
+} from '../contracts/index.js';
+import type {
+  LifecycleInterceptorResolutionQuery,
+  ResolvedLifecycleHandler,
+} from '../handler-registry.js';
+
+export const DEFAULT_LIFECYCLE_INTERCEPTOR_HANDLER_TIMEOUT_MS = 100;
+export const DEFAULT_LIFECYCLE_INTERCEPTOR_TOTAL_TIMEOUT_MS = 500;
+
+const IntrinsicPromiseThen = Object.getOwnPropertyDescriptor(Promise.prototype, 'then')?.value as (
+  this: Promise<unknown>,
+  onFulfilled: undefined,
+  onRejected: () => undefined,
+) => unknown;
+const IntrinsicReflectApply = Reflect.apply;
+
+/**
+ * A synchronous, bootstrap-owned native interceptor implementation.
+ *
+ * This in-process boundary deliberately accepts only native runtime identities.
+ * Such implementations are trusted daemon code and therefore can already
+ * terminate or mutate the process directly. They must return data, not a
+ * Promise. Every real, non-proxy Promise is rejected at this synchronous
+ * boundary. Ordinary native Promises (including regular subclasses) are
+ * locally drained through the captured intrinsic reaction. A handler whose
+ * Promise has a hostile `constructor` or `Symbol.species` violates this
+ * bootstrap-owned synchronous contract: JavaScript cannot attach a rejection
+ * handler locally in that case, and the engine deliberately never changes
+ * process-global fatal-error handling to hide it.
+ */
+export type LifecycleInterceptorHandler = (input: LifecycleInterceptorEnvelope) => unknown;
+
+/** Injected monotonic clock makes deadline checks deterministic in tests. */
+export interface LifecycleInterceptorClock {
+  now(): number;
+}
+
+export type LifecycleInterceptorInvocation = LifecycleInterceptorResolutionQuery;
+
+export interface LifecycleInterceptorEngineOptions {
+  readonly resolveHandlers: (
+    query: LifecycleInterceptorInvocation,
+  ) => readonly ResolvedLifecycleHandler[];
+  readonly implementations: Readonly<Record<string, LifecycleInterceptorHandler>>;
+  readonly auditLogger?: AuditLogger;
+  readonly clock?: LifecycleInterceptorClock;
+  readonly totalTimeoutMs?: number;
+  readonly defaultHandlerTimeoutMs?: number;
+}
+
+interface LifecycleInterceptorExecutionBase {
+  readonly input: LifecycleInterceptorEnvelope;
+  readonly signals: readonly LifecycleSignalEnvelope[];
+}
+
+export type LifecycleInterceptorExecution =
+  | (LifecycleInterceptorExecutionBase & Readonly<{ outcome: 'allow' }>)
+  | (LifecycleInterceptorExecutionBase &
+      Readonly<{
+        outcome: 'deny';
+        reason: string;
+        handlerId?: string;
+      }>)
+  | (LifecycleInterceptorExecutionBase &
+      Readonly<{
+        outcome: 'require_approval';
+        reason: string;
+        approvalKey: string;
+        handlerId: string;
+      }>);
+
+type InterceptorFailureReason =
+  | 'lifecycle_interceptor_error'
+  | 'lifecycle_interceptor_timeout'
+  | 'lifecycle_interceptor_total_timeout';
+
+interface DeadlineExceeded {
+  readonly kind: 'handler' | 'total';
+  readonly durationMs: number;
+}
+
+/** At most 32 resolved handlers may each emit the contract maximum of 32 signals. */
+const MAX_INTERCEPTOR_TERMINAL_SIGNALS = 1_024;
+
+function compareHandlers(left: ResolvedLifecycleHandler, right: ResolvedLifecycleHandler): number {
+  if (left.priority !== right.priority) {
+    return right.priority - left.priority;
+  }
+  return left.handler.id < right.handler.id ? -1 : left.handler.id > right.handler.id ? 1 : 0;
+}
+
+/** Parsed handler results originate from the contract materializer, so freezing
+ * them must not reinterpret bounded dynamic records through an output shape. */
+function freezeTrustedSnapshot<T>(value: T): T | undefined {
+  try {
+    const pending: object[] = [];
+    if (value && typeof value === 'object') pending.push(value as object);
+    while (pending.length > 0) {
+      const current = pending.pop()!;
+      for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(current))) {
+        const nested: unknown = 'value' in descriptor ? descriptor.value : undefined;
+        if (nested && typeof nested === 'object' && !Object.isFrozen(nested)) {
+          pending.push(nested);
+        }
+      }
+      Object.freeze(current);
+    }
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Inputs and signal entries have already crossed a bounded materialization
+ * boundary. Terminal completion therefore only needs a fixed-shape outer
+ * snapshot and a bounded signal-list copy; it must never rediscover dynamic
+ * record keys after the execution deadline has elapsed.
+ */
+function terminalSnapshot(
+  execution: LifecycleInterceptorExecution,
+): LifecycleInterceptorExecution | undefined {
+  if (execution.signals.length > MAX_INTERCEPTOR_TERMINAL_SIGNALS) {
+    return undefined;
+  }
+  const signals: LifecycleSignalEnvelope[] = [];
+  for (let index = 0; index < execution.signals.length; index += 1) {
+    signals.push(execution.signals[index]);
+  }
+  Object.freeze(signals);
+  switch (execution.outcome) {
+    case 'allow':
+      return Object.freeze({ outcome: 'allow' as const, input: execution.input, signals });
+    case 'deny':
+      return Object.freeze({
+        outcome: 'deny' as const,
+        reason: execution.reason,
+        ...(execution.handlerId ? { handlerId: execution.handlerId } : {}),
+        input: execution.input,
+        signals,
+      });
+    case 'require_approval':
+      return Object.freeze({
+        outcome: 'require_approval' as const,
+        reason: execution.reason,
+        approvalKey: execution.approvalKey,
+        handlerId: execution.handlerId,
+        input: execution.input,
+        signals,
+      });
+  }
+}
+
+function isNativePromise(value: unknown): value is Promise<unknown> {
+  return (
+    value !== null &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    !types.isProxy(value) &&
+    types.isPromise(value)
+  );
+}
+
+/**
+ * Look up a native implementation by the immutable runtime reference captured
+ * in the resolved identity. Descriptors avoid inherited implementations and
+ * accessor execution at this authority boundary.
+ */
+function findNativeImplementation(
+  implementations: Readonly<Record<string, LifecycleInterceptorHandler>>,
+  implementationRef: string,
+): LifecycleInterceptorHandler | undefined {
+  try {
+    if (types.isProxy(implementations)) {
+      return undefined;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(implementations, implementationRef);
+    return descriptor &&
+      'value' in descriptor &&
+      typeof descriptor.value === 'function' &&
+      !types.isProxy(descriptor.value)
+      ? (descriptor.value as LifecycleInterceptorHandler)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The engine's implementation map is bootstrap authority. Never let an
+ * implementationRef collision turn a subagent (or a forged resolved handler)
+ * into a native interceptor: both identity fields must be canonical own data.
+ */
+function captureNativeImplementationRef(handler: unknown): string | undefined {
+  try {
+    if (!handler || typeof handler !== 'object' || types.isProxy(handler)) {
+      return undefined;
+    }
+    const identityDescriptor = Object.getOwnPropertyDescriptor(handler, 'identity');
+    if (!identityDescriptor || !('value' in identityDescriptor)) {
+      return undefined;
+    }
+    const identity: unknown = identityDescriptor.value;
+    if (!identity || typeof identity !== 'object' || types.isProxy(identity)) {
+      return undefined;
+    }
+    const kindDescriptor = Object.getOwnPropertyDescriptor(identity, 'runtimeKind');
+    const refDescriptor = Object.getOwnPropertyDescriptor(identity, 'implementationRef');
+    return kindDescriptor &&
+      'value' in kindDescriptor &&
+      kindDescriptor.value === 'native' &&
+      refDescriptor &&
+      'value' in refDescriptor &&
+      typeof refDescriptor.value === 'string'
+      ? refDescriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `types.isPromise` rejects thenables and is checked before reflection. The
+ * captured intrinsic method bypasses instance `then`/`catch` overrides; a
+ * proxy is never passed to it because proxy reflection is trap-capable.
+ */
+function isDrainableIntrinsicPromise(promise: Promise<unknown>): boolean {
+  try {
+    return !types.isProxy(promise) && types.isPromise(promise);
+  } catch {
+    return false;
+  }
+}
+
+/** Returns whether the original rejection is known to have a safe reaction. */
+function drainNativePromiseRejection(promise: Promise<unknown>): boolean {
+  if (!isDrainableIntrinsicPromise(promise)) {
+    return false;
+  }
+  try {
+    // Both operations were captured before any handler runs. The intrinsic
+    // Promise path creates an intrinsic reaction Promise and the rejection
+    // callback resolves it, so no secondary rejection is introduced.
+    void IntrinsicReflectApply(IntrinsicPromiseThen, promise, [
+      undefined,
+      (): undefined => undefined,
+    ]);
+    return true;
+  } catch {
+    // Species construction can make intrinsic `then` unavailable before a
+    // rejection reaction is attached. This is a violation of the trusted
+    // synchronous native-handler contract; global rejection ownership would
+    // alter daemon-wide fatal-error semantics, so it is intentionally refused.
+    return false;
+  }
+}
+
+function transformMetadata(transform: LifecycleInterceptorTransform): Record<string, unknown> {
+  switch (transform.hook) {
+    case 'message.before_persist':
+    case 'message.before_send':
+      return {
+        kind: 'message_content',
+        fieldCount: 1,
+        contentLength: transform.content?.length ?? 0,
+      };
+    case 'run.before_execute':
+      return {
+        kind: 'run',
+        fieldCount:
+          Number(transform.provider !== undefined) +
+          Number(transform.model !== undefined) +
+          Number(transform.contextAdditions !== undefined),
+        contextAdditionCount: Object.keys(transform.contextAdditions ?? {}).length,
+      };
+    case 'tool.before_execute':
+      return transform.arguments !== undefined
+        ? { kind: 'tool_arguments_replace', fieldCount: Object.keys(transform.arguments).length }
+        : {
+            kind: 'tool_arguments_patch',
+            fieldCount: Object.keys(transform.argumentsPatch ?? {}).length,
+          };
+  }
+}
+
+function normalizeInput(input: unknown): LifecycleInterceptorEnvelope | undefined {
+  const contract = resolveLifecycleHandlerContract(
+    LIFECYCLE_INTERCEPTOR_INPUT_CONTRACT,
+    'talon.lifecycle.enforcing.interceptor.output.v1',
+  );
+  const parsed = contract?.parseInput(input);
+  return parsed?.success ? (parsed.data as LifecycleInterceptorEnvelope) : undefined;
+}
+
+function encodeTrustedInputForContract(input: LifecycleInterceptorEnvelope): unknown {
+  return input;
+}
+
+function applyTransform(
+  input: LifecycleInterceptorEnvelope,
+  transform: LifecycleInterceptorTransform,
+): LifecycleInterceptorEnvelope | undefined {
+  if (input.hook !== transform.hook) {
+    return undefined;
+  }
+
+  let candidate: unknown;
+  switch (transform.hook) {
+    case 'message.before_persist':
+    case 'message.before_send':
+      candidate = { ...input, input: { ...input.input, content: transform.content } };
+      break;
+    case 'run.before_execute': {
+      const runInput = input as Extract<
+        LifecycleInterceptorEnvelope,
+        { hook: 'run.before_execute' }
+      >;
+      candidate = {
+        ...input,
+        input: {
+          ...runInput.input,
+          ...(transform.provider !== undefined ? { provider: transform.provider } : {}),
+          ...(transform.model !== undefined ? { model: transform.model } : {}),
+          ...(transform.contextAdditions !== undefined
+            ? {
+                contextAdditions: {
+                  ...(runInput.input.contextAdditions ?? {}),
+                  ...transform.contextAdditions,
+                },
+              }
+            : {}),
+        },
+      };
+      break;
+    }
+    case 'tool.before_execute': {
+      const toolInput = input as Extract<
+        LifecycleInterceptorEnvelope,
+        { hook: 'tool.before_execute' }
+      >;
+      candidate = {
+        ...input,
+        input: {
+          ...toolInput.input,
+          arguments: transform.arguments ?? {
+            ...toolInput.input.arguments,
+            ...transform.argumentsPatch,
+          },
+        },
+      };
+      break;
+    }
+  }
+
+  // Contract parsing materializes a new detached, deep-frozen snapshot.
+  return normalizeInput(encodeTrustedInputForContract(candidate as LifecycleInterceptorEnvelope));
+}
+
+function boundedTimeout(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value >= 1 ? Math.floor(value) : fallback;
+}
+
+/**
+ * Executes registry-resolved native interceptors synchronously. JavaScript
+ * cannot preempt a blocked call, so every subsequent non-preemptible stage is
+ * deadline-checked before it can commit signals, transforms, or a decision.
+ */
+export class LifecycleInterceptorEngine {
+  private readonly clock: LifecycleInterceptorClock;
+  private readonly totalTimeoutMs: number;
+  private readonly defaultHandlerTimeoutMs: number;
+
+  constructor(private readonly options: LifecycleInterceptorEngineOptions) {
+    this.clock = options.clock ?? { now: (): number => performance.now() };
+    this.totalTimeoutMs = boundedTimeout(
+      options.totalTimeoutMs,
+      DEFAULT_LIFECYCLE_INTERCEPTOR_TOTAL_TIMEOUT_MS,
+    );
+    this.defaultHandlerTimeoutMs = boundedTimeout(
+      options.defaultHandlerTimeoutMs,
+      DEFAULT_LIFECYCLE_INTERCEPTOR_HANDLER_TIMEOUT_MS,
+    );
+  }
+
+  intercept(
+    invocation: LifecycleInterceptorInvocation,
+    rawInput: unknown,
+  ): Result<LifecycleInterceptorExecution, LifecycleError> {
+    const input = normalizeInput(rawInput);
+    if (!input) {
+      return err(new LifecycleError('invalid lifecycle interceptor input'));
+    }
+    if (input.hook !== invocation.hook) {
+      return err(new LifecycleError('interceptor invocation hook does not match input hook'));
+    }
+
+    const startedAt = this.clock.now();
+
+    if (input.context.recursion.depth >= input.context.recursion.maxDepth) {
+      this.auditSystem(input, 'deny', 'lifecycle_recursion_limit', 0);
+      return this.complete(
+        { outcome: 'deny', reason: 'lifecycle_recursion_limit', input, signals: [] },
+        startedAt,
+        [],
+      );
+    }
+
+    let handlers: readonly ResolvedLifecycleHandler[];
+    try {
+      handlers = [...this.options.resolveHandlers(invocation)].sort(compareHandlers);
+    } catch {
+      return err(new LifecycleError('failed to resolve lifecycle interceptor handlers'));
+    }
+
+    let current = input;
+    const signals: LifecycleSignalEnvelope[] = [];
+    const finish = (
+      execution: LifecycleInterceptorExecution,
+      unresolved: readonly ResolvedLifecycleHandler[],
+    ): Result<LifecycleInterceptorExecution, LifecycleError> =>
+      this.complete(execution, startedAt, unresolved);
+
+    for (let index = 0; index < handlers.length; index += 1) {
+      const handler = handlers[index];
+      const unresolved = handlers.slice(index);
+      const handlerStartedAt = this.clock.now();
+      const beforeInvocation = this.deadline(handler, startedAt, handlerStartedAt);
+      if (beforeInvocation) {
+        const result = this.timeoutResult(handler, current, signals, unresolved, beforeInvocation);
+        if (beforeInvocation.kind === 'total' || result.outcome !== 'allow') {
+          return finish(result, unresolved);
+        }
+        continue;
+      }
+
+      const implementationRef = captureNativeImplementationRef(handler);
+      const implementation = implementationRef
+        ? findNativeImplementation(this.options.implementations, implementationRef)
+        : undefined;
+      let rawResult: unknown;
+      let failed = false;
+      try {
+        rawResult = implementation?.(current);
+        if (!implementation) {
+          failed = true;
+        } else if (isNativePromise(rawResult)) {
+          // Reject async handlers at this synchronous boundary, while draining
+          // every genuine non-proxy Promise through the captured intrinsic
+          // reaction so rejected subclasses cannot escape as unhandled.
+          void drainNativePromiseRejection(rawResult);
+          failed = true;
+        }
+      } catch {
+        failed = true;
+      }
+
+      let deadline = this.deadline(handler, startedAt, handlerStartedAt);
+      if (deadline) {
+        const result = this.timeoutResult(handler, current, signals, unresolved, deadline);
+        if (deadline.kind === 'total' || result.outcome !== 'allow') {
+          return finish(result, unresolved);
+        }
+        continue;
+      }
+      const parsed = !failed
+        ? parseLifecycleHandlerResult(
+            handler.handler,
+            encodeTrustedInputForContract(current),
+            rawResult,
+          )
+        : undefined;
+      deadline = this.deadline(handler, startedAt, handlerStartedAt);
+      if (deadline) {
+        const result = this.timeoutResult(handler, current, signals, unresolved, deadline);
+        if (deadline.kind === 'total' || result.outcome !== 'allow') {
+          return finish(result, unresolved);
+        }
+        continue;
+      }
+      if (!parsed || !parsed.success || parsed.data.outcome === 'error') {
+        const result = this.handleFailure(
+          handler,
+          current,
+          signals,
+          'lifecycle_interceptor_error',
+          'error',
+          this.elapsed(handlerStartedAt),
+          false,
+        );
+        deadline = this.deadline(handler, startedAt, handlerStartedAt);
+        if (deadline) {
+          const timeoutResult = this.timeoutResult(handler, current, signals, unresolved, deadline);
+          if (deadline.kind === 'total' || timeoutResult.outcome !== 'allow') {
+            return finish(timeoutResult, unresolved);
+          }
+          continue;
+        }
+        this.audit(
+          handler,
+          current,
+          'error',
+          'lifecycle_interceptor_error',
+          this.elapsed(handlerStartedAt),
+        );
+        if (result.outcome !== 'allow') {
+          return finish(result, unresolved);
+        }
+        continue;
+      }
+
+      const outputSignals = freezeTrustedSnapshot(
+        parsed.data.outputContract === 'talon.lifecycle.signal.envelopes.v1'
+          ? parsed.data.signals
+          : parsed.data.result.signals,
+      ) as readonly LifecycleSignalEnvelope[] | undefined;
+      deadline = this.deadline(handler, startedAt, handlerStartedAt);
+      if (deadline) {
+        const result = this.timeoutResult(handler, current, signals, unresolved, deadline);
+        if (deadline.kind === 'total' || result.outcome !== 'allow') {
+          return finish(result, unresolved);
+        }
+        continue;
+      }
+      if (!outputSignals) {
+        const result = this.handleFailure(
+          handler,
+          current,
+          signals,
+          'lifecycle_interceptor_error',
+          'error',
+          this.elapsed(handlerStartedAt),
+          false,
+        );
+        deadline = this.deadline(handler, startedAt, handlerStartedAt);
+        if (deadline) {
+          const timeoutResult = this.timeoutResult(handler, current, signals, unresolved, deadline);
+          if (deadline.kind === 'total' || timeoutResult.outcome !== 'allow') {
+            return finish(timeoutResult, unresolved);
+          }
+          continue;
+        }
+        this.audit(
+          handler,
+          current,
+          'error',
+          'lifecycle_interceptor_error',
+          this.elapsed(handlerStartedAt),
+        );
+        if (result.outcome !== 'allow') {
+          return finish(result, unresolved);
+        }
+        continue;
+      }
+
+      if (parsed.data.outputContract === 'talon.lifecycle.advisory.interceptor.output.v1') {
+        const capacityFailure = this.signalCapacityFailure(
+          handler,
+          current,
+          signals,
+          outputSignals,
+        );
+        if (capacityFailure) {
+          if (capacityFailure.outcome !== 'allow') return finish(capacityFailure, unresolved);
+          continue;
+        }
+        this.audit(
+          handler,
+          current,
+          'advisory',
+          'handler_advisory',
+          this.elapsed(handlerStartedAt),
+        );
+        signals.push(...outputSignals);
+        continue;
+      }
+      if (parsed.data.outputContract !== 'talon.lifecycle.enforcing.interceptor.output.v1') {
+        const result = this.handleFailure(
+          handler,
+          current,
+          signals,
+          'lifecycle_interceptor_error',
+          'error',
+          this.elapsed(handlerStartedAt),
+          false,
+        );
+        deadline = this.deadline(handler, startedAt, handlerStartedAt);
+        if (deadline) {
+          const timeoutResult = this.timeoutResult(handler, current, signals, unresolved, deadline);
+          if (deadline.kind === 'total' || timeoutResult.outcome !== 'allow') {
+            return finish(timeoutResult, unresolved);
+          }
+          continue;
+        }
+        this.audit(
+          handler,
+          current,
+          'error',
+          'lifecycle_interceptor_error',
+          this.elapsed(handlerStartedAt),
+        );
+        if (result.outcome !== 'allow') {
+          return finish(result, unresolved);
+        }
+        continue;
+      }
+
+      const result = parsed.data.result;
+      if (result.outcome === 'transform') {
+        const transformed = applyTransform(current, result.transform);
+        deadline = this.deadline(handler, startedAt, handlerStartedAt);
+        if (deadline) {
+          const timeoutResult = this.timeoutResult(handler, current, signals, unresolved, deadline);
+          if (deadline.kind === 'total' || timeoutResult.outcome !== 'allow') {
+            return finish(timeoutResult, unresolved);
+          }
+          continue;
+        }
+        if (!transformed) {
+          const failure = this.handleFailure(
+            handler,
+            current,
+            signals,
+            'lifecycle_interceptor_error',
+            'error',
+            this.elapsed(handlerStartedAt),
+            false,
+          );
+          deadline = this.deadline(handler, startedAt, handlerStartedAt);
+          if (deadline) {
+            const timeoutResult = this.timeoutResult(
+              handler,
+              current,
+              signals,
+              unresolved,
+              deadline,
+            );
+            if (deadline.kind === 'total' || timeoutResult.outcome !== 'allow') {
+              return finish(timeoutResult, unresolved);
+            }
+            continue;
+          }
+          this.audit(
+            handler,
+            current,
+            'error',
+            'lifecycle_interceptor_error',
+            this.elapsed(handlerStartedAt),
+          );
+          if (failure.outcome !== 'allow') {
+            return finish(failure, unresolved);
+          }
+          continue;
+        }
+        const capacityFailure = this.signalCapacityFailure(
+          handler,
+          current,
+          signals,
+          outputSignals,
+        );
+        if (capacityFailure) {
+          if (capacityFailure.outcome !== 'allow') return finish(capacityFailure, unresolved);
+          continue;
+        }
+        this.audit(
+          handler,
+          transformed,
+          'transform',
+          'handler_transform',
+          this.elapsed(handlerStartedAt),
+          result.transform,
+        );
+        signals.push(...outputSignals);
+        current = transformed;
+        continue;
+      }
+
+      if (result.outcome === 'allow') {
+        const capacityFailure = this.signalCapacityFailure(
+          handler,
+          current,
+          signals,
+          outputSignals,
+        );
+        if (capacityFailure) {
+          if (capacityFailure.outcome !== 'allow') return finish(capacityFailure, unresolved);
+          continue;
+        }
+        this.audit(handler, current, 'allow', 'handler_allow', this.elapsed(handlerStartedAt));
+        signals.push(...outputSignals);
+        continue;
+      }
+      if (result.outcome === 'deny') {
+        const capacityFailure = this.signalCapacityFailure(
+          handler,
+          current,
+          signals,
+          outputSignals,
+        );
+        if (capacityFailure) {
+          if (capacityFailure.outcome !== 'allow') return finish(capacityFailure, unresolved);
+          continue;
+        }
+        this.audit(handler, current, 'deny', 'handler_deny', this.elapsed(handlerStartedAt));
+        signals.push(...outputSignals);
+        return finish(
+          {
+            outcome: 'deny',
+            reason: result.reason,
+            handlerId: handler.identity.handlerId,
+            input: current,
+            signals,
+          },
+          handlers.slice(index + 1),
+        );
+      }
+      if (result.outcome === 'require_approval') {
+        const capacityFailure = this.signalCapacityFailure(
+          handler,
+          current,
+          signals,
+          outputSignals,
+        );
+        if (capacityFailure) {
+          if (capacityFailure.outcome !== 'allow') return finish(capacityFailure, unresolved);
+          continue;
+        }
+        this.audit(
+          handler,
+          current,
+          'require_approval',
+          'handler_require_approval',
+          this.elapsed(handlerStartedAt),
+        );
+        signals.push(...outputSignals);
+        return finish(
+          {
+            outcome: 'require_approval',
+            reason: result.reason,
+            approvalKey: result.approvalKey,
+            handlerId: handler.identity.handlerId,
+            input: current,
+            signals,
+          },
+          handlers.slice(index + 1),
+        );
+      }
+
+      const failure = this.handleFailure(
+        handler,
+        current,
+        signals,
+        'lifecycle_interceptor_error',
+        'error',
+        this.elapsed(handlerStartedAt),
+        false,
+      );
+      deadline = this.deadline(handler, startedAt, handlerStartedAt);
+      if (deadline) {
+        const timeoutResult = this.timeoutResult(handler, current, signals, unresolved, deadline);
+        if (deadline.kind === 'total' || timeoutResult.outcome !== 'allow') {
+          return finish(timeoutResult, unresolved);
+        }
+        continue;
+      }
+      this.audit(
+        handler,
+        current,
+        'error',
+        'lifecycle_interceptor_error',
+        this.elapsed(handlerStartedAt),
+      );
+      if (failure.outcome !== 'allow') {
+        return finish(failure, unresolved);
+      }
+    }
+
+    return finish({ outcome: 'allow', input: current, signals }, []);
+  }
+
+  private deadline(
+    handler: ResolvedLifecycleHandler,
+    startedAt: number,
+    handlerStartedAt: number,
+  ): DeadlineExceeded | undefined {
+    const now = this.clock.now();
+    const durationMs = Math.max(0, now - handlerStartedAt);
+    if (durationMs >= boundedTimeout(handler.budget?.timeoutMs, this.defaultHandlerTimeoutMs)) {
+      return { kind: 'handler', durationMs };
+    }
+    const totalDurationMs = Math.max(0, now - startedAt);
+    if (totalDurationMs >= this.totalTimeoutMs) {
+      return { kind: 'total', durationMs: totalDurationMs };
+    }
+    return undefined;
+  }
+
+  private elapsed(startedAt: number): number {
+    return Math.max(0, this.clock.now() - startedAt);
+  }
+
+  private timeoutResult(
+    handler: ResolvedLifecycleHandler,
+    input: LifecycleInterceptorEnvelope,
+    signals: readonly LifecycleSignalEnvelope[],
+    unresolved: readonly ResolvedLifecycleHandler[],
+    deadline: DeadlineExceeded,
+    audit = true,
+  ): LifecycleInterceptorExecution {
+    if (deadline.kind === 'total') {
+      return this.handleAggregateTimeout(input, signals, unresolved, deadline.durationMs, audit);
+    }
+    return this.handleFailure(
+      handler,
+      input,
+      signals,
+      'lifecycle_interceptor_timeout',
+      'timeout',
+      deadline.durationMs,
+      audit,
+    );
+  }
+
+  private handleAggregateTimeout(
+    input: LifecycleInterceptorEnvelope,
+    signals: readonly LifecycleSignalEnvelope[],
+    unresolved: readonly ResolvedLifecycleHandler[],
+    durationMs: number,
+    audit = true,
+  ): LifecycleInterceptorExecution {
+    const enforcingRemaining = unresolved.filter(
+      (handler) => handler.identity.interceptorSafety === 'enforcing',
+    );
+    const outcome = enforcingRemaining.length > 0 ? 'deny' : 'allow';
+    if (audit) {
+      this.auditSystem(input, outcome, 'lifecycle_interceptor_total_timeout', durationMs, {
+        unresolvedEnforcingHandlers: enforcingRemaining.length,
+      });
+    }
+    return outcome === 'deny'
+      ? { outcome, reason: 'lifecycle_interceptor_total_timeout', input, signals }
+      : { outcome, input, signals };
+  }
+
+  private handleFailure(
+    handler: ResolvedLifecycleHandler,
+    input: LifecycleInterceptorEnvelope,
+    signals: readonly LifecycleSignalEnvelope[],
+    reason: InterceptorFailureReason,
+    decision: 'error' | 'timeout',
+    durationMs: number,
+    audit = true,
+  ): LifecycleInterceptorExecution {
+    if (audit) this.audit(handler, input, decision, reason, durationMs);
+    return handler.failurePolicy.mode === 'fail_open'
+      ? { outcome: 'allow', input, signals }
+      : { outcome: 'deny', reason, handlerId: handler.identity.handlerId, input, signals };
+  }
+
+  private signalCapacityFailure(
+    handler: ResolvedLifecycleHandler,
+    input: LifecycleInterceptorEnvelope,
+    signals: readonly LifecycleSignalEnvelope[],
+    outputSignals: readonly LifecycleSignalEnvelope[],
+  ): LifecycleInterceptorExecution | undefined {
+    return signals.length + outputSignals.length > MAX_INTERCEPTOR_TERMINAL_SIGNALS
+      ? this.handleFailure(handler, input, signals, 'lifecycle_interceptor_error', 'error', 0)
+      : undefined;
+  }
+
+  private isAggregateTimeout(execution: LifecycleInterceptorExecution): boolean {
+    return (
+      execution.outcome === 'deny' &&
+      execution.reason === 'lifecycle_interceptor_total_timeout' &&
+      execution.handlerId === undefined
+    );
+  }
+
+  private complete(
+    execution: LifecycleInterceptorExecution,
+    startedAt: number,
+    unresolved: readonly ResolvedLifecycleHandler[],
+  ): Result<LifecycleInterceptorExecution, LifecycleError> {
+    const beforeMaterializationMs = Math.max(0, this.clock.now() - startedAt);
+    // An aggregate timeout was already selected and audited at a checked
+    // execution boundary. Do not replace it merely because snapshotting is
+    // later than the deadline.
+    const alreadyAggregateTimeout = this.isAggregateTimeout(execution);
+    // A current handler has already made a restrictive terminal decision.
+    // Deadline accounting can prevent further work, but must never weaken
+    // deny/approval/fail-closed/recursion outcomes into an aggregate allow.
+    if (execution.outcome !== 'allow') {
+      const snapshot = terminalSnapshot(execution);
+      return snapshot
+        ? ok(snapshot)
+        : err(new LifecycleError('failed to materialize lifecycle interceptor execution'));
+    }
+    if (beforeMaterializationMs >= this.totalTimeoutMs && !alreadyAggregateTimeout) {
+      // Completion is deliberately non-recursive and audit-free: this is the
+      // post-deadline fallback and a synchronous audit sink could block again.
+      const timeout = this.handleAggregateTimeout(
+        execution.input,
+        execution.signals,
+        unresolved,
+        beforeMaterializationMs,
+        false,
+      );
+      const timeoutSnapshot = terminalSnapshot(timeout);
+      return timeoutSnapshot
+        ? ok(timeoutSnapshot)
+        : err(new LifecycleError('failed to materialize lifecycle interceptor timeout execution'));
+    }
+    const snapshot = terminalSnapshot(execution);
+    if (!snapshot) {
+      return err(new LifecycleError('failed to materialize lifecycle interceptor execution'));
+    }
+
+    const durationMs = Math.max(0, this.clock.now() - startedAt);
+    if (alreadyAggregateTimeout || durationMs < this.totalTimeoutMs) {
+      return ok(snapshot);
+    }
+
+    // Do not recurse through `complete`: the timeout terminal result uses the
+    // same already-trusted input and bounded signal references, and one fixed
+    // shape snapshot is sufficient after the deadline is exhausted.
+    const timeout = this.handleAggregateTimeout(
+      snapshot.input,
+      snapshot.signals,
+      unresolved,
+      durationMs,
+      false,
+    );
+    const timeoutSnapshot = terminalSnapshot(timeout);
+    return timeoutSnapshot
+      ? ok(timeoutSnapshot)
+      : err(new LifecycleError('failed to materialize lifecycle interceptor timeout execution'));
+  }
+
+  private audit(
+    handler: ResolvedLifecycleHandler,
+    input: LifecycleInterceptorEnvelope,
+    decision: string,
+    reason: string,
+    durationMs: number,
+    transform?: LifecycleInterceptorTransform,
+  ): void {
+    try {
+      this.options.auditLogger?.logLifecycleInterceptor({
+        action: 'lifecycle.interceptor',
+        details: {
+          handlerId: handler.identity.handlerId,
+          implementationRef: handler.identity.implementationRef,
+          implementationVersion: handler.identity.implementationVersion,
+          hook: input.hook,
+          decision,
+          reason,
+          durationMs: Math.floor(durationMs),
+          ...(transform ? { transform: transformMetadata(transform) } : {}),
+        },
+      });
+    } catch {
+      // Audit storage outages must not make a synchronous policy decision nondeterministic.
+    }
+  }
+
+  private auditSystem(
+    input: LifecycleInterceptorEnvelope,
+    decision: string,
+    reason: string,
+    durationMs: number,
+    details: Record<string, unknown> = {},
+  ): void {
+    try {
+      this.options.auditLogger?.logLifecycleInterceptor({
+        action: 'lifecycle.interceptor',
+        details: {
+          handlerId: 'lifecycle-engine',
+          hook: input.hook,
+          decision,
+          reason,
+          durationMs: Math.floor(durationMs),
+          ...details,
+        },
+      });
+    } catch {
+      // See `audit`: audit failures do not change enforcement semantics.
+    }
+  }
+}

--- a/src/lifecycle/interceptors/native-example-handlers.ts
+++ b/src/lifecycle/interceptors/native-example-handlers.ts
@@ -1,0 +1,27 @@
+import type { LifecycleInterceptorHandler } from './interceptor-engine.js';
+
+/** A deterministic native baseline suitable for an explicitly registered allow policy. */
+export const nativeAllowInterceptor: LifecycleInterceptorHandler = () => ({
+  outcome: 'success',
+  outputContract: 'talon.lifecycle.enforcing.interceptor.output.v1',
+  result: { outcome: 'allow', signals: [] },
+});
+
+/**
+ * Creates a deterministic native tool-name deny policy. This is deliberately
+ * data-only and synchronous; it is an example of an enforcing handler that
+ * does not delegate a security decision to a model.
+ */
+export function createNativeToolNameDenyInterceptor(
+  deniedToolNames: readonly string[],
+): LifecycleInterceptorHandler {
+  const denied = new Set(deniedToolNames);
+  return (input) => ({
+    outcome: 'success',
+    outputContract: 'talon.lifecycle.enforcing.interceptor.output.v1',
+    result:
+      input.hook === 'tool.before_execute' && denied.has(input.input.toolName)
+        ? { outcome: 'deny', reason: 'tool_denied_by_native_policy', signals: [] }
+        : { outcome: 'allow', signals: [] },
+  });
+}

--- a/tests/unit/core/logging/audit-logger.test.ts
+++ b/tests/unit/core/logging/audit-logger.test.ts
@@ -10,7 +10,10 @@ import type { AuditEntry, AuditStore } from '../../../../src/core/logging/audit-
 /**
  * Creates a pino logger that writes JSON to an in-memory array.
  */
-function createCapturingLogger(): { logger: pino.Logger; records: () => Record<string, unknown>[] } {
+function createCapturingLogger(): {
+  logger: pino.Logger;
+  records: () => Record<string, unknown>[];
+} {
   const raw: string[] = [];
   const writable = {
     write(chunk: string) {
@@ -64,6 +67,7 @@ describe.each([
   ['logChannelSend', 'channel.send'],
   ['logScheduleTrigger', 'schedule.trigger'],
   ['logConfigReload', 'config.reload'],
+  ['logLifecycleInterceptor', 'lifecycle.interceptor'],
 ] as const)('%s()', (method, expectedMsg) => {
   it(`writes a pino record with msg "${expectedMsg}"`, () => {
     const { logger, records } = createCapturingLogger();
@@ -208,9 +212,7 @@ describe('details payload', () => {
   it('preserves nested objects', () => {
     const { logger, records } = createCapturingLogger();
     const audit = new AuditLogger(logger);
-    audit.logToolExecution(
-      makeEntry({ details: { nested: { a: 1, b: [2, 3] }, flag: true } }),
-    );
+    audit.logToolExecution(makeEntry({ details: { nested: { a: 1, b: [2, 3] }, flag: true } }));
     expect(records()[0].details).toEqual({ nested: { a: 1, b: [2, 3] }, flag: true });
   });
 

--- a/tests/unit/lifecycle/handler-registry.test.ts
+++ b/tests/unit/lifecycle/handler-registry.test.ts
@@ -217,10 +217,13 @@ interface DerivedSignal {
       sourceReferences: Array<{ type: string; id: string }>;
     };
   };
-  payload: { references: never[]; metadata: Record<string, never> };
+  payload: { references: never[]; metadata: Record<string, unknown> };
 }
 
-function makeCausallyDerivedSignal(invocation: CausalInvocation): DerivedSignal {
+function makeCausallyDerivedSignal(
+  invocation: CausalInvocation,
+  metadata: Record<string, unknown> = {},
+): DerivedSignal {
   const causationId = invocation.eventId ?? invocation.signalId ?? invocation.interceptionId;
   return {
     version: 'v1',
@@ -241,7 +244,7 @@ function makeCausallyDerivedSignal(invocation: CausalInvocation): DerivedSignal 
         sourceReferences: [...invocation.context.provenance.sourceReferences],
       },
     },
-    payload: { references: [], metadata: {} },
+    payload: { references: [], metadata },
   };
 }
 
@@ -535,7 +538,11 @@ describe('LifecycleHandlerRegistry', () => {
       },
       {
         hook: 'tool.before_execute',
-        input: { toolCallId: 'tool-1', toolName: 'calendar-create', arguments: { duration: 30 } },
+        input: {
+          toolCallId: 'tool-1',
+          toolName: 'calendar-create',
+          arguments: { duration: 30 },
+        },
       },
       {
         hook: 'message.before_send',
@@ -655,7 +662,10 @@ describe('LifecycleHandlerRegistry', () => {
         contextAdditions: { executionEnvironment: { resources: { memoryMb: 4096 } } },
       },
       { hook: 'tool.before_execute', arguments: { duration: 30 } },
-      { hook: 'tool.before_execute', argumentsPatch: { headers: { 'x-trace': 'trace-1' } } },
+      {
+        hook: 'tool.before_execute',
+        argumentsPatch: { headers: { 'x-trace': 'trace-1' } },
+      },
     ]) {
       expect(LifecycleInterceptorTransformSchema.safeParse(transform).success).toBe(true);
     }
@@ -822,7 +832,10 @@ describe('LifecycleHandlerRegistry', () => {
         outputContract: LIFECYCLE_ENFORCING_INTERCEPTOR_OUTPUT_CONTRACT,
         result: {
           outcome: 'transform',
-          transform: { hook: 'tool.before_execute', argumentsPatch: { trace: true } },
+          transform: {
+            hook: 'tool.before_execute',
+            argumentsPatch: { trace: true },
+          },
           signals: [],
         },
       }).success,
@@ -988,6 +1001,179 @@ describe('LifecycleHandlerRegistry', () => {
         signals: [boundarySignal],
       }).success,
     ).toBe(false);
+  });
+
+  it('defaults omitted metadata in causally valid enforcing interceptor signals', () => {
+    const context = {
+      aggregate: { type: 'thread', id: 'thread-omitted-metadata' },
+      correlationId: 'correlation-omitted-metadata',
+      recursion: { depth: 0, maxDepth: 2 },
+      provenance: { source: 'message-pipeline', sourceEventIds: [], sourceReferences: [] },
+    };
+    const input = {
+      version: 'v1' as const,
+      interceptionId: 'interception-omitted-metadata',
+      context,
+      hook: 'tool.before_execute' as const,
+      input: { toolCallId: 'tool-omitted-metadata', toolName: 'Tool.Http:Send', arguments: {} },
+    };
+    const handler = LifecycleHandlerContractSchema.parse({
+      version: 'v1',
+      id: 'enforcer-omitted-metadata',
+      mode: 'interceptor',
+      interceptorSafety: 'enforcing',
+      inputContract: LIFECYCLE_INTERCEPTOR_INPUT_CONTRACT,
+      outputContract: LIFECYCLE_ENFORCING_INTERCEPTOR_OUTPUT_CONTRACT,
+      runtime: { kind: 'native', ref: 'enforcer-omitted-metadata', implementationVersion: '1.0.0' },
+    });
+    const signal = makeCausallyDerivedSignal(input);
+    delete (signal.payload as { metadata?: unknown }).metadata;
+
+    const parsed = parseLifecycleHandlerResult(handler, input, {
+      outcome: 'success',
+      outputContract: LIFECYCLE_ENFORCING_INTERCEPTOR_OUTPUT_CONTRACT,
+      result: { outcome: 'allow', signals: [signal] },
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.outcome !== 'error') {
+      expect(parsed.data.result.signals[0]?.payload.metadata).toEqual({});
+    }
+  });
+
+  it('materializes ordinary handler signal metadata without executing hostile accessors', () => {
+    const handler = makeRegistryInput().lifecycle!.handlers[0]!;
+    const input = makeEventEnvelope();
+    const parse = (metadata: unknown) =>
+      parseLifecycleHandlerResult(handler, input, {
+        outcome: 'success',
+        outputContract: LIFECYCLE_SIGNAL_ENVELOPES_OUTPUT_CONTRACT,
+        signals: [makeCausallyDerivedSignal(input, metadata as Record<string, unknown>)],
+      });
+
+    const accepted = parse({
+      'customer.custom': 'retained',
+      outcome: true,
+      entries: 3,
+      metadata: null,
+    });
+    expect(accepted.success).toBe(true);
+    if (accepted.success && accepted.data.outcome !== 'error') {
+      expect(accepted.data.signals[0]?.payload.metadata).toEqual({
+        'customer.custom': 'retained',
+        outcome: true,
+        entries: 3,
+        metadata: null,
+      });
+    }
+
+    const protoMetadata = Object.create(null) as Record<string, unknown>;
+    Object.defineProperty(protoMetadata, '__proto__', {
+      configurable: true,
+      enumerable: true,
+      value: 'retained',
+      writable: true,
+    });
+    const protoAccepted = parse(protoMetadata);
+    expect(protoAccepted.success).toBe(true);
+    if (protoAccepted.success && protoAccepted.data.outcome !== 'error') {
+      const metadata = protoAccepted.data.signals[0]!.payload.metadata;
+      expect(Object.getPrototypeOf(metadata)).toBeNull();
+      expect(metadata.__proto__).toBe('retained');
+    }
+
+    expect(parse({ A: 1, Ａ: 2 }).success).toBe(false);
+    expect(parse({ A: 1, Ａ: 2 }).success).toBe(false);
+
+    let accessorCalls = 0;
+    const accessorEntry = {};
+    Object.defineProperty(accessorEntry, 'never-read', {
+      enumerable: true,
+      get() {
+        accessorCalls += 1;
+        return 'never-read';
+      },
+    });
+    expect(parse(accessorEntry).success).toBe(false);
+    expect(accessorCalls).toBe(0);
+
+    let proxyTraps = 0;
+    const metadataProxy = new Proxy(
+      {},
+      {
+        get() {
+          proxyTraps += 1;
+          throw new Error('proxy trap');
+        },
+        getOwnPropertyDescriptor() {
+          proxyTraps += 1;
+          throw new Error('proxy trap');
+        },
+      },
+    );
+    expect(parse(metadataProxy).success).toBe(false);
+    expect(proxyTraps).toBe(0);
+
+    let unknownGetterCalls = 0;
+    const boundedMetadata: Record<string, unknown> = {};
+    const ordinaryRecord: Record<string, unknown> = {};
+    for (let index = 0; index < 4_096; index += 1) {
+      Object.defineProperty(boundedMetadata, `unknown-${index}`, {
+        enumerable: true,
+        get() {
+          unknownGetterCalls += 1;
+          throw new Error('unknown metadata must not be read');
+        },
+      });
+      Object.defineProperty(ordinaryRecord, `unknown-${index}`, {
+        enumerable: true,
+        get() {
+          unknownGetterCalls += 1;
+          throw new Error('ordinary metadata must not be enumerated');
+        },
+      });
+    }
+    expect(parse(boundedMetadata).success).toBe(false);
+    expect(parse(ordinaryRecord).success).toBe(false);
+    expect(unknownGetterCalls).toBe(0);
+  });
+
+  it('strictly rejects unknown handler-output fields without executing their accessors', () => {
+    const handler = makeRegistryInput().lifecycle!.handlers[0]!;
+    const input = makeEventEnvelope();
+    const output = {
+      outcome: 'success' as const,
+      outputContract: LIFECYCLE_SIGNAL_ENVELOPES_OUTPUT_CONTRACT,
+      signals: [makeCausallyDerivedSignal(input)],
+    };
+    let topLevelGetterCalls = 0;
+    Object.defineProperty(output, 'unexpected', {
+      enumerable: true,
+      get() {
+        topLevelGetterCalls += 1;
+        throw new Error('unknown top-level output field must not be read');
+      },
+    });
+
+    expect(parseLifecycleHandlerResult(handler, input, output).success).toBe(false);
+    expect(topLevelGetterCalls).toBe(0);
+
+    const nestedOutput = {
+      outcome: 'success' as const,
+      outputContract: LIFECYCLE_SIGNAL_ENVELOPES_OUTPUT_CONTRACT,
+      signals: [makeCausallyDerivedSignal(input)],
+    };
+    let nestedGetterCalls = 0;
+    Object.defineProperty(nestedOutput.signals[0]!.context, 'unexpected', {
+      enumerable: true,
+      get() {
+        nestedGetterCalls += 1;
+        throw new Error('unknown nested output field must not be read');
+      },
+    });
+
+    expect(parseLifecycleHandlerResult(handler, input, nestedOutput).success).toBe(false);
+    expect(nestedGetterCalls).toBe(0);
   });
 
   it('resolves explicitly attached event handlers in deterministic priority order', () => {

--- a/tests/unit/lifecycle/interceptor-engine.test.ts
+++ b/tests/unit/lifecycle/interceptor-engine.test.ts
@@ -1,0 +1,1566 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AuditLogger, type AuditEntry } from '../../../src/core/logging/audit-logger.js';
+import {
+  LifecycleInterceptorEngine,
+  type LifecycleInterceptorClock,
+  type LifecycleInterceptorHandler,
+  type LifecycleInterceptorInvocation,
+} from '../../../src/lifecycle/interceptors/interceptor-engine.js';
+import {
+  createNativeToolNameDenyInterceptor,
+  nativeAllowInterceptor,
+} from '../../../src/lifecycle/interceptors/native-example-handlers.js';
+import type { ResolvedLifecycleHandler } from '../../../src/lifecycle/handler-registry.js';
+import {
+  LifecycleInterceptorEnvelopeSchema,
+  LifecycleInterceptorTransformSchema,
+  type LifecycleSignalEnvelope,
+} from '../../../src/lifecycle/contracts/index.js';
+
+const hook = 'tool.before_execute' as const;
+
+function makeInput(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 'v1',
+    interceptionId: 'interception-1',
+    hook,
+    context: {
+      aggregate: { type: 'thread', id: 'thread-1' },
+      correlationId: 'correlation-1',
+      recursion: { depth: 0, maxDepth: 4 },
+      provenance: { source: 'test-source' },
+    },
+    input: {
+      toolCallId: 'tool-call-1',
+      toolName: 'web_search',
+      arguments: { query: 'original' },
+    },
+    ...overrides,
+  };
+}
+
+function makeHandler(
+  id: string,
+  priority: number,
+  overrides: {
+    safety?: 'advisory' | 'enforcing';
+    timeoutMs?: number;
+    failurePolicy?: 'fail_open' | 'fail_closed';
+    implementationRef?: string;
+  } = {},
+): ResolvedLifecycleHandler {
+  const safety = overrides.safety ?? 'enforcing';
+  const implementationRef = overrides.implementationRef ?? id;
+  return {
+    persona: 'assistant',
+    priority,
+    handler: {
+      version: 'v1',
+      id,
+      mode: 'interceptor',
+      inputContract: 'talon.lifecycle.interceptor.input.v1',
+      outputContract:
+        safety === 'enforcing'
+          ? 'talon.lifecycle.enforcing.interceptor.output.v1'
+          : 'talon.lifecycle.advisory.interceptor.output.v1',
+      runtime: {
+        kind: 'native',
+        ref: implementationRef,
+        implementationVersion: '1.0.0',
+      },
+      interceptorSafety: safety,
+    },
+    identity: {
+      version: 'v1',
+      handlerId: id,
+      runtimeKind: 'native',
+      implementationRef,
+      implementationVersion: '1.0.0',
+      mode: 'interceptor',
+      inputContract: 'talon.lifecycle.interceptor.input.v1',
+      outputContract:
+        safety === 'enforcing'
+          ? 'talon.lifecycle.enforcing.interceptor.output.v1'
+          : 'talon.lifecycle.advisory.interceptor.output.v1',
+      interceptorSafety: safety,
+    },
+    subscription: { kind: 'interceptor', interceptors: [{ version: 'v1', hook }] },
+    ...(overrides.timeoutMs ? { budget: { version: 'v1', timeoutMs: overrides.timeoutMs } } : {}),
+    failurePolicy: {
+      version: 'v1',
+      mode: overrides.failurePolicy ?? (safety === 'advisory' ? 'fail_open' : 'fail_closed'),
+    },
+  };
+}
+
+function enforcingResult(result: Record<string, unknown>) {
+  return {
+    outcome: 'success' as const,
+    outputContract: 'talon.lifecycle.enforcing.interceptor.output.v1' as const,
+    result: { signals: [], ...result },
+  };
+}
+
+function advisoryResult() {
+  return {
+    outcome: 'success' as const,
+    outputContract: 'talon.lifecycle.advisory.interceptor.output.v1' as const,
+    result: { outcome: 'advisory' as const, signals: [] },
+  };
+}
+
+function handlerMetadata(entries: Array<readonly [string, string | number | boolean | null]>) {
+  return Object.fromEntries(entries);
+}
+
+function causallyDerivedSignal(
+  input: { interceptionId: string; context: Record<string, unknown> },
+  signalId: string,
+  metadata = handlerMetadata([]),
+) {
+  const context = input.context as {
+    aggregate: { type: string; id: string };
+    correlationId: string;
+    recursion: { depth: number; maxDepth: number };
+    provenance: { source: string; sourceEventIds?: string[]; sourceReferences?: unknown[] };
+  };
+  return {
+    version: 'v1' as const,
+    type: 'context.rotate.requested.v1' as const,
+    signalId,
+    occurredAt: '2026-07-15T19:00:01.000Z',
+    context: {
+      aggregate: { ...context.aggregate },
+      correlationId: context.correlationId,
+      causationId: input.interceptionId,
+      recursion: { depth: context.recursion.depth + 1, maxDepth: context.recursion.maxDepth },
+      provenance: {
+        source: context.provenance.source,
+        sourceEventIds: [...(context.provenance.sourceEventIds ?? [])],
+        sourceReferences: [...(context.provenance.sourceReferences ?? [])],
+      },
+    },
+    payload: { references: [], metadata },
+  };
+}
+
+function makeClock(): LifecycleInterceptorClock & { advance: (milliseconds: number) => void } {
+  let now = 0;
+  return {
+    now: () => now,
+    advance: (milliseconds) => {
+      now += milliseconds;
+    },
+  };
+}
+
+function makeEngine(
+  handlers: readonly ResolvedLifecycleHandler[],
+  implementations: Record<string, LifecycleInterceptorHandler>,
+  options: Partial<ConstructorParameters<typeof LifecycleInterceptorEngine>[0]> = {},
+) {
+  return new LifecycleInterceptorEngine({
+    resolveHandlers: () => handlers,
+    implementations,
+    totalTimeoutMs: 50,
+    ...options,
+  });
+}
+
+function invoke(engine: LifecycleInterceptorEngine, input = makeInput()) {
+  return engine.intercept({ persona: 'assistant', hook }, input);
+}
+
+describe('LifecycleInterceptorEngine', () => {
+  it('orders handlers by descending priority then handler id and composes transforms', () => {
+    const calls: string[] = [];
+    const engine = makeEngine(
+      [makeHandler('z-last', 0), makeHandler('a-first', 10), makeHandler('middle', 5)],
+      {
+        'a-first': (input) => {
+          calls.push('a-first');
+          expect(input.input.arguments).toEqual({ query: 'original' });
+          return enforcingResult({
+            outcome: 'transform',
+            transform: { hook, argumentsPatch: { page: 1 } },
+          });
+        },
+        middle: (input) => {
+          calls.push('middle');
+          expect(input.input.arguments).toEqual({ query: 'original', page: 1 });
+          return enforcingResult({
+            outcome: 'transform',
+            transform: { hook, argumentsPatch: { limit: 10 } },
+          });
+        },
+        'z-last': (input) => {
+          calls.push('z-last');
+          expect(input.input.arguments).toEqual({ query: 'original', page: 1, limit: 10 });
+          return enforcingResult({ outcome: 'allow' });
+        },
+      },
+    );
+
+    const result = invoke(engine);
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toMatchObject({
+      outcome: 'allow',
+      input: { input: { arguments: { query: 'original', page: 1, limit: 10 } } },
+    });
+    expect(calls).toEqual(['a-first', 'middle', 'z-last']);
+  });
+
+  it('breaks equal-priority ties by handler id regardless of resolver input order', () => {
+    const calls: string[] = [];
+    const engine = makeEngine([makeHandler('z-last', 1), makeHandler('a-first', 1)], {
+      'a-first': () => {
+        calls.push('a-first');
+        return enforcingResult({ outcome: 'allow' });
+      },
+      'z-last': () => {
+        calls.push('z-last');
+        return enforcingResult({ outcome: 'allow' });
+      },
+    });
+
+    expect(invoke(engine)._unsafeUnwrap().outcome).toBe('allow');
+    expect(calls).toEqual(['a-first', 'z-last']);
+  });
+
+  it('dispatches by the resolved implementation reference, not the configured handler id', () => {
+    const implementation = vi.fn(() => enforcingResult({ outcome: 'allow' }));
+    const engine = makeEngine(
+      [makeHandler('configured-handler-id', 1, { implementationRef: 'native-implementation-ref' })],
+      { 'native-implementation-ref': implementation },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap().outcome).toBe('allow');
+    expect(implementation).toHaveBeenCalledOnce();
+  });
+
+  it('never dispatches a colliding implementation reference for a non-native identity', () => {
+    const implementation = vi.fn(() => enforcingResult({ outcome: 'allow' }));
+    const handler = makeHandler('subagent-collision', 1, { implementationRef: 'shared-ref' });
+    const collision = {
+      ...handler,
+      identity: { ...handler.identity, runtimeKind: 'subagent' },
+    } as unknown as ResolvedLifecycleHandler;
+    const engine = makeEngine([collision], { 'shared-ref': implementation });
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+      handlerId: 'subagent-collision',
+    });
+    expect(implementation).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch inherited implementations', () => {
+    const inheritedImplementation = vi.fn(() => enforcingResult({ outcome: 'allow' }));
+    const implementations = Object.create({
+      'native-implementation-ref': inheritedImplementation,
+    }) as Record<string, LifecycleInterceptorHandler>;
+    const engine = makeEngine(
+      [makeHandler('configured-handler-id', 1, { implementationRef: 'native-implementation-ref' })],
+      implementations,
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+      handlerId: 'configured-handler-id',
+    });
+    expect(inheritedImplementation).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits a deny and preserves its transformed input snapshot', () => {
+    const after = vi.fn();
+    const engine = makeEngine(
+      [makeHandler('transform', 2), makeHandler('deny', 1), makeHandler('after', 0)],
+      {
+        transform: () =>
+          enforcingResult({
+            outcome: 'transform',
+            transform: { hook, argumentsPatch: { safe: true } },
+          }),
+        deny: () => enforcingResult({ outcome: 'deny', reason: 'not allowed' }),
+        after,
+      },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'not allowed',
+      input: { input: { arguments: { query: 'original', safe: true } } },
+    });
+    expect(after).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits a required approval', () => {
+    const engine = makeEngine([makeHandler('approval', 1)], {
+      approval: () =>
+        enforcingResult({
+          outcome: 'require_approval',
+          reason: 'approval required',
+          approvalKey: 'approval-1',
+        }),
+    });
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'require_approval',
+      reason: 'approval required',
+      approvalKey: 'approval-1',
+    });
+  });
+
+  it('applies message and run transforms without exposing unbounded values', () => {
+    const messageInput = {
+      ...makeInput(),
+      hook: 'message.before_send',
+      input: {
+        messageId: 'message-1',
+        recipientId: 'recipient-1',
+        content: 'original',
+        source: 'outbound',
+      },
+    };
+    const messageEngine = makeEngine([makeHandler('message-transform', 1)], {
+      'message-transform': () =>
+        enforcingResult({
+          outcome: 'transform',
+          transform: { hook: 'message.before_send', content: 'updated' },
+        }),
+    });
+
+    expect(
+      messageEngine
+        .intercept({ persona: 'assistant', hook: 'message.before_send' }, messageInput)
+        ._unsafeUnwrap(),
+    ).toMatchObject({ outcome: 'allow', input: { input: { content: 'updated' } } });
+
+    const runInput = {
+      ...makeInput(),
+      hook: 'run.before_execute',
+      input: {
+        runId: 'run-1',
+        provider: 'provider-a',
+        model: 'model-a',
+        persona: 'assistant',
+        contextAdditions: { retained: true },
+      },
+    };
+    const runEngine = makeEngine([makeHandler('run-transform', 1)], {
+      'run-transform': () =>
+        enforcingResult({
+          outcome: 'transform',
+          transform: {
+            hook: 'run.before_execute',
+            provider: 'provider-b',
+            contextAdditions: { added: true },
+          },
+        }),
+    });
+
+    expect(
+      runEngine
+        .intercept({ persona: 'assistant', hook: 'run.before_execute' }, runInput)
+        ._unsafeUnwrap(),
+    ).toMatchObject({
+      outcome: 'allow',
+      input: {
+        input: {
+          provider: 'provider-b',
+          contextAdditions: { retained: true, added: true },
+        },
+      },
+    });
+  });
+
+  it('fails closed on thrown errors and ignores advisory handler failures', () => {
+    const next = vi.fn(() => enforcingResult({ outcome: 'allow' }));
+    const engine = makeEngine(
+      [
+        makeHandler('open', 2, { safety: 'advisory' }),
+        makeHandler('closed', 1),
+        makeHandler('next', 0),
+      ],
+      {
+        open: () => {
+          throw new Error('advisory failure');
+        },
+        closed: () => {
+          throw new Error('enforcing failure');
+        },
+        next,
+      },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+      handlerId: 'closed',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('enforces per-handler and aggregate deadlines deterministically', () => {
+    const clock = makeClock();
+    const skipped = vi.fn();
+    const engine = makeEngine(
+      [makeHandler('slow', 2, { timeoutMs: 5 }), makeHandler('skipped', 1)],
+      {
+        slow: () => {
+          clock.advance(6);
+          return enforcingResult({ outcome: 'allow' });
+        },
+        skipped,
+      },
+      { clock, totalTimeoutMs: 5 },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_timeout',
+    });
+    expect(skipped).not.toHaveBeenCalled();
+  });
+
+  it('continues after a fail-open handler timeout while ignoring its result', () => {
+    const clock = makeClock();
+    const next = vi.fn(() => enforcingResult({ outcome: 'allow' }));
+    const engine = makeEngine(
+      [
+        makeHandler('slow-advisory', 2, { safety: 'advisory', timeoutMs: 5 }),
+        makeHandler('next', 1),
+      ],
+      {
+        'slow-advisory': () => {
+          clock.advance(6);
+          return advisoryResult();
+        },
+        next,
+      },
+      { clock, totalTimeoutMs: 50 },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap().outcome).toBe('allow');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('executes a later enforcing deny after a fail-open pre-invocation timeout', () => {
+    let clockReads = 0;
+    const clock: LifecycleInterceptorClock = {
+      now: () => {
+        clockReads += 1;
+        return clockReads < 3 ? 0 : 6;
+      },
+    };
+    const timedOutAdvisory = vi.fn(() => advisoryResult());
+    const enforcingDeny = vi.fn(() =>
+      enforcingResult({ outcome: 'deny', reason: 'enforced after pre-invocation timeout' }),
+    );
+    const engine = makeEngine(
+      [
+        makeHandler('timed-out-advisory', 2, { safety: 'advisory', timeoutMs: 5 }),
+        makeHandler('enforcing-deny', 1),
+      ],
+      { 'timed-out-advisory': timedOutAdvisory, 'enforcing-deny': enforcingDeny },
+      { clock, totalTimeoutMs: 50 },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'enforced after pre-invocation timeout',
+      handlerId: 'enforcing-deny',
+    });
+    expect(timedOutAdvisory).not.toHaveBeenCalled();
+    expect(enforcingDeny).toHaveBeenCalledOnce();
+  });
+
+  it('continues after an advisory failure audit exhausts only that handler deadline and executes a later deny', () => {
+    const clock = makeClock();
+    const auditLogger = {
+      logLifecycleInterceptor: vi.fn(() => clock.advance(6)),
+    } as unknown as AuditLogger;
+    const deny = vi.fn(() => enforcingResult({ outcome: 'deny', reason: 'enforced after audit' }));
+    const engine = makeEngine(
+      [
+        makeHandler('advisory-failure', 2, { safety: 'advisory', timeoutMs: 5 }),
+        makeHandler('enforcing-deny', 1),
+      ],
+      {
+        'advisory-failure': () => {
+          throw new Error('advisory failure');
+        },
+        'enforcing-deny': deny,
+      },
+      { clock, totalTimeoutMs: 50, auditLogger },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'enforced after audit',
+      handlerId: 'enforcing-deny',
+    });
+    expect(deny).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed at the aggregate deadline when an enforcing handler remains after advisory work', () => {
+    let reads = 0;
+    const clock: LifecycleInterceptorClock = {
+      now: () => {
+        reads += 1;
+        return reads >= 9 ? 5 : 0;
+      },
+    };
+    const enforcing = vi.fn(() => enforcingResult({ outcome: 'allow' }));
+    const engine = makeEngine(
+      [makeHandler('advisory', 2, { safety: 'advisory' }), makeHandler('enforcing', 1)],
+      { advisory: advisoryResult, enforcing },
+      { clock, totalTimeoutMs: 5 },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_total_timeout',
+    });
+    expect(enforcing).not.toHaveBeenCalled();
+  });
+
+  it('rejects a late parsed result before its deny decision can take effect', () => {
+    let reads = 0;
+    const clock: LifecycleInterceptorClock = {
+      now: () => {
+        reads += 1;
+        return reads >= 6 ? 6 : 0;
+      },
+    };
+    const engine = makeEngine(
+      [makeHandler('late-parser', 1, { timeoutMs: 5 })],
+      { 'late-parser': () => enforcingResult({ outcome: 'deny', reason: 'late deny' }) },
+      { clock },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_timeout',
+      handlerId: 'late-parser',
+    });
+  });
+
+  it('rejects a late transform before it can commit its input or signals', () => {
+    let reads = 0;
+    const clock: LifecycleInterceptorClock = {
+      now: () => {
+        reads += 1;
+        return reads >= 7 ? 6 : 0;
+      },
+    };
+    const engine = makeEngine(
+      [makeHandler('late-transform', 1, { timeoutMs: 5 })],
+      {
+        'late-transform': () =>
+          enforcingResult({
+            outcome: 'transform',
+            transform: { hook, argumentsPatch: { late: true } },
+          }),
+      },
+      { clock },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_timeout',
+      input: { input: { arguments: { query: 'original' } } },
+      signals: [],
+    });
+  });
+
+  it('does not invoke handlers after an aggregate deadline is exhausted', () => {
+    const clock = makeClock();
+    const second = vi.fn();
+    const engine = makeEngine(
+      [makeHandler('first', 2), makeHandler('second', 1)],
+      {
+        first: () => {
+          clock.advance(5);
+          return enforcingResult({ outcome: 'allow' });
+        },
+        second,
+      },
+      { clock, totalTimeoutMs: 5 },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_total_timeout',
+    });
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it('gives later handlers and callers detached immutable snapshots', () => {
+    const engine = makeEngine([makeHandler('transform', 2), makeHandler('assert-frozen', 1)], {
+      transform: () =>
+        enforcingResult({
+          outcome: 'transform',
+          transform: { hook, argumentsPatch: { safe: true } },
+        }),
+      'assert-frozen': (input) => {
+        expect(Object.isFrozen(input)).toBe(true);
+        expect(Object.isFrozen(input.input)).toBe(true);
+        expect(Object.isFrozen(input.input.arguments)).toBe(true);
+        expect(() => {
+          (input.input.arguments as Record<string, unknown>).query = 'mutated';
+        }).toThrow(TypeError);
+        return enforcingResult({ outcome: 'allow' });
+      },
+    });
+
+    const result = invoke(engine)._unsafeUnwrap();
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.input)).toBe(true);
+    expect(Object.isFrozen(result.input.input.arguments)).toBe(true);
+    expect(Object.isFrozen(result.signals)).toBe(true);
+    expect(() => {
+      (result.input.input.arguments as Record<string, unknown>).query = 'mutated';
+    }).toThrow(TypeError);
+    expect(() =>
+      (result.signals as LifecycleSignalEnvelope[]).push({} as LifecycleSignalEnvelope),
+    ).toThrow(TypeError);
+  });
+
+  it('preserves arbitrary bounded handler metadata keys, including fixed-shape collisions', () => {
+    const engine = makeEngine([makeHandler('metadata', 1)], {
+      metadata: (input) =>
+        enforcingResult({
+          outcome: 'allow',
+          signals: [
+            causallyDerivedSignal(
+              input,
+              'metadata-signal',
+              handlerMetadata([
+                ['customer.custom', 'retained'],
+                ['outcome', true],
+                ['entries', 7],
+                ['metadata', null],
+              ]),
+            ),
+          ],
+        }),
+    });
+
+    expect(invoke(engine)._unsafeUnwrap().signals[0]?.payload.metadata).toEqual({
+      'customer.custom': 'retained',
+      outcome: true,
+      entries: 7,
+      metadata: null,
+    });
+  });
+
+  it('allows enforcing signals that omit metadata and defaults it', () => {
+    const engine = makeEngine([makeHandler('omitted-metadata', 1)], {
+      'omitted-metadata': (input) => {
+        const signal = causallyDerivedSignal(input, 'omitted-metadata-signal');
+        delete (signal.payload as { metadata?: unknown }).metadata;
+        return enforcingResult({ outcome: 'allow', signals: [signal] });
+      },
+    });
+
+    const result = invoke(engine)._unsafeUnwrap();
+
+    expect(result).toMatchObject({ outcome: 'allow' });
+    expect(result.signals[0]?.payload.metadata).toEqual({});
+  });
+
+  it('rejects malformed handler metadata without invoking accessors or proxy traps', () => {
+    const execute = (metadata: unknown) => {
+      const engine = makeEngine([makeHandler('metadata-boundary', 1)], {
+        'metadata-boundary': (input) =>
+          enforcingResult({
+            outcome: 'allow',
+            signals: [
+              causallyDerivedSignal(
+                input,
+                'metadata-boundary-signal',
+                metadata as ReturnType<typeof handlerMetadata>,
+              ),
+            ],
+          }),
+      });
+      return invoke(engine)._unsafeUnwrap();
+    };
+
+    expect(execute({ same: 1, Ａ: 2, A: 3 })).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+    });
+    expect(execute({ A: 1, Ａ: 2 })).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+    });
+
+    let accessorCalls = 0;
+    const accessorEntry = {};
+    Object.defineProperty(accessorEntry, 'never-read', {
+      enumerable: true,
+      get() {
+        accessorCalls += 1;
+        return 'never-read';
+      },
+    });
+    expect(execute(accessorEntry)).toMatchObject({ outcome: 'deny' });
+    expect(accessorCalls).toBe(0);
+
+    let proxyTraps = 0;
+    const proxy = new Proxy(
+      {},
+      {
+        get() {
+          proxyTraps += 1;
+          throw new Error('proxy trap');
+        },
+      },
+    );
+    expect(execute(proxy)).toMatchObject({ outcome: 'deny' });
+    expect(proxyTraps).toBe(0);
+
+    let unknownGetterCalls = 0;
+    const boundedMetadata: Record<string, unknown> = {};
+    for (let index = 0; index < 4_096; index += 1) {
+      Object.defineProperty(boundedMetadata, `unknown-${index}`, {
+        enumerable: true,
+        get() {
+          unknownGetterCalls += 1;
+          throw new Error('unknown metadata must not be read');
+        },
+      });
+    }
+    expect(execute(boundedMetadata)).toMatchObject({ outcome: 'deny' });
+    expect(unknownGetterCalls).toBe(0);
+  });
+
+  it('applies the responsible handler failure policy before committing over-capacity signals', () => {
+    const handlers = Array.from({ length: 33 }, (_, index) =>
+      makeHandler(`signal-${index}`, 33 - index, { failurePolicy: 'fail_closed' }),
+    );
+    const implementations = Object.fromEntries(
+      handlers.map((handler) => [
+        handler.identity.implementationRef,
+        (input: Parameters<LifecycleInterceptorHandler>[0]) =>
+          enforcingResult({
+            outcome: 'allow',
+            signals: Array.from({ length: 32 }, (_, index) =>
+              causallyDerivedSignal(input, `${handler.handler.id}-${index}`),
+            ),
+          }),
+      ]),
+    ) as Record<string, LifecycleInterceptorHandler>;
+    const result = invoke(
+      makeEngine(handlers, implementations, { totalTimeoutMs: 10_000 }),
+    )._unsafeUnwrap();
+
+    expect(result).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+      handlerId: 'signal-32',
+    });
+    expect(result.signals).toHaveLength(1_024);
+  });
+
+  it.each([
+    [9, 288],
+    [32, 1_024],
+  ])(
+    'preserves every accepted signal at the %i by 32 aggregate boundary',
+    (handlerCount, expected) => {
+      const handlers = Array.from({ length: handlerCount }, (_, index) =>
+        makeHandler(`bulk-${index}`, handlerCount - index),
+      );
+      const implementations = Object.fromEntries(
+        handlers.map((handler) => [
+          handler.identity.implementationRef,
+          (input: Parameters<LifecycleInterceptorHandler>[0]) =>
+            enforcingResult({
+              outcome: 'allow',
+              signals: Array.from({ length: 32 }, (_, index) =>
+                causallyDerivedSignal(input, `${handler.handler.id}-${index}`),
+              ),
+            }),
+        ]),
+      ) as Record<string, LifecycleInterceptorHandler>;
+
+      const result = invoke(
+        makeEngine(handlers, implementations, { totalTimeoutMs: 10_000 }),
+      )._unsafeUnwrap();
+      expect(result.outcome).toBe('allow');
+      expect(result.signals).toHaveLength(expected);
+    },
+  );
+
+  it('drains a rejected genuine native Promise through the captured intrinsic reaction', async () => {
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+    process.on('unhandledRejection', onUnhandledRejection);
+    const throwingCatchAccessor = vi.fn(() => {
+      throw new Error('handler-controlled catch accessor');
+    });
+    const rejectedCatchOverride = vi.fn(() => Promise.reject(new Error('secondary rejection')));
+    const throwingAccessorPromise = Promise.reject(new Error('accessor rejection'));
+    const rejectedOverridePromise = Promise.reject(new Error('override rejection'));
+    Object.defineProperty(throwingAccessorPromise, 'catch', {
+      configurable: true,
+      get: throwingCatchAccessor,
+    });
+    Object.defineProperty(rejectedOverridePromise, 'catch', {
+      configurable: true,
+      value: rejectedCatchOverride,
+    });
+    let proxyTrapCount = 0;
+    const proxyResult = new Proxy(
+      {},
+      {
+        get() {
+          proxyTrapCount += 1;
+          throw new Error('proxy trap');
+        },
+      },
+    );
+    const engine = makeEngine(
+      [
+        makeHandler('throwing-accessor', 4, { safety: 'advisory' }),
+        makeHandler('rejected-override', 5, { safety: 'advisory' }),
+        makeHandler('proxy', 1),
+      ],
+      {
+        'throwing-accessor': () => throwingAccessorPromise,
+        'rejected-override': () => rejectedOverridePromise,
+        proxy: () => proxyResult,
+      },
+    );
+
+    try {
+      expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+        outcome: 'deny',
+        reason: 'lifecycle_interceptor_error',
+        handlerId: 'proxy',
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(throwingCatchAccessor).not.toHaveBeenCalled();
+      expect(rejectedCatchOverride).not.toHaveBeenCalled();
+      expect(unhandledRejections).toEqual([]);
+      expect(proxyTrapCount).toBe(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  it('does not add, remove, reorder, or invoke process-level fatal listeners while draining engine promises', async () => {
+    const unhandled = vi.fn();
+    const uncaught = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    process.on('uncaughtException', uncaught);
+    const beforeUnhandled = process.listeners('unhandledRejection');
+    const beforeUncaught = process.listeners('uncaughtException');
+    const rejected = Promise.reject(new Error('engine-owned rejection'));
+    const engine = makeEngine([makeHandler('regular-promise', 1, { safety: 'advisory' })], {
+      'regular-promise': () => rejected,
+    });
+
+    try {
+      expect(invoke(engine)._unsafeUnwrap().outcome).toBe('allow');
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandled).not.toHaveBeenCalled();
+      expect(uncaught).not.toHaveBeenCalled();
+      expect(process.listeners('unhandledRejection')).toEqual(beforeUnhandled);
+      expect(process.listeners('uncaughtException')).toEqual(beforeUncaught);
+      expect(process.listenerCount('unhandledRejection')).toBe(beforeUnhandled.length);
+      expect(process.listenerCount('uncaughtException')).toBe(beforeUncaught.length);
+    } finally {
+      process.off('unhandledRejection', unhandled);
+      process.off('uncaughtException', uncaught);
+    }
+  });
+
+  it('drains a rejected intrinsic Promise subclass', async () => {
+    class NativePromiseSubclass<T> extends Promise<T> {}
+    const rejected = NativePromiseSubclass.reject(new Error('expected rejection'));
+    const engine = makeEngine([makeHandler('subclass', 1, { safety: 'advisory' })], {
+      subclass: () => rejected,
+    });
+
+    expect(invoke(engine)._unsafeUnwrap().outcome).toBe('allow');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  });
+
+  it.each(['throwing Symbol.species', 'throwing constructor accessor'])(
+    'rejects a %s Promise under the trusted synchronous-handler contract without global listeners',
+    (caseName) => {
+      class NativePromiseSubclass<T> extends Promise<T> {
+        static get [Symbol.species](): PromiseConstructor {
+          if (caseName === 'throwing Symbol.species') throw new Error('hostile species');
+          return Promise;
+        }
+      }
+      const pending = new NativePromiseSubclass<never>(() => undefined);
+      if (caseName === 'throwing constructor accessor') {
+        Object.defineProperty(pending, 'constructor', {
+          get() {
+            throw new Error('hostile constructor');
+          },
+        });
+      }
+      const beforeUnhandled = process.listeners('unhandledRejection');
+      const beforeUncaught = process.listeners('uncaughtException');
+      const engine = makeEngine([makeHandler('strict-promise', 1)], {
+        'strict-promise': () => pending,
+      });
+
+      expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+        outcome: 'deny',
+        reason: 'lifecycle_interceptor_error',
+        handlerId: 'strict-promise',
+      });
+      expect(process.listeners('unhandledRejection')).toEqual(beforeUnhandled);
+      expect(process.listeners('uncaughtException')).toEqual(beforeUncaught);
+    },
+  );
+
+  it('rejects sparse arrays with hostile prototypes before parsing reads inherited indices', () => {
+    let inheritedIndexReads = 0;
+    const signals = new Array<unknown>(1);
+    Object.setPrototypeOf(
+      signals,
+      Object.create(Array.prototype, {
+        0: {
+          configurable: true,
+          enumerable: true,
+          get() {
+            inheritedIndexReads += 1;
+            throw new Error('inherited array index trap');
+          },
+        },
+      }),
+    );
+    const engine = makeEngine([makeHandler('sparse-array', 1)], {
+      'sparse-array': () => enforcingResult({ outcome: 'allow', signals }),
+    });
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+      handlerId: 'sparse-array',
+    });
+    expect(inheritedIndexReads).toBe(0);
+  });
+
+  it('rejects accessor-backed output before parsing invokes the accessor', () => {
+    let getterCalls = 0;
+    const accessorResult = {};
+    Object.defineProperty(accessorResult, 'outcome', {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return 'success';
+      },
+    });
+    const engine = makeEngine([makeHandler('accessor', 1)], { accessor: () => accessorResult });
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+    });
+    expect(getterCalls).toBe(0);
+  });
+
+  it('rejects bounded hostile unknown top-level output fields without executing their accessors', () => {
+    const output = enforcingResult({ outcome: 'allow' });
+    let getterCalls = 0;
+    for (let index = 0; index < 4_096; index += 1) {
+      Object.defineProperty(output, `ignored-${index}`, {
+        enumerable: true,
+        get() {
+          getterCalls += 1;
+          throw new Error('unknown output field must not be read');
+        },
+      });
+    }
+    const engine = makeEngine([makeHandler('known-fields-only', 1)], {
+      'known-fields-only': () => output,
+    });
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+      handlerId: 'known-fields-only',
+    });
+    expect(getterCalls).toBe(0);
+  });
+
+  it('rejects nested unknown output fields without executing their accessors', () => {
+    let getterCalls = 0;
+    const output = enforcingResult({ outcome: 'allow' });
+    Object.defineProperty(output.result, 'unexpected', {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        throw new Error('nested unknown output field must not be read');
+      },
+    });
+    const engine = makeEngine([makeHandler('nested-unknown', 1)], {
+      'nested-unknown': () => output,
+    });
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+      handlerId: 'nested-unknown',
+    });
+    expect(getterCalls).toBe(0);
+  });
+
+  it('checks the deadline after hostile-output inspection before choosing a failure policy', () => {
+    let reads = 0;
+    const clock: LifecycleInterceptorClock = {
+      now: () => {
+        reads += 1;
+        return reads >= 5 ? 6 : 0;
+      },
+    };
+    const accessorResult = {};
+    Object.defineProperty(accessorResult, 'outcome', {
+      enumerable: true,
+      get: () => 'success',
+    });
+    const engine = makeEngine(
+      [makeHandler('late-inspection', 1, { timeoutMs: 5 })],
+      { 'late-inspection': () => accessorResult },
+      { clock },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_timeout',
+      handlerId: 'late-inspection',
+    });
+  });
+
+  it('does not execute handlers when the recursion limit has been reached', () => {
+    const handler = vi.fn(() => enforcingResult({ outcome: 'allow' }));
+    const engine = makeEngine([makeHandler('guarded', 1)], { guarded: handler });
+    const input = makeInput({
+      context: {
+        aggregate: { type: 'thread', id: 'thread-1' },
+        correlationId: 'correlation-1',
+        recursion: { depth: 4, maxDepth: 4 },
+        provenance: { source: 'test-source' },
+      },
+    });
+
+    expect(invoke(engine, input)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_recursion_limit',
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('audits identity, decision, duration, and redacted transform metadata', () => {
+    const entries: AuditEntry[] = [];
+    const auditLogger = {
+      logLifecycleInterceptor: vi.fn((entry: AuditEntry) => entries.push(entry)),
+    } as unknown as AuditLogger;
+    const engine = makeEngine(
+      [makeHandler('redactor', 1)],
+      {
+        redactor: () =>
+          enforcingResult({
+            outcome: 'transform',
+            transform: {
+              hook,
+              argumentsPatch: { authorization: 'Bearer top-secret', query: 'safe' },
+            },
+          }),
+      },
+      { auditLogger },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap().outcome).toBe('allow');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      action: 'lifecycle.interceptor',
+      details: {
+        handlerId: 'redactor',
+        decision: 'transform',
+        reason: 'handler_transform',
+        transform: { kind: 'tool_arguments_patch', fieldCount: 2 },
+      },
+    });
+    expect(JSON.stringify(entries[0])).not.toContain('top-secret');
+    expect(JSON.stringify(entries[0])).not.toContain('Bearer');
+  });
+
+  it('commits an allow before its durable audit can exhaust that handler deadline', () => {
+    const clock = makeClock();
+    const entries: AuditEntry[] = [];
+    const auditLogger = {
+      logLifecycleInterceptor: vi.fn((entry: AuditEntry) => {
+        entries.push(entry);
+        clock.advance(6);
+      }),
+    } as unknown as AuditLogger;
+    const engine = makeEngine(
+      [makeHandler('audit-late', 1, { timeoutMs: 5 })],
+      { 'audit-late': () => enforcingResult({ outcome: 'allow' }) },
+      { clock, auditLogger },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap().outcome).toBe('allow');
+    expect(auditLogger.logLifecycleInterceptor).toHaveBeenCalledOnce();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      details: { decision: 'allow', reason: 'handler_allow' },
+    });
+  });
+
+  it('audits the committed post-audit decisions exactly, including transform, fail-open failure, and total timeout', () => {
+    const clock = makeClock();
+    const entries: AuditEntry[] = [];
+    const auditLogger = {
+      logLifecycleInterceptor: vi.fn((entry: AuditEntry) => {
+        entries.push(entry);
+        clock.advance(6);
+      }),
+    } as unknown as AuditLogger;
+
+    const transform = makeEngine(
+      [makeHandler('transform-after-audit', 1, { timeoutMs: 5 })],
+      {
+        'transform-after-audit': () =>
+          enforcingResult({
+            outcome: 'transform',
+            transform: { hook, argumentsPatch: { audited: true } },
+          }),
+      },
+      { clock, totalTimeoutMs: 50, auditLogger },
+    );
+    expect(invoke(transform)._unsafeUnwrap()).toMatchObject({
+      outcome: 'allow',
+      input: { input: { arguments: { query: 'original', audited: true } } },
+    });
+    expect(entries.at(-1)).toMatchObject({
+      details: { decision: 'transform', reason: 'handler_transform' },
+    });
+
+    const failOpen = makeEngine(
+      [makeHandler('fail-open-after-audit', 1, { safety: 'advisory', timeoutMs: 5 })],
+      {
+        'fail-open-after-audit': () => {
+          throw new Error('expected advisory failure');
+        },
+      },
+      { clock, totalTimeoutMs: 50, auditLogger },
+    );
+    expect(invoke(failOpen)._unsafeUnwrap().outcome).toBe('allow');
+    expect(entries.at(-1)).toMatchObject({
+      details: { decision: 'error', reason: 'lifecycle_interceptor_error' },
+    });
+
+    const failClosed = makeEngine(
+      [makeHandler('fail-closed-after-audit', 1, { timeoutMs: 5 })],
+      {
+        'fail-closed-after-audit': () => {
+          throw new Error('expected enforcing failure');
+        },
+      },
+      { clock, totalTimeoutMs: 50, auditLogger },
+    );
+    expect(invoke(failClosed)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_error',
+      handlerId: 'fail-closed-after-audit',
+    });
+    expect(entries.at(-1)).toMatchObject({
+      details: { decision: 'error', reason: 'lifecycle_interceptor_error' },
+    });
+
+    const enforcing = vi.fn(() => enforcingResult({ outcome: 'allow' }));
+    const totalTimeout = makeEngine(
+      [
+        makeHandler('advisory-before-total', 2, { safety: 'advisory', timeoutMs: 50 }),
+        makeHandler('enforcing-after-total', 1),
+      ],
+      { 'advisory-before-total': advisoryResult, 'enforcing-after-total': enforcing },
+      { clock, totalTimeoutMs: 5, auditLogger },
+    );
+    expect(invoke(totalTimeout)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_total_timeout',
+    });
+    expect(enforcing).not.toHaveBeenCalled();
+    expect(entries.at(-1)).toMatchObject({
+      details: {
+        handlerId: 'lifecycle-engine',
+        decision: 'deny',
+        reason: 'lifecycle_interceptor_total_timeout',
+      },
+    });
+  });
+
+  it('preserves a terminal deny when completion crosses the aggregate deadline', () => {
+    let reads = 0;
+    const clock: LifecycleInterceptorClock = {
+      now: () => {
+        reads += 1;
+        return reads >= 10 ? 6 : 0;
+      },
+    };
+    const entries: AuditEntry[] = [];
+    const auditLogger = {
+      logLifecycleInterceptor: vi.fn((entry: AuditEntry) => entries.push(entry)),
+    } as unknown as AuditLogger;
+    const next = vi.fn(() => enforcingResult({ outcome: 'allow' }));
+    const engine = makeEngine(
+      [makeHandler('terminal-deny', 2), makeHandler('unresolved-enforcing', 1)],
+      {
+        'terminal-deny': () => enforcingResult({ outcome: 'deny', reason: 'would deny' }),
+        'unresolved-enforcing': next,
+      },
+      { auditLogger, clock, totalTimeoutMs: 5 },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'would deny',
+    });
+    expect(next).not.toHaveBeenCalled();
+    expect(entries.at(-1)).toMatchObject({ details: { reason: 'handler_deny' } });
+  });
+
+  it('never weakens approval, fail-closed, or recursion denials at an exact deadline', () => {
+    const approvalReads = { value: 0 };
+    const approvalClock: LifecycleInterceptorClock = {
+      now: () => (approvalReads.value++ >= 9 ? 5 : 0),
+    };
+    const approval = makeEngine(
+      [makeHandler('approval', 1)],
+      {
+        approval: () =>
+          enforcingResult({
+            outcome: 'require_approval',
+            reason: 'approval required',
+            approvalKey: 'approval-1',
+          }),
+      },
+      { clock: approvalClock, totalTimeoutMs: 5 },
+    )
+      .intercept({ persona: 'assistant', hook }, makeInput())
+      ._unsafeUnwrap();
+    expect(approval).toMatchObject({ outcome: 'require_approval', approvalKey: 'approval-1' });
+
+    const clock = makeClock();
+    const auditLogger = {
+      logLifecycleInterceptor: vi.fn(() => clock.advance(5)),
+    } as unknown as AuditLogger;
+    const failClosed = makeEngine(
+      [makeHandler('failure', 1)],
+      {
+        failure: () => {
+          throw new Error('failure');
+        },
+      },
+      { clock, totalTimeoutMs: 5, auditLogger },
+    );
+    expect(invoke(failClosed)._unsafeUnwrap().outcome).toBe('deny');
+
+    const recursionClock = makeClock();
+    const recursionAudit = {
+      logLifecycleInterceptor: vi.fn(() => recursionClock.advance(5)),
+    } as unknown as AuditLogger;
+    const recursion = makeEngine(
+      [makeHandler('unreachable', 1)],
+      { unreachable: () => enforcingResult({ outcome: 'allow' }) },
+      { clock: recursionClock, totalTimeoutMs: 5, auditLogger: recursionAudit },
+    );
+    expect(
+      invoke(
+        recursion,
+        makeInput({
+          context: {
+            aggregate: { type: 'thread', id: 'thread-1' },
+            correlationId: 'correlation-1',
+            recursion: { depth: 4, maxDepth: 4 },
+            provenance: { source: 'test-source' },
+          },
+        }),
+      )._unsafeUnwrap(),
+    ).toMatchObject({ outcome: 'deny', reason: 'lifecycle_recursion_limit' });
+  });
+
+  it.each([
+    ['exactly before terminal materialization', 9],
+    ['exactly during terminal materialization', 10],
+  ])(
+    'preserves an ordinary deny %s without re-entering a throwing audit sink',
+    (_position, deadlineRead) => {
+      let reads = 0;
+      const clock: LifecycleInterceptorClock = {
+        now: () => {
+          reads += 1;
+          return reads >= deadlineRead ? 5 : 0;
+        },
+      };
+      const auditLogger = {
+        logLifecycleInterceptor: vi.fn(() => {
+          throw new Error('audit sink unavailable');
+        }),
+      } as unknown as AuditLogger;
+      const advisory = vi.fn();
+      const enforcing = vi.fn();
+      const engine = makeEngine(
+        [
+          makeHandler('ordinary-deny', 3),
+          makeHandler('unresolved-advisory', 2, { safety: 'advisory' }),
+          makeHandler('unresolved-enforcing', 1),
+        ],
+        {
+          'ordinary-deny': () => enforcingResult({ outcome: 'deny', reason: 'ordinary decision' }),
+          'unresolved-advisory': advisory,
+          'unresolved-enforcing': enforcing,
+        },
+        { clock, totalTimeoutMs: 5, auditLogger },
+      );
+
+      expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+        outcome: 'deny',
+        reason: 'ordinary decision',
+      });
+      expect(advisory).not.toHaveBeenCalled();
+      expect(enforcing).not.toHaveBeenCalled();
+      expect(auditLogger.logLifecycleInterceptor).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('keeps an already-materialized aggregate timeout without re-auditing it', () => {
+    let reads = 0;
+    const clock: LifecycleInterceptorClock = {
+      now: () => {
+        reads += 1;
+        return reads >= 3 ? 5 : 0;
+      },
+    };
+    const auditLogger = {
+      logLifecycleInterceptor: vi.fn(() => {
+        throw new Error('audit sink unavailable');
+      }),
+    } as unknown as AuditLogger;
+    const advisory = vi.fn();
+    const enforcing = vi.fn();
+    const engine = makeEngine(
+      [
+        makeHandler('unresolved-advisory', 2, { safety: 'advisory' }),
+        makeHandler('unresolved-enforcing', 1),
+      ],
+      { 'unresolved-advisory': advisory, 'unresolved-enforcing': enforcing },
+      { clock, totalTimeoutMs: 5, auditLogger },
+    );
+
+    expect(invoke(engine)._unsafeUnwrap()).toMatchObject({
+      outcome: 'deny',
+      reason: 'lifecycle_interceptor_total_timeout',
+    });
+    expect(advisory).not.toHaveBeenCalled();
+    expect(enforcing).not.toHaveBeenCalled();
+    expect(auditLogger.logLifecycleInterceptor).toHaveBeenCalledOnce();
+  });
+});
+
+describe('native interceptor examples', () => {
+  it('provides deterministic native allow and tool-deny handlers', () => {
+    const input = LifecycleInterceptorEnvelopeSchema.parse(makeInput());
+
+    expect(nativeAllowInterceptor(input)).toMatchObject({ result: { outcome: 'allow' } });
+    expect(createNativeToolNameDenyInterceptor(['web_search'])(input)).toMatchObject({
+      result: { outcome: 'deny', reason: 'tool_denied_by_native_policy' },
+    });
+  });
+});
+
+describe('bounded interceptor JSON proxy rejection', () => {
+  it.each(['root object', 'root array', 'nested object', 'nested array'])(
+    'rejects a %s before proxy traps run',
+    (kind) => {
+      let trapCount = 0;
+      const proxy = (value: object) =>
+        new Proxy(value, {
+          get(target, key, receiver) {
+            trapCount += 1;
+            return Reflect.get(target, key, receiver);
+          },
+          getPrototypeOf(target) {
+            trapCount += 1;
+            return Reflect.getPrototypeOf(target);
+          },
+          ownKeys(target) {
+            trapCount += 1;
+            return Reflect.ownKeys(target);
+          },
+          getOwnPropertyDescriptor(target, key) {
+            trapCount += 1;
+            return Reflect.getOwnPropertyDescriptor(target, key);
+          },
+        });
+      const argumentsValue =
+        kind === 'root object'
+          ? proxy({})
+          : kind === 'root array'
+            ? proxy(['value'])
+            : kind === 'nested object'
+              ? { nested: proxy({}) }
+              : { nested: proxy(['value']) };
+
+      const parsed = LifecycleInterceptorEnvelopeSchema.safeParse({
+        version: 'v1',
+        interceptionId: 'interception-1',
+        hook,
+        context: {
+          aggregate: { type: 'thread', id: 'thread-1' },
+          correlationId: 'correlation-1',
+          recursion: { depth: 0, maxDepth: 4 },
+          provenance: { source: 'test-source' },
+        },
+        input: { toolCallId: 'tool-call-1', toolName: 'web_search', arguments: argumentsValue },
+      });
+
+      expect(parsed.success).toBe(false);
+      expect(trapCount).toBe(0);
+    },
+  );
+
+  it('accepts ordinary records and rejects array extras without reading them', () => {
+    let getterCalls = 0;
+    const values = ['safe'];
+    for (let index = 0; index < 4_096; index += 1) {
+      Object.defineProperty(values, `ignored-${index}`, {
+        enumerable: true,
+        get() {
+          getterCalls += 1;
+          throw new Error('array extra must not be read');
+        },
+      });
+    }
+    const envelope = {
+      ...makeInput(),
+      input: {
+        toolCallId: 'tool-call-1',
+        toolName: 'web_search',
+        arguments: { values },
+      },
+    };
+
+    expect(LifecycleInterceptorEnvelopeSchema.safeParse(envelope).success).toBe(false);
+    expect(getterCalls).toBe(0);
+    expect(
+      LifecycleInterceptorEnvelopeSchema.safeParse({
+        ...envelope,
+        input: {
+          ...envelope.input,
+          arguments: { nested: { unbounded: true } },
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('charges serialized numeric primitives while accepting numeric boundary values', () => {
+    const parsed = LifecycleInterceptorEnvelopeSchema.safeParse({
+      ...makeInput(),
+      input: {
+        toolCallId: 'tool-call-1',
+        toolName: 'web_search',
+        arguments: {
+          largest: Number.MAX_VALUE,
+          smallest: Number.MIN_VALUE,
+          negative: -Number.MAX_VALUE,
+          zero: -0,
+        },
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(
+        Buffer.byteLength(JSON.stringify(parsed.data.input.arguments), 'utf8'),
+      ).toBeLessThanOrEqual(32_768);
+      expect(parsed.data.input.arguments).toMatchObject({
+        largest: Number.MAX_VALUE,
+        smallest: Number.MIN_VALUE,
+        negative: -Number.MAX_VALUE,
+        zero: -0,
+      });
+    }
+  });
+
+  it('enforces the JSON byte limit exactly after ordinary-record detachment', () => {
+    const keys = Array.from({ length: 8 }, (_, index) => `value${index}`);
+    const empty = Object.fromEntries(keys.map((key) => [key, '']));
+    const overhead = Buffer.byteLength(JSON.stringify(empty), 'utf8');
+    const remaining = 32_768 - overhead;
+    const atLimit = Object.fromEntries(
+      keys.map((key, index) => [key, 'x'.repeat(index < 7 ? 4_096 : remaining - 7 * 4_096)]),
+    );
+    const overLimit = { ...atLimit, value7: `${atLimit.value7}x` };
+
+    expect(Buffer.byteLength(JSON.stringify(atLimit), 'utf8')).toBe(32_768);
+    expect(
+      LifecycleInterceptorEnvelopeSchema.safeParse({
+        ...makeInput(),
+        input: { toolCallId: 'tool-call-1', toolName: 'web_search', arguments: atLimit },
+      }).success,
+    ).toBe(true);
+    expect(
+      LifecycleInterceptorEnvelopeSchema.safeParse({
+        ...makeInput(),
+        input: { toolCallId: 'tool-call-1', toolName: 'web_search', arguments: overLimit },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects NFKC-colliding keys at every nested dynamic-record level', () => {
+    expect(
+      LifecycleInterceptorEnvelopeSchema.safeParse({
+        ...makeInput(),
+        input: {
+          toolCallId: 'tool-call-1',
+          toolName: 'web_search',
+          arguments: { nested: { A: 1, Ａ: 2 } },
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      LifecycleInterceptorTransformSchema.safeParse({
+        hook,
+        argumentsPatch: { A: 1, Ａ: 2 },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects accessor-backed ordinary records without invoking the getter', () => {
+    let getterCalls = 0;
+    const argumentsValue = {};
+    Object.defineProperty(argumentsValue, 'entries', {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        throw new Error('entries getter must not run');
+      },
+    });
+
+    expect(
+      LifecycleInterceptorEnvelopeSchema.safeParse({
+        ...makeInput(),
+        input: { toolCallId: 'tool-call-1', toolName: 'web_search', arguments: argumentsValue },
+      }).success,
+    ).toBe(false);
+    expect(getterCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic bounded lifecycle interceptor composition
- enforce timeout, failure-policy, recursion, transform, and signal limits
- harden descriptor-only materialization and audit redaction
- add deterministic native example handlers and focused regressions

## Verification
- Sol/high full-diff review: C0/H0/M0/L0 (`019f6962-32a0-7af1-9165-c43e6342c4b4`)
- Node 24.15.0: 141 focused tests passed
- disposable build passed
- scoped ESLint and `git diff --check` passed
- branch-refresh merge reviewed C0/H0/M0 and matches epic checkpoint `1fa6454`

Closes TASK-003 in EPIC-durable-lifecycle-pipeline. Documentation remains owned by TASK-020.