### PR TITLE
feat(lifecycle): add durable event persistence

### DIFF
--- a/src/core/database/connection.ts
+++ b/src/core/database/connection.ts
@@ -8,6 +8,7 @@
 import Database from 'better-sqlite3';
 import { ok, err, type Result } from 'neverthrow';
 import { DbError } from '../errors/index.js';
+import { registerLifecycleSqlFunctions } from './lifecycle-sql-functions.js';
 
 /**
  * Opens a SQLite database at the given path and applies performance/safety PRAGMAs.
@@ -22,6 +23,7 @@ export function createDatabase(
 ): Result<Database.Database, DbError> {
   try {
     const db = new Database(dbPath, { readonly: options?.readonly ?? false });
+    registerLifecycleSqlFunctions(db);
 
     // WAL mode: concurrent readers do not block writers and vice versa.
     db.pragma('journal_mode = WAL');

--- a/src/core/database/lifecycle-sql-functions.ts
+++ b/src/core/database/lifecycle-sql-functions.ts
@@ -1,0 +1,354 @@
+/** Exact, fail-closed lifecycle JSON validators registered on every SQLite connection. */
+
+import type Database from 'better-sqlite3';
+import {
+  hasCompatibleLifecycleFailurePolicy,
+  isBoundedUnicodeScalarsUtf8,
+  isBoundedWellFormedUtf8,
+} from './repositories/lifecycle-persistence-validation.js';
+
+const identifier = /^[a-z][a-z0-9]*(?:[-_.][a-z0-9]+)*$/;
+
+function text(value: unknown, units: number, bytes: number): value is string {
+  return (
+    typeof value === 'string' &&
+    isBoundedWellFormedUtf8(value, units, bytes) &&
+    value.indexOf('\0') === -1
+  );
+}
+
+function runtimeId(value: unknown): value is string {
+  return text(value, 256, 1024) && value.length > 0 && value.trim() === value;
+}
+
+function lifecycleIdentifier(value: unknown): value is string {
+  return text(value, 128, 512) && identifier.test(value);
+}
+
+function runtimeName(value: unknown): value is string {
+  if (!text(value, 128, 512) || value.length === 0 || value.trim() !== value) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    const point = value.codePointAt(index)!;
+    if (point < 0x20 || (point >= 0x7f && point <= 0x9f)) return false;
+    if (point > 0xffff) index += 1;
+  }
+  return true;
+}
+
+function displayName(value: unknown): value is string {
+  return text(value, 256, 1024) && value.length > 0 && value.trim() === value;
+}
+
+function plainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function exactKeys(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+  if (!plainObject(value)) return false;
+  const actual = Object.keys(value);
+  return actual.length === keys.length && keys.every((key) => Object.hasOwn(value, key));
+}
+
+/** Walks raw JSON before JSON.parse can collapse duplicate object member names. */
+function hasDuplicateJsonKeys(raw: string): boolean {
+  let cursor = 0;
+  const whitespace = (): void => {
+    while (/\s/.test(raw[cursor] ?? '')) cursor += 1;
+  };
+  const string = (): string => {
+    const start = cursor;
+    cursor += 1;
+    while (cursor < raw.length) {
+      const char = raw[cursor] ?? '';
+      if (char === '\\') {
+        cursor += 2;
+        continue;
+      }
+      cursor += 1;
+      if (char === '"') return JSON.parse(raw.slice(start, cursor)) as string;
+    }
+    throw new Error('unterminated JSON string');
+  };
+  const primitive = (): void => {
+    const match = /^(?:true|false|null|-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)/.exec(
+      raw.slice(cursor),
+    );
+    if (!match) throw new Error('invalid JSON primitive');
+    cursor += match[0].length;
+  };
+  const value = (): void => {
+    whitespace();
+    const token = raw[cursor];
+    if (token === '"') {
+      string();
+      return;
+    }
+    if (token === '[') {
+      cursor += 1;
+      whitespace();
+      if (raw[cursor] === ']') {
+        cursor += 1;
+        return;
+      }
+      while (true) {
+        value();
+        whitespace();
+        if (raw[cursor] === ']') {
+          cursor += 1;
+          return;
+        }
+        if (raw[cursor++] !== ',') throw new Error('invalid array');
+      }
+    }
+    if (token === '{') {
+      cursor += 1;
+      whitespace();
+      const keys = new Set<string>();
+      if (raw[cursor] === '}') {
+        cursor += 1;
+        return;
+      }
+      while (true) {
+        whitespace();
+        if (raw[cursor] !== '"') throw new Error('invalid object key');
+        const key = string();
+        if (keys.has(key)) throw new Error('duplicate JSON key');
+        keys.add(key);
+        whitespace();
+        if (raw[cursor++] !== ':') throw new Error('invalid object');
+        value();
+        whitespace();
+        if (raw[cursor] === '}') {
+          cursor += 1;
+          return;
+        }
+        if (raw[cursor++] !== ',') throw new Error('invalid object');
+      }
+    }
+    primitive();
+  };
+  try {
+    value();
+    whitespace();
+    return cursor !== raw.length;
+  } catch {
+    return true;
+  }
+}
+
+function parseJson(raw: unknown, maxBytes: number): unknown {
+  if (typeof raw !== 'string' || raw.length > maxBytes || Buffer.byteLength(raw, 'utf8') > maxBytes)
+    return null;
+  try {
+    if (hasDuplicateJsonKeys(raw)) return null;
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function reference(value: unknown): boolean {
+  return exactKeys(value, ['type', 'id']) && lifecycleIdentifier(value.type) && runtimeId(value.id);
+}
+
+function references(value: unknown): boolean {
+  return Array.isArray(value) && value.length <= 32 && value.every(reference);
+}
+
+function metadata(value: unknown): boolean {
+  if (!plainObject(value)) return false;
+  const entries = Object.entries(value);
+  if (entries.length > 32) return false;
+  const normalized = new Set<string>();
+  for (const [key, item] of entries) {
+    if (!text(key, 128, 512) || key.length === 0 || key.trim() !== key) return false;
+    const normalizedKey = key.normalize('NFKC');
+    if (normalized.has(normalizedKey)) return false;
+    normalized.add(normalizedKey);
+    if (typeof item === 'string') {
+      if (!text(item, 1024, 4096)) return false;
+    } else if (
+      item !== null &&
+      typeof item !== 'boolean' &&
+      (typeof item !== 'number' || !Number.isFinite(item))
+    )
+      return false;
+  }
+  return true;
+}
+
+export function validPayload(raw: unknown): boolean {
+  const value = parseJson(raw, 262_144);
+  return (
+    exactKeys(value, ['references', 'metadata']) &&
+    references(value.references) &&
+    metadata(value.metadata)
+  );
+}
+
+export function validProvenance(raw: unknown): boolean {
+  const value = parseJson(raw, 131_072);
+  return (
+    exactKeys(value, ['source', 'sourceEventIds', 'sourceReferences']) &&
+    lifecycleIdentifier(value.source) &&
+    Array.isArray(value.sourceEventIds) &&
+    value.sourceEventIds.length <= 32 &&
+    value.sourceEventIds.every(runtimeId) &&
+    references(value.sourceReferences)
+  );
+}
+
+export function validIdentity(raw: unknown, handlerId: unknown): boolean {
+  const value = parseJson(raw, 8192);
+  if (!plainObject(value)) return false;
+  const allowed = [
+    'version',
+    'handlerId',
+    'runtimeKind',
+    'implementationRef',
+    'implementationVersion',
+    'mode',
+    'inputContract',
+    'outputContract',
+    'interceptorSafety',
+  ];
+  if (
+    Object.keys(value).some((key) => !allowed.includes(key)) ||
+    (!Object.hasOwn(value, 'interceptorSafety') && Object.keys(value).length !== 8) ||
+    (Object.hasOwn(value, 'interceptorSafety') && Object.keys(value).length !== 9)
+  )
+    return false;
+  if (
+    value.version !== 'v1' ||
+    value.handlerId !== handlerId ||
+    !lifecycleIdentifier(value.handlerId) ||
+    (value.runtimeKind !== 'native' && value.runtimeKind !== 'subagent') ||
+    !runtimeName(value.implementationRef) ||
+    !displayName(value.implementationVersion) ||
+    !text(value.mode, 16, 64) ||
+    !text(value.inputContract, 128, 512) ||
+    !text(value.outputContract, 128, 512)
+  )
+    return false;
+  if (value.mode === 'event')
+    return (
+      value.inputContract === 'talon.lifecycle.event.envelope.v1' &&
+      value.outputContract === 'talon.lifecycle.signal.envelopes.v1' &&
+      !Object.hasOwn(value, 'interceptorSafety')
+    );
+  if (value.mode === 'signal')
+    return (
+      value.inputContract === 'talon.lifecycle.signal.envelope.v1' &&
+      value.outputContract === 'talon.lifecycle.signal.envelopes.v1' &&
+      !Object.hasOwn(value, 'interceptorSafety')
+    );
+  if (
+    value.mode !== 'interceptor' ||
+    value.inputContract !== 'talon.lifecycle.interceptor.input.v1'
+  )
+    return false;
+  if (value.interceptorSafety === 'enforcing')
+    return (
+      value.runtimeKind === 'native' &&
+      value.outputContract === 'talon.lifecycle.enforcing.interceptor.output.v1'
+    );
+  return (
+    (value.interceptorSafety === undefined || value.interceptorSafety === 'advisory') &&
+    value.outputContract === 'talon.lifecycle.advisory.interceptor.output.v1'
+  );
+}
+
+export function validFailurePolicy(raw: unknown): boolean {
+  const value = parseJson(raw, 1024);
+  return (
+    exactKeys(value, ['version', 'mode']) &&
+    value.version === 'v1' &&
+    (value.mode === 'fail_closed' ||
+      value.mode === 'fail_open' ||
+      value.mode === 'dead_letter' ||
+      value.mode === 'preserve_session')
+  );
+}
+
+/** Validates the identity/policy pair as one durable authority boundary. */
+export function validDeliveryContract(
+  identityRaw: unknown,
+  failurePolicyRaw: unknown,
+  handlerId: unknown,
+): boolean {
+  if (!validIdentity(identityRaw, handlerId) || !validFailurePolicy(failurePolicyRaw)) return false;
+  const identity = parseJson(identityRaw, 8192);
+  const failurePolicy = parseJson(failurePolicyRaw, 1024);
+  if (!plainObject(identity) || !plainObject(failurePolicy)) return false;
+  return hasCompatibleLifecycleFailurePolicy(
+    identity as {
+      mode: string;
+      runtimeKind: string;
+      inputContract: string;
+      outputContract: string;
+      interceptorSafety?: string;
+    },
+    failurePolicy as { mode: string },
+  );
+}
+
+export function validDiagnostic(raw: unknown): boolean {
+  const value = parseJson(raw, 1024);
+  return exactKeys(value, ['code']) && lifecycleIdentifier(value.code);
+}
+
+function validPersona(value: unknown): boolean {
+  return (
+    typeof value === 'string' &&
+    value.indexOf('\0') === -1 &&
+    value.length > 0 &&
+    isBoundedUnicodeScalarsUtf8(value, 256, 1024)
+  );
+}
+
+/** Registers validators before migrations and on normal application connections. */
+export function registerLifecycleSqlFunctions(db: Database.Database): void {
+  db.function(
+    'lifecycle_json_valid_provenance',
+    { deterministic: true },
+    (value: unknown): number => (validProvenance(value) ? 1 : 0),
+  );
+  db.function('lifecycle_json_valid_payload', { deterministic: true }, (value: unknown): number =>
+    validPayload(value) ? 1 : 0,
+  );
+  db.function(
+    'lifecycle_json_valid_handler_identity',
+    { deterministic: true },
+    (value: unknown, handlerId: unknown): number => (validIdentity(value, handlerId) ? 1 : 0),
+  );
+  db.function(
+    'lifecycle_json_valid_failure_policy',
+    { deterministic: true },
+    (value: unknown): number => (validFailurePolicy(value) ? 1 : 0),
+  );
+  db.function(
+    'lifecycle_json_valid_delivery_contract',
+    { deterministic: true },
+    (identity: unknown, failurePolicy: unknown, handlerId: unknown): number =>
+      validDeliveryContract(identity, failurePolicy, handlerId) ? 1 : 0,
+  );
+  db.function(
+    'lifecycle_json_valid_diagnostic',
+    { deterministic: true },
+    (value: unknown): number => (validDiagnostic(value) ? 1 : 0),
+  );
+  db.function('lifecycle_runtime_id_valid', { deterministic: true }, (value: unknown): number =>
+    runtimeId(value) ? 1 : 0,
+  );
+  db.function('lifecycle_identifier_valid', { deterministic: true }, (value: unknown): number =>
+    lifecycleIdentifier(value) ? 1 : 0,
+  );
+  db.function('lifecycle_persona_valid', { deterministic: true }, (value: unknown): number =>
+    validPersona(value) ? 1 : 0,
+  );
+}

--- a/src/core/database/migrations/014-lifecycle-events.sql
+++ b/src/core/database/migrations/014-lifecycle-events.sql
@@ -1,0 +1,191 @@
+-- Migration 014: durable lifecycle event outbox and per-handler deliveries.
+--
+-- The lifecycle_json_* functions are registered by the connection factory and
+-- migration runner. They parse bounded JSON before any deep walk, preserve
+-- escaped Unicode exactly, reject duplicate keys, and fail closed if absent.
+
+CREATE TABLE lifecycle_events (
+  event_sequence INTEGER PRIMARY KEY AUTOINCREMENT CHECK (event_sequence > 0),
+  event_id       TEXT NOT NULL UNIQUE CHECK (typeof(event_id) = 'text' AND lifecycle_runtime_id_valid(event_id)),
+  version        TEXT NOT NULL CHECK (version = 'v1'),
+  type           TEXT NOT NULL CHECK (type IN ('message.persisted.v1', 'message.routed.v1', 'queue.item.enqueued.v1', 'queue.item.completed.v1', 'queue.item.failed.v1', 'queue.item.dead_lettered.v1', 'run.started.v1', 'provider.tool.started.v1', 'provider.tool.completed.v1', 'run.completed.v1', 'run.failed.v1', 'message.sent.v1', 'message.send_failed.v1', 'context.threshold_exceeded.v1', 'context.rotated.v1', 'context.observation_log_threshold_exceeded.v1', 'schedule.fired.v1')),
+  aggregate_type TEXT NOT NULL CHECK (typeof(aggregate_type) = 'text' AND lifecycle_identifier_valid(aggregate_type)),
+  aggregate_id   TEXT NOT NULL CHECK (typeof(aggregate_id) = 'text' AND lifecycle_runtime_id_valid(aggregate_id)),
+  correlation_id TEXT NOT NULL CHECK (typeof(correlation_id) = 'text' AND lifecycle_runtime_id_valid(correlation_id)),
+  causation_id   TEXT CHECK (causation_id IS NULL OR (typeof(causation_id) = 'text' AND lifecycle_runtime_id_valid(causation_id))),
+  recursion_depth     INTEGER NOT NULL CHECK (typeof(recursion_depth) = 'integer' AND recursion_depth BETWEEN 0 AND 16),
+  recursion_max_depth INTEGER NOT NULL CHECK (typeof(recursion_max_depth) = 'integer' AND recursion_max_depth BETWEEN 1 AND 16 AND recursion_depth <= recursion_max_depth),
+  provenance     TEXT NOT NULL CHECK (typeof(provenance) = 'text' AND lifecycle_json_valid_provenance(provenance)),
+  payload        TEXT NOT NULL CHECK (typeof(payload) = 'text' AND lifecycle_json_valid_payload(payload)),
+  occurred_at    TEXT NOT NULL CHECK (typeof(occurred_at) = 'text' AND occurred_at GLOB '????-??-??T??:??:??.???Z' AND strftime('%Y-%m-%dT%H:%M:%fZ', occurred_at) IS occurred_at),
+  created_at     INTEGER NOT NULL CHECK (typeof(created_at) = 'integer' AND created_at BETWEEN -9007199254740991 AND 9007199254740991)
+);
+
+CREATE INDEX idx_lifecycle_events_aggregate_sequence ON lifecycle_events(aggregate_type, aggregate_id, event_sequence);
+CREATE INDEX idx_lifecycle_events_correlation ON lifecycle_events(correlation_id, event_sequence);
+CREATE INDEX idx_lifecycle_events_type_created ON lifecycle_events(type, created_at);
+
+-- Conflict resolution must not turn the append-only outbox into a destructive
+-- upsert. A BEFORE INSERT trigger runs before SQLite can delete the conflicted
+-- row for INSERT OR REPLACE, preserving both the original event and any
+-- deliveries that reference it. Check both persisted identities: event_id is
+-- the external idempotency key, while event_sequence is the append-only key.
+-- Before SQLite allocates an omitted INTEGER PRIMARY KEY, NEW.event_sequence
+-- is its undefined-rowid sentinel (-1). Do not compare that provisional value.
+-- The table's positive-sequence CHECK runs after allocation, so it permits an
+-- omitted sequence but rejects every explicit non-positive sequence.
+CREATE TRIGGER lifecycle_events_reject_replacements
+BEFORE INSERT ON lifecycle_events
+FOR EACH ROW
+WHEN EXISTS (
+  SELECT 1
+  FROM lifecycle_events
+  WHERE event_id IS NEW.event_id
+    OR (NEW.event_sequence IS NOT -1 AND event_sequence IS NEW.event_sequence)
+)
+BEGIN
+  SELECT RAISE(ABORT, 'lifecycle events cannot be replaced');
+END;
+
+CREATE TABLE lifecycle_event_deliveries (
+  event_id          TEXT NOT NULL REFERENCES lifecycle_events(event_id) ON DELETE CASCADE,
+  handler_id        TEXT NOT NULL CHECK (typeof(handler_id) = 'text' AND lifecycle_identifier_valid(handler_id)),
+  persona           TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  priority          INTEGER NOT NULL DEFAULT 0 CHECK (typeof(priority) = 'integer' AND priority BETWEEN -1000 AND 1000),
+  handler_identity  TEXT NOT NULL CHECK (typeof(handler_identity) = 'text' AND lifecycle_json_valid_handler_identity(handler_identity, handler_id)),
+  failure_policy    TEXT NOT NULL CHECK (typeof(failure_policy) = 'text' AND lifecycle_json_valid_failure_policy(failure_policy)),
+  status            TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'claimed', 'failed', 'completed', 'dead_letter')),
+  attempts          INTEGER NOT NULL DEFAULT 0 CHECK (typeof(attempts) = 'integer' AND attempts >= 0),
+  max_attempts      INTEGER NOT NULL DEFAULT 3 CHECK (typeof(max_attempts) = 'integer' AND max_attempts BETWEEN 1 AND 100),
+  next_retry_at     INTEGER CHECK (next_retry_at IS NULL OR (typeof(next_retry_at) = 'integer' AND next_retry_at BETWEEN -9007199254740991 AND 9007199254740991)),
+  claim_token       TEXT CHECK (claim_token IS NULL OR (typeof(claim_token) = 'text' AND lifecycle_runtime_id_valid(claim_token))),
+  claim_expires_at  INTEGER CHECK (claim_expires_at IS NULL OR (typeof(claim_expires_at) = 'integer' AND claim_expires_at BETWEEN -9007199254740991 AND 9007199254740991)),
+  last_error        TEXT CHECK (last_error IS NULL OR (typeof(last_error) = 'text' AND lifecycle_json_valid_diagnostic(last_error))),
+  completed_at      INTEGER CHECK (completed_at IS NULL OR (typeof(completed_at) = 'integer' AND completed_at BETWEEN -9007199254740991 AND 9007199254740991)),
+  created_at        INTEGER NOT NULL CHECK (typeof(created_at) = 'integer' AND created_at BETWEEN -9007199254740991 AND 9007199254740991),
+  updated_at        INTEGER NOT NULL CHECK (typeof(updated_at) = 'integer' AND updated_at BETWEEN -9007199254740991 AND 9007199254740991),
+  CHECK (lifecycle_json_valid_delivery_contract(handler_identity, failure_policy, handler_id)),
+  PRIMARY KEY (event_id, handler_id),
+  CHECK (attempts <= max_attempts),
+  CHECK ((status = 'pending' AND attempts = 0 AND next_retry_at IS NULL AND claim_token IS NULL AND claim_expires_at IS NULL AND last_error IS NULL AND completed_at IS NULL) OR (status = 'claimed' AND attempts < max_attempts AND next_retry_at IS NULL AND claim_token IS NOT NULL AND claim_expires_at IS NOT NULL AND last_error IS NULL AND completed_at IS NULL) OR (status = 'failed' AND attempts >= 1 AND attempts < max_attempts AND next_retry_at IS NOT NULL AND claim_token IS NULL AND claim_expires_at IS NULL AND last_error IS NOT NULL AND completed_at IS NULL) OR (status = 'completed' AND attempts < max_attempts AND claim_token IS NULL AND claim_expires_at IS NULL AND next_retry_at IS NULL AND last_error IS NULL AND completed_at IS NOT NULL) OR (status = 'dead_letter' AND attempts = max_attempts AND next_retry_at IS NULL AND claim_token IS NULL AND claim_expires_at IS NULL AND last_error IS NOT NULL AND completed_at IS NULL))
+);
+
+CREATE INDEX idx_lifecycle_deliveries_ready ON lifecycle_event_deliveries(status, next_retry_at, priority DESC, created_at) WHERE status IN ('pending', 'failed');
+CREATE INDEX idx_lifecycle_deliveries_expired_claims ON lifecycle_event_deliveries(claim_expires_at, priority DESC, created_at) WHERE status = 'claimed' AND claim_expires_at IS NOT NULL;
+CREATE INDEX idx_lifecycle_deliveries_handler_status ON lifecycle_event_deliveries(handler_id, status, created_at);
+
+-- A fan-out always begins at the canonical pending state. The transition
+-- trigger below protects existing rows; this INSERT guard closes the direct
+-- SQL path that could otherwise forge a terminal state at creation time.
+CREATE TRIGGER lifecycle_event_deliveries_guard_initial_insert
+BEFORE INSERT ON lifecycle_event_deliveries
+FOR EACH ROW
+WHEN NOT (
+  NEW.status IS 'pending'
+  AND NEW.attempts IS 0
+  AND NEW.next_retry_at IS NULL
+  AND NEW.claim_token IS NULL
+  AND NEW.claim_expires_at IS NULL
+  AND NEW.last_error IS NULL
+  AND NEW.completed_at IS NULL
+)
+BEGIN
+  SELECT RAISE(ABORT, 'lifecycle deliveries must be inserted pending');
+END;
+
+-- A delivery's composite event/handler key is a durable fan-out identity.
+-- Abort before INSERT OR REPLACE can delete the original row and bypass the
+-- immutable snapshot and transition guards that apply only to UPDATE.
+CREATE TRIGGER lifecycle_event_deliveries_reject_replacements
+BEFORE INSERT ON lifecycle_event_deliveries
+FOR EACH ROW
+WHEN EXISTS (
+  SELECT 1
+  FROM lifecycle_event_deliveries
+  WHERE event_id IS NEW.event_id AND handler_id IS NEW.handler_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'lifecycle deliveries cannot be replaced');
+END;
+
+-- Events are an append-only outbox. All columns, including the generated
+-- sequence, are immutable once SQLite has accepted the insert.
+CREATE TRIGGER lifecycle_events_reject_updates
+BEFORE UPDATE ON lifecycle_events
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'lifecycle events are immutable');
+END;
+
+-- Deliveries retain their event/handler identity and fan-out policy snapshot.
+-- The remaining fields may change only as part of one of the durable state
+-- transitions below. CHECK constraints validate each target state; this trigger
+-- additionally prevents direct SQL from skipping a claim or rewriting history.
+CREATE TRIGGER lifecycle_event_deliveries_guard_transitions
+BEFORE UPDATE ON lifecycle_event_deliveries
+FOR EACH ROW
+WHEN NOT (
+  NEW.event_id IS OLD.event_id
+  AND NEW.handler_id IS OLD.handler_id
+  AND NEW.persona IS OLD.persona
+  AND NEW.priority IS OLD.priority
+  AND NEW.handler_identity IS OLD.handler_identity
+  AND NEW.failure_policy IS OLD.failure_policy
+  AND NEW.max_attempts IS OLD.max_attempts
+  AND NEW.created_at IS OLD.created_at
+  AND (
+    -- A ready delivery acquires exactly one fresh lease without changing its
+    -- attempt count. Failed deliveries clear their retry diagnostic here.
+    (
+      OLD.status IN ('pending', 'failed')
+      AND NEW.status = 'claimed'
+      AND NEW.attempts IS OLD.attempts
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NOT NULL
+      AND NEW.claim_expires_at IS NOT NULL
+      AND NEW.last_error IS NULL
+      AND NEW.completed_at IS OLD.completed_at
+    )
+    OR
+    -- Only a leased delivery can complete; completion does not consume a new
+    -- attempt and clears the lease atomically.
+    (
+      OLD.status = 'claimed'
+      AND NEW.status = 'completed'
+      AND NEW.attempts IS OLD.attempts
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IS NULL
+      AND NEW.completed_at IS NOT NULL
+    )
+    OR
+    -- A failed execution or expired lease consumes exactly one attempt before
+    -- moving to retryable failure or the terminal dead-letter state.
+    (
+      OLD.status = 'claimed'
+      AND NEW.status IN ('failed', 'dead_letter')
+      AND NEW.attempts = OLD.attempts + 1
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IS NOT NULL
+      AND NEW.completed_at IS OLD.completed_at
+    )
+    OR
+    -- Explicit replay may reopen only a terminal delivery and resets every
+    -- mutable execution field to the canonical pending state.
+    (
+      OLD.status IN ('completed', 'dead_letter')
+      AND NEW.status = 'pending'
+      AND NEW.attempts = 0
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IS NULL
+      AND NEW.completed_at IS NULL
+    )
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid lifecycle delivery update');
+END;

--- a/src/core/database/migrations/runner.ts
+++ b/src/core/database/migrations/runner.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import type Database from 'better-sqlite3';
 import { ok, err, type Result } from 'neverthrow';
 import { MigrationError } from '../../errors/index.js';
+import { registerLifecycleSqlFunctions } from '../lifecycle-sql-functions.js';
 
 /**
  * Applies all pending migrations from `migrationsDir` to `db`.
@@ -28,6 +29,19 @@ export function runMigrations(
   db: Database.Database,
   migrationsDir: string,
 ): Result<number, MigrationError> {
+  // Tests and upgrade callers commonly construct better-sqlite3 directly.
+  // Register before parsing migration SQL so the CHECK constraints are usable
+  // immediately and unknown functions cannot accidentally weaken validation.
+  try {
+    registerLifecycleSqlFunctions(db);
+  } catch (cause) {
+    return err(
+      new MigrationError(
+        `Cannot register lifecycle SQLite validators: ${String(cause)}`,
+        cause instanceof Error ? cause : undefined,
+      ),
+    );
+  }
   // Read current schema version from the database.
   const currentVersion = db.pragma('user_version', { simple: true }) as number;
 

--- a/src/core/database/repositories/base-repository.ts
+++ b/src/core/database/repositories/base-repository.ts
@@ -29,17 +29,24 @@ export abstract class BaseRepository {
   /** Returns the current time as Unix epoch milliseconds, strictly monotonic. */
   protected now(): number {
     const wall = Date.now();
-    const next = wall > BaseRepository.lastMonotonicTs
-      ? wall
-      : BaseRepository.lastMonotonicTs + 1;
+    const next = wall > BaseRepository.lastMonotonicTs ? wall : BaseRepository.lastMonotonicTs + 1;
     BaseRepository.lastMonotonicTs = next;
     return next;
   }
 
   /**
+   * Returns wall-clock time for lease durations. This intentionally does not
+   * participate in write ordering: a burst of unrelated writes must not make
+   * a valid 100ms lease appear expired.
+   */
+  protected leaseNow(): number {
+    return Date.now();
+  }
+
+  /**
    * Seed the in-memory monotonic counter from the max `created_at` across
    * the tables whose timestamps gate durable correctness checks (messages,
-   * memory_items). Call once at bootstrap.
+   * memory_items, and lifecycle event/delivery state). Call once at bootstrap.
    *
    * Why: monotonic issuance is otherwise only safe within a single process
    * lifetime. If process A persisted drift-inflated timestamps (or the
@@ -56,7 +63,11 @@ export abstract class BaseRepository {
         .prepare(
           `SELECT MAX(
              COALESCE((SELECT MAX(created_at) FROM messages), 0),
-             COALESCE((SELECT MAX(created_at) FROM memory_items), 0)
+             COALESCE((SELECT MAX(created_at) FROM memory_items), 0),
+             COALESCE((SELECT MAX(created_at) FROM lifecycle_events), 0),
+             COALESCE((SELECT MAX(created_at) FROM lifecycle_event_deliveries), 0),
+             COALESCE((SELECT MAX(updated_at) FROM lifecycle_event_deliveries), 0),
+             COALESCE((SELECT MAX(completed_at) FROM lifecycle_event_deliveries), 0)
            ) AS max_ts`,
         )
         .get() as { max_ts: number | null } | undefined;

--- a/src/core/database/repositories/index.ts
+++ b/src/core/database/repositories/index.ts
@@ -23,12 +23,7 @@ export { ThreadRepository } from './thread-repository.js';
 export type { MessageRow, InsertMessageInput } from './message-repository.js';
 export { MessageRepository } from './message-repository.js';
 
-export type {
-  QueueItemRow,
-  QueueStatus,
-  QueueType,
-  EnqueueInput,
-} from './queue-repository.js';
+export type { QueueItemRow, QueueStatus, QueueType, EnqueueInput } from './queue-repository.js';
 export { QueueRepository } from './queue-repository.js';
 
 export type {
@@ -40,7 +35,12 @@ export type {
 } from './run-repository.js';
 export { RunRepository } from './run-repository.js';
 
-export type { ScheduleRow, ScheduleType, InsertScheduleInput, UpdateScheduleInput } from './schedule-repository.js';
+export type {
+  ScheduleRow,
+  ScheduleType,
+  InsertScheduleInput,
+  UpdateScheduleInput,
+} from './schedule-repository.js';
 export { ScheduleRepository } from './schedule-repository.js';
 
 export type {
@@ -57,7 +57,11 @@ export { ArtifactRepository } from './artifact-repository.js';
 export type { AuditLogRow, InsertAuditLogInput } from './audit-repository.js';
 export { AuditRepository } from './audit-repository.js';
 
-export type { ToolResultRow, ToolResultStatus, InsertToolResultInput } from './tool-result-repository.js';
+export type {
+  ToolResultRow,
+  ToolResultStatus,
+  InsertToolResultInput,
+} from './tool-result-repository.js';
 export { ToolResultRepository } from './tool-result-repository.js';
 
 export { BackgroundTaskRepository } from './background-task-repository.js';
@@ -65,3 +69,20 @@ export type { InsertA2ATaskInput } from './a2a-task-repository.js';
 export { A2ATaskRepository } from './a2a-task-repository.js';
 export { ExecutionEnvRepository } from './execution-env-repository.js';
 export { ExecutionEnvCheckpointRepository } from './execution-env-checkpoint-repository.js';
+
+export type {
+  LifecycleEventRow,
+  LifecycleEventFanoutResult,
+} from './lifecycle-event-repository.js';
+export { LifecycleEventRepository } from './lifecycle-event-repository.js';
+
+export type {
+  LifecycleDeliveryStatus,
+  LifecycleDeliveryFanoutInput,
+  LifecycleDeliveryRow,
+  ClaimedLifecycleDelivery,
+  ClaimLifecycleDeliveryOptions,
+  LifecycleDeliveryClock,
+  LifecycleFailureDiagnostic,
+} from './lifecycle-delivery-repository.js';
+export { LifecycleDeliveryRepository } from './lifecycle-delivery-repository.js';

--- a/src/core/database/repositories/lifecycle-delivery-repository.ts
+++ b/src/core/database/repositories/lifecycle-delivery-repository.ts
@@ -1,0 +1,724 @@
+/** Durable claims, retries, terminal state, and replay primitives for lifecycle deliveries. */
+
+import { v4 as uuidv4 } from 'uuid';
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import {
+  LifecycleEventEnvelopeSchema,
+  LifecycleFailurePolicyContractSchema,
+  LifecycleFilterOwnerNameSchema,
+  LifecycleHandlerIdentityContractSchema,
+  LifecycleIdentifierSchema,
+  LifecycleRuntimeIdSchema,
+} from '../../../lifecycle/contracts/index.js';
+import type {
+  LifecycleFailurePolicyContract,
+  LifecycleHandlerIdentityContract,
+} from '../../../lifecycle/contracts/index.js';
+import { DbError } from '../../errors/index.js';
+import {
+  validDiagnostic,
+  validFailurePolicy,
+  validIdentity,
+  validPayload,
+  validProvenance,
+} from '../lifecycle-sql-functions.js';
+import { BaseRepository } from './base-repository.js';
+import {
+  hasDurableHandlerIdentityAuthority,
+  hasCompatibleLifecycleFailurePolicy,
+  isBoundedWellFormedUtf8,
+  isBoundedUnicodeScalarsUtf8,
+  snapshotBoundedPlainDataRecord,
+  snapshotLifecycleDeliveries,
+  snapshotLifecycleEvent,
+  snapshotLifecycleFailureDiagnostic,
+} from './lifecycle-persistence-validation.js';
+import type { LifecycleEventRow } from './lifecycle-event-repository.js';
+
+export type LifecycleDeliveryStatus =
+  | 'pending'
+  | 'claimed'
+  | 'failed'
+  | 'completed'
+  | 'dead_letter';
+
+/** Immutable handler snapshot used when fanning out one persisted event. */
+export interface LifecycleDeliveryFanoutInput {
+  handlerId: string;
+  persona: string;
+  priority: number;
+  identity: LifecycleHandlerIdentityContract;
+  failurePolicy: LifecycleFailurePolicyContract;
+  maxAttempts?: number;
+}
+
+/** Database row for a single stable (event_id, handler_id) delivery identity. */
+export interface LifecycleDeliveryRow {
+  event_id: string;
+  handler_id: string;
+  persona: string;
+  priority: number;
+  handler_identity: string;
+  failure_policy: string;
+  status: LifecycleDeliveryStatus;
+  attempts: number;
+  max_attempts: number;
+  next_retry_at: number | null;
+  claim_token: string | null;
+  claim_expires_at: number | null;
+  last_error: string | null;
+  completed_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+/** A successful claim carries the immutable event envelope row for execution. */
+export interface ClaimedLifecycleDelivery {
+  delivery: LifecycleDeliveryRow;
+  event: LifecycleEventRow;
+}
+
+export interface ClaimLifecycleDeliveryOptions {
+  leaseMs: number;
+}
+
+/** Trusted clock supplied by repository composition; production defaults to Date.now. */
+export type LifecycleDeliveryClock = () => number;
+
+/** Persisted failure diagnostics intentionally carry only a stable, non-secret code. */
+export interface LifecycleFailureDiagnostic {
+  code: string;
+}
+
+const LifecycleFailureDiagnosticSchema = z.object({ code: LifecycleIdentifierSchema }).strict();
+
+const LifecycleDeliveryStatusSchema = z.enum([
+  'pending',
+  'claimed',
+  'failed',
+  'completed',
+  'dead_letter',
+]);
+
+const MAX_LIFECYCLE_DELIVERY_PERSONA_LENGTH = 256;
+const MAX_LIFECYCLE_DELIVERY_PERSONA_UTF8_BYTES = 1_024;
+
+function toDbError(operation: string, cause: unknown): DbError {
+  // Public boundaries must not retain caller-controlled Error instances: they
+  // can contain credentials and can expose hostile values through a later
+  // inspection of Error.cause.
+  void cause;
+  return new DbError(`Failed to ${operation}`);
+}
+
+/** Repository for independently retryable lifecycle handler deliveries. */
+export class LifecycleDeliveryRepository extends BaseRepository {
+  private readonly claimNextStmt: Database.Statement;
+  private readonly findByKeyStmt: Database.Statement;
+  private readonly findByEventIdStmt: Database.Statement;
+  private readonly completeStmt: Database.Statement;
+  private readonly failStmt: Database.Statement;
+  private readonly expireClaimsStmt: Database.Statement;
+  private readonly canReopenStmt: Database.Statement;
+  private readonly reopenStmt: Database.Statement;
+  private readonly findEventStmt: Database.Statement;
+
+  constructor(
+    db: Database.Database,
+    private readonly leaseClock: LifecycleDeliveryClock = Date.now,
+  ) {
+    super(db);
+    this.claimNextStmt = db.prepare(`
+      WITH candidate AS (
+        SELECT d.event_id, d.handler_id
+        FROM lifecycle_event_deliveries d
+        JOIN lifecycle_events e ON e.event_id = d.event_id
+        WHERE d.status IN ('pending', 'failed')
+          AND (d.next_retry_at IS NULL OR d.next_retry_at <= @lease_now)
+        AND NOT EXISTS (
+          SELECT 1
+          FROM lifecycle_event_deliveries previous_delivery
+          JOIN lifecycle_events previous_event ON previous_event.event_id = previous_delivery.event_id
+          WHERE previous_delivery.handler_id = d.handler_id
+            AND previous_event.aggregate_type = e.aggregate_type
+            AND previous_event.aggregate_id = e.aggregate_id
+            AND previous_event.event_sequence < e.event_sequence
+            AND previous_delivery.status NOT IN ('completed', 'dead_letter')
+        )
+        ORDER BY d.priority DESC, e.event_sequence ASC, d.created_at ASC
+        LIMIT 1
+      )
+      UPDATE lifecycle_event_deliveries
+      SET status = 'claimed',
+          claim_token = @claim_token,
+          claim_expires_at = @claim_expires_at,
+          next_retry_at = NULL,
+          last_error = NULL,
+          updated_at = @write_now
+      WHERE (event_id, handler_id) IN (SELECT event_id, handler_id FROM candidate)
+      RETURNING *
+    `);
+    this.findByKeyStmt = db.prepare(`
+      SELECT * FROM lifecycle_event_deliveries WHERE event_id = ? AND handler_id = ?
+    `);
+    this.findByEventIdStmt = db.prepare(`
+      SELECT * FROM lifecycle_event_deliveries WHERE event_id = ? ORDER BY priority DESC, created_at ASC
+    `);
+    this.completeStmt = db.prepare(`
+      UPDATE lifecycle_event_deliveries
+      SET status = 'completed', claim_token = NULL, claim_expires_at = NULL,
+          next_retry_at = NULL, last_error = NULL, completed_at = @write_now, updated_at = @write_now
+      WHERE event_id = @event_id AND handler_id = @handler_id
+        AND status = 'claimed' AND claim_token = @claim_token
+        AND claim_expires_at > @lease_now
+      RETURNING *
+    `);
+    this.failStmt = db.prepare(`
+      UPDATE lifecycle_event_deliveries
+      SET status = CASE WHEN attempts + 1 >= max_attempts THEN 'dead_letter' ELSE 'failed' END,
+          attempts = attempts + 1,
+          next_retry_at = CASE WHEN attempts + 1 >= max_attempts THEN NULL ELSE @next_retry_at END,
+          claim_token = NULL, claim_expires_at = NULL, last_error = @last_error,
+          updated_at = @write_now
+      WHERE event_id = @event_id AND handler_id = @handler_id
+        AND status = 'claimed' AND claim_token = @claim_token
+        AND claim_expires_at > @lease_now
+      RETURNING *
+    `);
+    this.expireClaimsStmt = db.prepare(`
+      UPDATE lifecycle_event_deliveries
+      SET status = CASE WHEN attempts + 1 >= max_attempts THEN 'dead_letter' ELSE 'failed' END,
+          attempts = attempts + 1,
+          next_retry_at = CASE WHEN attempts + 1 >= max_attempts THEN NULL ELSE @lease_now END,
+          claim_token = NULL,
+          claim_expires_at = NULL,
+          last_error = '{"code":"lease-expired"}',
+          updated_at = @write_now
+      WHERE status = 'claimed' AND claim_expires_at <= @lease_now
+    `);
+    this.canReopenStmt = db.prepare(`
+      SELECT 1
+      FROM lifecycle_event_deliveries target_delivery
+      WHERE target_delivery.event_id = @event_id AND target_delivery.handler_id = @handler_id
+        AND target_delivery.status IN ('completed', 'dead_letter')
+        AND NOT EXISTS (
+          SELECT 1
+          FROM lifecycle_event_deliveries later_delivery
+          JOIN lifecycle_events target_event ON target_event.event_id = target_delivery.event_id
+          JOIN lifecycle_events later_event ON later_event.event_id = later_delivery.event_id
+          WHERE later_delivery.handler_id = target_delivery.handler_id
+            AND later_event.aggregate_type = target_event.aggregate_type
+            AND later_event.aggregate_id = target_event.aggregate_id
+            AND later_event.event_sequence > target_event.event_sequence
+            AND later_delivery.status = 'claimed'
+            AND later_delivery.claim_expires_at > @lease_now
+        )
+    `);
+    this.reopenStmt = db.prepare(`
+      UPDATE lifecycle_event_deliveries
+      SET status = 'pending', attempts = 0, next_retry_at = NULL,
+          claim_token = NULL, claim_expires_at = NULL, last_error = NULL,
+          completed_at = NULL, updated_at = @write_now
+      WHERE event_id = @event_id AND handler_id = @handler_id
+        AND status IN ('completed', 'dead_letter')
+        AND NOT EXISTS (
+          SELECT 1
+          FROM lifecycle_event_deliveries later_delivery
+          JOIN lifecycle_events target_event ON target_event.event_id = lifecycle_event_deliveries.event_id
+          JOIN lifecycle_events later_event ON later_event.event_id = later_delivery.event_id
+          WHERE later_delivery.handler_id = lifecycle_event_deliveries.handler_id
+            AND later_event.aggregate_type = target_event.aggregate_type
+            AND later_event.aggregate_id = target_event.aggregate_id
+            AND later_event.event_sequence > target_event.event_sequence
+            AND later_delivery.status = 'claimed'
+            AND later_delivery.claim_expires_at > @lease_now
+        )
+      RETURNING *
+    `);
+    this.findEventStmt = db.prepare(`SELECT * FROM lifecycle_events WHERE event_id = ?`);
+  }
+
+  /**
+   * Atomically claims the highest-priority eligible delivery. Earlier
+   * unfinished work for the same aggregate and handler blocks later events.
+   * Expired leases are eligible again, making a process restart recoverable.
+   */
+  claimNext(
+    options: ClaimLifecycleDeliveryOptions,
+  ): Result<ClaimedLifecycleDelivery | null, DbError> {
+    try {
+      const normalizedOptions = this.normalizeClaimOptions(options);
+      if (!normalizedOptions) {
+        return err(
+          new DbError(
+            'Failed to claim lifecycle delivery: leaseMs must be an integer between 1 and 86400000',
+          ),
+        );
+      }
+      const leaseNow = this.leaseNow();
+      const claimExpiresAt = leaseNow + normalizedOptions.leaseMs;
+      if (!Number.isSafeInteger(leaseNow) || !Number.isSafeInteger(claimExpiresAt)) {
+        return err(new DbError('Failed to claim lifecycle delivery: lease timestamp overflow'));
+      }
+      // A lease token is always repository-owned. A caller must never be able
+      // to resurrect a stale worker's token during expiry reclamation.
+      const claimToken = uuidv4();
+      const claim = this.db.transaction((): ClaimedLifecycleDelivery | null => {
+        const writeNow = this.now();
+        // A vanished worker consumed an execution attempt. Reclaim every
+        // expired lease before selecting work so an exhausted earlier event
+        // dead-letters and can no longer block its aggregate.
+        this.expireClaimsStmt.run({ lease_now: leaseNow, write_now: writeNow });
+        const row = this.claimNextStmt.get({
+          lease_now: leaseNow,
+          write_now: writeNow,
+          claim_token: claimToken,
+          claim_expires_at: claimExpiresAt,
+        }) as LifecycleDeliveryRow | undefined;
+        if (!row) {
+          return null;
+        }
+        const delivery = this.validateDeliveryRow(row);
+        const storedEvent = this.findEventStmt.get(delivery.event_id) as
+          | LifecycleEventRow
+          | undefined;
+        if (!storedEvent) {
+          throw new Error('claimed lifecycle delivery has no event');
+        }
+        return { delivery, event: this.validateEventRow(storedEvent) };
+      });
+      return ok(claim());
+    } catch (cause) {
+      return err(toDbError('claim lifecycle delivery', cause));
+    }
+  }
+
+  /** Completes only the current lease holder; stale workers cannot complete reclaimed work. */
+  complete(
+    eventId: string,
+    handlerId: string,
+    claimToken: string,
+  ): Result<LifecycleDeliveryRow, DbError> {
+    try {
+      if (
+        !this.isRuntimeId(eventId) ||
+        !this.isIdentifier(handlerId) ||
+        !this.isRuntimeId(claimToken)
+      ) {
+        return err(new DbError('Failed to complete lifecycle delivery: invalid delivery identity'));
+      }
+      const complete = this.db.transaction((): LifecycleDeliveryRow | null => {
+        const leaseNow = this.leaseNow();
+        const row = this.completeStmt.get({
+          event_id: eventId,
+          handler_id: handlerId,
+          claim_token: claimToken,
+          lease_now: leaseNow,
+          write_now: this.now(),
+        }) as LifecycleDeliveryRow | undefined;
+        return row ? this.validateDeliveryRow(row) : null;
+      });
+      const row = complete();
+      return row
+        ? ok(row)
+        : err(new DbError('Failed to complete lifecycle delivery: no active matching lease'));
+    } catch (cause) {
+      return err(toDbError('complete lifecycle delivery', cause));
+    }
+  }
+
+  /**
+   * Records a retryable failure or atomically moves the delivery to its
+   * terminal dead-letter state once its bounded attempt budget is exhausted.
+   */
+  fail(
+    eventId: string,
+    handlerId: string,
+    claimToken: string,
+    failureDiagnostic: LifecycleFailureDiagnostic,
+    nextRetryAt: number,
+  ): Result<LifecycleDeliveryRow, DbError> {
+    try {
+      const diagnosticSnapshot = snapshotLifecycleFailureDiagnostic(failureDiagnostic);
+      const diagnostic = diagnosticSnapshot
+        ? this.parse(LifecycleFailureDiagnosticSchema, diagnosticSnapshot)
+        : null;
+      if (
+        !diagnostic ||
+        !this.isRuntimeId(eventId) ||
+        !this.isIdentifier(handlerId) ||
+        !this.isRuntimeId(claimToken) ||
+        !Number.isSafeInteger(nextRetryAt)
+      ) {
+        return err(
+          new DbError(
+            'Failed to fail lifecycle delivery: invalid failure diagnostic or retry timestamp',
+          ),
+        );
+      }
+      const fail = this.db.transaction((): LifecycleDeliveryRow | null => {
+        const leaseNow = this.leaseNow();
+        const row = this.failStmt.get({
+          event_id: eventId,
+          handler_id: handlerId,
+          claim_token: claimToken,
+          next_retry_at: nextRetryAt,
+          // Never persist arbitrary handler error text; it may contain prompts,
+          // tokens, headers, or other secrets. A parsed contract-owned code is
+          // sufficient for retry policy and operator aggregation.
+          last_error: JSON.stringify(diagnostic),
+          lease_now: leaseNow,
+          write_now: this.now(),
+        }) as LifecycleDeliveryRow | undefined;
+        return row ? this.validateDeliveryRow(row) : null;
+      });
+      const row = fail();
+      return row ? ok(row) : err(new DbError('Failed to fail lifecycle delivery: lease was lost'));
+    } catch (cause) {
+      return err(toDbError('fail lifecycle delivery', cause));
+    }
+  }
+
+  /** Reopens one terminal delivery for an explicit replay without creating a second identity. */
+  reopen(eventId: string, handlerId: string): Result<LifecycleDeliveryRow, DbError> {
+    try {
+      if (!this.isRuntimeId(eventId) || !this.isIdentifier(handlerId)) {
+        return err(new DbError('Failed to reopen lifecycle delivery: invalid delivery identity'));
+      }
+      const reopen = this.db.transaction((): LifecycleDeliveryRow | null => {
+        const leaseNow = this.leaseNow();
+        // Prove this specific replay is eligible before recovering any stale
+        // leases. A rejected replay must be observationally read-only for
+        // unrelated deliveries in the same transaction.
+        if (
+          !this.canReopenStmt.get({ event_id: eventId, handler_id: handlerId, lease_now: leaseNow })
+        ) {
+          return null;
+        }
+        const writeNow = this.now();
+        // Expiry is handled before replay, rather than merely changing an
+        // opaque token: the stale worker is invalidated and its lost execution
+        // consumes exactly one attempt in the same transaction.
+        this.expireClaimsStmt.run({
+          lease_now: leaseNow,
+          write_now: writeNow,
+        });
+        const row = this.reopenStmt.get({
+          event_id: eventId,
+          handler_id: handlerId,
+          lease_now: leaseNow,
+          write_now: writeNow,
+        }) as LifecycleDeliveryRow | undefined;
+        if (!row) {
+          // The eligibility check and state transition share one SQLite
+          // transaction. If they diverge, roll back expiry recovery too.
+          throw new Error('lifecycle delivery replay eligibility changed inside transaction');
+        }
+        return this.validateDeliveryRow(row);
+      });
+      const row = reopen();
+      return row
+        ? ok(row)
+        : err(new DbError('Failed to reopen lifecycle delivery: delivery is not terminal'));
+    } catch (cause) {
+      return err(toDbError('reopen lifecycle delivery', cause));
+    }
+  }
+
+  findByEventId(eventId: string): Result<LifecycleDeliveryRow[], DbError> {
+    try {
+      if (!this.isRuntimeId(eventId)) {
+        return err(
+          new DbError('Failed to find lifecycle deliveries by event id: invalid event id'),
+        );
+      }
+      return ok(
+        (this.findByEventIdStmt.all(eventId) as LifecycleDeliveryRow[]).map((row) =>
+          this.validateDeliveryRow(row),
+        ),
+      );
+    } catch (cause) {
+      return err(toDbError('find lifecycle deliveries by event id', cause));
+    }
+  }
+
+  findByKey(eventId: string, handlerId: string): Result<LifecycleDeliveryRow | null, DbError> {
+    try {
+      if (!this.isRuntimeId(eventId) || !this.isIdentifier(handlerId)) {
+        return err(
+          new DbError('Failed to find lifecycle delivery by key: invalid delivery identity'),
+        );
+      }
+      const row = this.findByKeyStmt.get(eventId, handlerId) as LifecycleDeliveryRow | undefined;
+      return ok(row ? this.validateDeliveryRow(row) : null);
+    } catch (cause) {
+      return err(toDbError('find lifecycle delivery by key', cause));
+    }
+  }
+
+  private normalizeClaimOptions(options: unknown): ClaimLifecycleDeliveryOptions | null {
+    // Unknown data fields remain backward-compatible, but their inspection is
+    // capped before any descriptor values are materialized.
+    const snapshot = snapshotBoundedPlainDataRecord(options, 8);
+    if (!snapshot || !Object.hasOwn(snapshot, 'leaseMs')) return null;
+    const leaseMs: unknown = snapshot.leaseMs;
+    if (
+      typeof leaseMs !== 'number' ||
+      !Number.isSafeInteger(leaseMs) ||
+      leaseMs < 1 ||
+      leaseMs > 86_400_000
+    ) {
+      return null;
+    }
+    return { leaseMs };
+  }
+
+  /** Lease mutation time is repository-owned, never supplied by a claim caller. */
+  protected override leaseNow(): number {
+    const now = this.leaseClock();
+    if (!Number.isSafeInteger(now)) {
+      throw new Error('invalid lifecycle lease clock');
+    }
+    return now;
+  }
+
+  private validateDeliveryRow(row: LifecycleDeliveryRow): LifecycleDeliveryRow {
+    if (!row || typeof row !== 'object') {
+      throw new Error('invalid persisted lifecycle delivery row');
+    }
+    if (
+      !validIdentity(row.handler_identity, row.handler_id) ||
+      !validFailurePolicy(row.failure_policy) ||
+      (row.last_error !== null && !validDiagnostic(row.last_error))
+    )
+      throw new Error('invalid persisted lifecycle delivery JSON');
+    const rawIdentity = this.parseJson(row.handler_identity, 'handler identity');
+    const rawFailurePolicy = this.parseJson(row.failure_policy, 'failure policy');
+    const snapshot = snapshotLifecycleDeliveries([
+      {
+        handlerId: row.handler_id,
+        persona: row.persona,
+        priority: row.priority,
+        identity: rawIdentity,
+        failurePolicy: rawFailurePolicy,
+        maxAttempts: row.max_attempts,
+      },
+    ]);
+    if (!snapshot) {
+      throw new Error('invalid persisted lifecycle delivery row');
+    }
+    const deliverySnapshot = snapshot[0];
+    if (!deliverySnapshot) {
+      throw new Error('invalid persisted lifecycle delivery row');
+    }
+    const identity = this.parse(LifecycleHandlerIdentityContractSchema, deliverySnapshot.identity);
+    const failurePolicy = this.parse(
+      LifecycleFailurePolicyContractSchema,
+      deliverySnapshot.failurePolicy,
+    );
+    const diagnostic =
+      row.last_error === null
+        ? null
+        : this.parse(
+            LifecycleFailureDiagnosticSchema,
+            this.parseJson(row.last_error, 'failure diagnostic'),
+          );
+    if (
+      !identity ||
+      !hasDurableHandlerIdentityAuthority(identity) ||
+      !failurePolicy ||
+      !hasCompatibleLifecycleFailurePolicy(identity, failurePolicy) ||
+      (row.last_error !== null && !diagnostic) ||
+      !this.isRuntimeId(row.event_id) ||
+      !this.isIdentifier(row.handler_id) ||
+      identity.handlerId !== row.handler_id ||
+      !this.isBoundedPersona(row.persona) ||
+      !this.parses(LifecycleDeliveryStatusSchema, row.status) ||
+      !Number.isSafeInteger(row.priority) ||
+      row.priority < -1000 ||
+      row.priority > 1000 ||
+      !Number.isSafeInteger(row.attempts) ||
+      !Number.isSafeInteger(row.max_attempts) ||
+      row.attempts < 0 ||
+      row.max_attempts < 1 ||
+      row.max_attempts > 100 ||
+      row.attempts > row.max_attempts ||
+      !this.isNullableTimestamp(row.next_retry_at) ||
+      !this.isNullableTimestamp(row.claim_expires_at) ||
+      !this.isNullableTimestamp(row.completed_at) ||
+      !Number.isSafeInteger(row.created_at) ||
+      !Number.isSafeInteger(row.updated_at) ||
+      !this.hasValidStatusFields(row, diagnostic)
+    ) {
+      throw new Error('invalid persisted lifecycle delivery row');
+    }
+    return {
+      ...row,
+      handler_identity: JSON.stringify(identity),
+      failure_policy: JSON.stringify(failurePolicy),
+      last_error: diagnostic ? JSON.stringify(diagnostic) : null,
+    };
+  }
+
+  private validateEventRow(row: LifecycleEventRow): LifecycleEventRow {
+    if (!validProvenance(row.provenance) || !validPayload(row.payload))
+      throw new Error('invalid persisted lifecycle event JSON');
+    const provenance = this.parseJson(row.provenance, 'event provenance');
+    const payload = this.parseJson(row.payload, 'event payload');
+    const snapshot = snapshotLifecycleEvent({
+      version: row.version,
+      eventId: row.event_id,
+      type: row.type,
+      occurredAt: row.occurred_at,
+      context: {
+        aggregate: { type: row.aggregate_type, id: row.aggregate_id },
+        correlationId: row.correlation_id,
+        ...(row.causation_id === null ? {} : { causationId: row.causation_id }),
+        recursion: { depth: row.recursion_depth, maxDepth: row.recursion_max_depth },
+        provenance,
+      },
+      payload,
+    });
+    const event = snapshot ? this.parse(LifecycleEventEnvelopeSchema, snapshot) : null;
+    if (
+      !event ||
+      !snapshot ||
+      !Number.isSafeInteger(row.event_sequence) ||
+      row.event_sequence < 1 ||
+      !Number.isSafeInteger(row.created_at)
+    ) {
+      throw new Error('invalid persisted lifecycle event row');
+    }
+    return {
+      ...row,
+      version: event.version,
+      provenance: JSON.stringify((snapshot.context as { provenance: unknown }).provenance),
+      payload: JSON.stringify(snapshot.payload),
+    };
+  }
+
+  private parseJson(value: unknown, field: string): unknown {
+    if (typeof value !== 'string') {
+      throw new Error(`invalid persisted lifecycle ${field}`);
+    }
+    try {
+      return JSON.parse(value) as unknown;
+    } catch {
+      throw new Error(`invalid persisted lifecycle ${field}`);
+    }
+  }
+
+  private parse<T>(
+    schema: { safeParse(input: unknown): { success: true; data: T } | { success: false } },
+    input: unknown,
+  ): T | null {
+    try {
+      const parsed = schema.safeParse(input);
+      return parsed.success ? parsed.data : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private parses(
+    schema: { safeParse(input: unknown): { success: boolean } },
+    input: unknown,
+  ): boolean {
+    try {
+      return schema.safeParse(input).success;
+    } catch {
+      return false;
+    }
+  }
+
+  private isRuntimeId(value: unknown): boolean {
+    return (
+      typeof value === 'string' &&
+      isBoundedWellFormedUtf8(value, 256, 1024) &&
+      value.indexOf('\0') === -1 &&
+      this.parses(LifecycleRuntimeIdSchema, value)
+    );
+  }
+
+  private isIdentifier(value: unknown): boolean {
+    return (
+      typeof value === 'string' &&
+      isBoundedWellFormedUtf8(value, 128, 512) &&
+      value.indexOf('\0') === -1 &&
+      this.parses(LifecycleIdentifierSchema, value)
+    );
+  }
+
+  private isBoundedPersona(value: unknown): boolean {
+    return (
+      typeof value === 'string' &&
+      value.indexOf('\0') === -1 &&
+      isBoundedUnicodeScalarsUtf8(
+        value,
+        MAX_LIFECYCLE_DELIVERY_PERSONA_LENGTH,
+        MAX_LIFECYCLE_DELIVERY_PERSONA_UTF8_BYTES,
+      ) &&
+      this.parses(LifecycleFilterOwnerNameSchema, value)
+    );
+  }
+
+  private isNullableTimestamp(value: unknown): boolean {
+    return value === null || Number.isSafeInteger(value);
+  }
+
+  private hasValidStatusFields(
+    row: LifecycleDeliveryRow,
+    diagnostic: LifecycleFailureDiagnostic | null,
+  ): boolean {
+    switch (row.status) {
+      case 'pending':
+        return (
+          row.attempts === 0 &&
+          row.next_retry_at === null &&
+          row.claim_token === null &&
+          row.claim_expires_at === null &&
+          diagnostic === null &&
+          row.completed_at === null
+        );
+      case 'claimed':
+        return (
+          row.attempts < row.max_attempts &&
+          row.next_retry_at === null &&
+          this.isRuntimeId(row.claim_token) &&
+          Number.isSafeInteger(row.claim_expires_at) &&
+          diagnostic === null &&
+          row.completed_at === null
+        );
+      case 'failed':
+        return (
+          row.attempts >= 1 &&
+          row.attempts < row.max_attempts &&
+          Number.isSafeInteger(row.next_retry_at) &&
+          row.claim_token === null &&
+          row.claim_expires_at === null &&
+          diagnostic !== null &&
+          row.completed_at === null
+        );
+      case 'completed':
+        return (
+          row.attempts < row.max_attempts &&
+          row.next_retry_at === null &&
+          row.claim_token === null &&
+          row.claim_expires_at === null &&
+          diagnostic === null &&
+          Number.isSafeInteger(row.completed_at)
+        );
+      case 'dead_letter':
+        return (
+          row.attempts === row.max_attempts &&
+          row.next_retry_at === null &&
+          row.claim_token === null &&
+          row.claim_expires_at === null &&
+          diagnostic !== null &&
+          row.completed_at === null
+        );
+    }
+  }
+}

--- a/src/core/database/repositories/lifecycle-event-repository.ts
+++ b/src/core/database/repositories/lifecycle-event-repository.ts
@@ -1,0 +1,484 @@
+/** Durable storage for validated lifecycle event envelopes and handler fan-out. */
+
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+import {
+  LifecycleEventEnvelopeSchema,
+  LifecycleFailurePolicyContractSchema,
+  LifecycleFilterOwnerNameSchema,
+  LifecycleHandlerIdentityContractSchema,
+  LifecycleIdentifierSchema,
+  LifecycleRuntimeIdSchema,
+  type LifecycleEventEnvelope,
+} from '../../../lifecycle/contracts/index.js';
+import { DbError } from '../../errors/index.js';
+import {
+  validFailurePolicy,
+  validIdentity,
+  validPayload,
+  validProvenance,
+} from '../lifecycle-sql-functions.js';
+import { BaseRepository } from './base-repository.js';
+import {
+  hasCompatibleLifecycleFailurePolicy,
+  hasDurableHandlerIdentityAuthority,
+  isBoundedWellFormedUtf8,
+  isBoundedUnicodeScalarsUtf8,
+  snapshotLifecycleDeliveries,
+  snapshotLifecycleEvent,
+} from './lifecycle-persistence-validation.js';
+import type {
+  LifecycleDeliveryFanoutInput,
+  LifecycleDeliveryRow,
+} from './lifecycle-delivery-repository.js';
+
+/** Database row for one immutable lifecycle event. */
+export interface LifecycleEventRow {
+  event_sequence: number;
+  event_id: string;
+  version: 'v1';
+  type: string;
+  aggregate_type: string;
+  aggregate_id: string;
+  correlation_id: string;
+  causation_id: string | null;
+  recursion_depth: number;
+  recursion_max_depth: number;
+  provenance: string;
+  payload: string;
+  occurred_at: string;
+  created_at: number;
+}
+
+/** Result of atomically writing an event and every resolved handler delivery. */
+export interface LifecycleEventFanoutResult {
+  event: LifecycleEventRow;
+  deliveries: LifecycleDeliveryRow[];
+}
+
+function toDbError(operation: string, cause: unknown): DbError {
+  // A public repository Result must not retain caller-controlled Error causes:
+  // those errors can carry credentials or hostile inspection behavior.
+  void cause;
+  return new DbError(`Failed to ${operation}`);
+}
+
+const MAX_LIFECYCLE_DELIVERY_PERSONA_LENGTH = 256;
+const MAX_LIFECYCLE_DELIVERY_PERSONA_UTF8_BYTES = 1_024;
+
+/** Repository for the immutable lifecycle outbox. */
+export class LifecycleEventRepository extends BaseRepository {
+  private readonly insertStmt: Database.Statement;
+  private readonly findByIdStmt: Database.Statement;
+  private readonly findByAggregateStmt: Database.Statement;
+  private readonly countStmt: Database.Statement;
+  private readonly insertDeliveryStmt: Database.Statement;
+  private readonly findDeliveriesByEventStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    super(db);
+    this.insertStmt = db.prepare(`
+      INSERT INTO lifecycle_events (
+        event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+        causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+        occurred_at, created_at
+      ) VALUES (
+        @event_id, @version, @type, @aggregate_type, @aggregate_id, @correlation_id,
+        @causation_id, @recursion_depth, @recursion_max_depth, @provenance, @payload,
+        @occurred_at, @created_at
+      )
+    `);
+    this.findByIdStmt = db.prepare(`SELECT * FROM lifecycle_events WHERE event_id = ?`);
+    this.findByAggregateStmt = db.prepare(`
+      SELECT * FROM lifecycle_events
+      WHERE aggregate_type = ? AND aggregate_id = ?
+      ORDER BY event_sequence ASC
+    `);
+    this.countStmt = db.prepare(`SELECT COUNT(*) AS count FROM lifecycle_events`);
+    this.insertDeliveryStmt = db.prepare(`
+      INSERT INTO lifecycle_event_deliveries (
+        event_id, handler_id, persona, priority, handler_identity, failure_policy,
+        status, attempts, max_attempts, next_retry_at, claim_token, claim_expires_at,
+        last_error, completed_at, created_at, updated_at
+      ) VALUES (
+        @event_id, @handler_id, @persona, @priority, @handler_identity, @failure_policy,
+        'pending', 0, @max_attempts, NULL, NULL, NULL, NULL, NULL, @created_at, @updated_at
+      )
+    `);
+    this.findDeliveriesByEventStmt = db.prepare(`
+      SELECT * FROM lifecycle_event_deliveries WHERE event_id = ? ORDER BY priority DESC, created_at ASC
+    `);
+  }
+
+  /** Inserts one validated, bounded lifecycle event. */
+  insert(event: LifecycleEventEnvelope): Result<LifecycleEventRow, DbError> {
+    try {
+      const normalized = this.normalizeEvent(event);
+      if (!normalized) {
+        return err(new DbError('Failed to insert lifecycle event: invalid bounded event envelope'));
+      }
+      const insert = this.db.transaction(() => this.insertNormalized(normalized));
+      return ok(insert());
+    } catch (cause) {
+      return err(toDbError('insert lifecycle event', cause));
+    }
+  }
+
+  /**
+   * Atomically persists an event and every resolved delivery. No partially
+   * fanned-out event can survive a handler identity or database constraint
+   * failure.
+   */
+  insertWithDeliveries(
+    event: LifecycleEventEnvelope,
+    deliveries: readonly LifecycleDeliveryFanoutInput[],
+  ): Result<LifecycleEventFanoutResult, DbError> {
+    try {
+      const normalized = this.normalizeEvent(event);
+      if (!normalized) {
+        return err(
+          new DbError('Failed to insert lifecycle event fan-out: invalid bounded event envelope'),
+        );
+      }
+      const normalizedDeliveries = this.normalizeDeliveries(deliveries);
+      if (!normalizedDeliveries) {
+        return err(
+          new DbError(
+            'Failed to insert lifecycle event fan-out: invalid or duplicate handler deliveries',
+          ),
+        );
+      }
+
+      const write = this.db.transaction((): LifecycleEventFanoutResult => {
+        const storedEvent = this.insertNormalized(normalized);
+        const createdAt = this.now();
+        for (const delivery of normalizedDeliveries) {
+          this.insertDeliveryStmt.run({
+            event_id: storedEvent.event_id,
+            handler_id: delivery.handlerId,
+            persona: delivery.persona,
+            priority: delivery.priority,
+            handler_identity: JSON.stringify(delivery.identity),
+            failure_policy: JSON.stringify(delivery.failurePolicy),
+            max_attempts: delivery.maxAttempts,
+            created_at: createdAt,
+            updated_at: createdAt,
+          });
+        }
+        const storedDeliveries = this.findDeliveriesByEventStmt.all(
+          storedEvent.event_id,
+        ) as LifecycleDeliveryRow[];
+        return {
+          event: storedEvent,
+          deliveries: storedDeliveries.map((delivery) => this.validateDeliveryRow(delivery)),
+        };
+      });
+
+      return ok(write());
+    } catch (cause) {
+      return err(toDbError('insert lifecycle event fan-out', cause));
+    }
+  }
+
+  /** Finds one immutable event by stable event ID. */
+  findById(eventId: string): Result<LifecycleEventRow | null, DbError> {
+    try {
+      if (!this.isRuntimeId(eventId)) {
+        return err(new DbError('Failed to find lifecycle event by id: invalid event id'));
+      }
+      const row = this.findByIdStmt.get(eventId) as LifecycleEventRow | undefined;
+      return ok(row ? this.validateEventRow(row) : null);
+    } catch (cause) {
+      return err(toDbError('find lifecycle event by id', cause));
+    }
+  }
+
+  /** Returns events in durable insertion order for one aggregate. */
+  findByAggregate(
+    aggregateType: string,
+    aggregateId: string,
+  ): Result<LifecycleEventRow[], DbError> {
+    try {
+      if (!this.isIdentifier(aggregateType) || !this.isRuntimeId(aggregateId)) {
+        return err(new DbError('Failed to find lifecycle events by aggregate: invalid aggregate'));
+      }
+      const rows = this.findByAggregateStmt.all(aggregateType, aggregateId) as LifecycleEventRow[];
+      return ok(rows.map((row) => this.validateEventRow(row)));
+    } catch (cause) {
+      return err(toDbError('find lifecycle events by aggregate', cause));
+    }
+  }
+
+  /** Returns the current event count. Primarily useful for health and tests. */
+  count(): Result<number, DbError> {
+    try {
+      return ok((this.countStmt.get() as { count: number }).count);
+    } catch (cause) {
+      return err(toDbError('count lifecycle events', cause));
+    }
+  }
+
+  private normalizeEvent(event: LifecycleEventEnvelope): LifecycleEventEnvelope | null {
+    try {
+      const snapshot = snapshotLifecycleEvent(event);
+      if (!snapshot) {
+        return null;
+      }
+      const parsed = LifecycleEventEnvelopeSchema.safeParse(snapshot);
+      if (!parsed.success) {
+        return null;
+      }
+      // SQLite can validate this canonical ISO-8601 representation exactly.
+      // Normalize accepted offset variants before persistence so the durable
+      // contract has no equivalent timestamp spellings.
+      const occurredAt = new Date(parsed.data.occurredAt).toISOString();
+      // Keep the descriptor-safe snapshot rather than Zod's materialized
+      // object so a valid metadata key named "__proto__" remains own data.
+      return { ...snapshot, occurredAt } as LifecycleEventEnvelope;
+    } catch {
+      return null;
+    }
+  }
+
+  private normalizeDeliveries(
+    deliveries: readonly LifecycleDeliveryFanoutInput[],
+  ): Array<Required<LifecycleDeliveryFanoutInput>> | null {
+    try {
+      const candidates = snapshotLifecycleDeliveries(deliveries);
+      if (!candidates) {
+        return null;
+      }
+      const seenHandlerIds = new Set<string>();
+      const normalized: Array<Required<LifecycleDeliveryFanoutInput>> = [];
+      for (const candidate of candidates) {
+        if (!candidate || typeof candidate !== 'object') {
+          return null;
+        }
+        const delivery = candidate as Record<string, unknown>;
+        const handlerId = delivery.handlerId;
+        const persona = delivery.persona;
+        const priority = delivery.priority;
+        const maxAttempts = delivery.maxAttempts ?? 3;
+        if (
+          typeof handlerId !== 'string' ||
+          typeof persona !== 'string' ||
+          typeof priority !== 'number' ||
+          typeof maxAttempts !== 'number' ||
+          !Number.isInteger(priority) ||
+          priority < -1000 ||
+          priority > 1000 ||
+          !Number.isInteger(maxAttempts) ||
+          maxAttempts < 1 ||
+          maxAttempts > 100 ||
+          !this.isIdentifier(handlerId) ||
+          !this.isBoundedPersona(persona)
+        ) {
+          return null;
+        }
+        const identity = this.parse(LifecycleHandlerIdentityContractSchema, delivery.identity);
+        const failurePolicy = this.parse(
+          LifecycleFailurePolicyContractSchema,
+          delivery.failurePolicy,
+        );
+        if (
+          !identity ||
+          !failurePolicy ||
+          !hasDurableHandlerIdentityAuthority(identity) ||
+          !hasCompatibleLifecycleFailurePolicy(identity, failurePolicy)
+        ) {
+          return null;
+        }
+        if (seenHandlerIds.has(handlerId) || identity.handlerId !== handlerId) {
+          return null;
+        }
+        seenHandlerIds.add(handlerId);
+        // Persist only contract-owned parsed snapshots; never retain fields,
+        // accessors, or toJSON methods supplied by the caller.
+        normalized.push({
+          handlerId,
+          persona,
+          priority,
+          identity,
+          failurePolicy,
+          maxAttempts,
+        });
+      }
+      return normalized;
+    } catch {
+      return null;
+    }
+  }
+
+  private insertNormalized(event: LifecycleEventEnvelope): LifecycleEventRow {
+    const createdAt = this.now();
+    this.insertStmt.run({
+      event_id: event.eventId,
+      version: event.version,
+      type: event.type,
+      aggregate_type: event.context.aggregate.type,
+      aggregate_id: event.context.aggregate.id,
+      correlation_id: event.context.correlationId,
+      causation_id: event.context.causationId ?? null,
+      recursion_depth: event.context.recursion.depth,
+      recursion_max_depth: event.context.recursion.maxDepth,
+      provenance: JSON.stringify(event.context.provenance),
+      payload: JSON.stringify(event.payload),
+      occurred_at: event.occurredAt,
+      created_at: createdAt,
+    });
+    return this.validateEventRow(this.findByIdStmt.get(event.eventId) as LifecycleEventRow);
+  }
+
+  private validateEventRow(row: LifecycleEventRow): LifecycleEventRow {
+    if (!validProvenance(row.provenance) || !validPayload(row.payload)) {
+      throw new Error('invalid persisted lifecycle event JSON');
+    }
+    const provenance = this.parseJson(row.provenance, 'event provenance');
+    const payload = this.parseJson(row.payload, 'event payload');
+    const snapshot = snapshotLifecycleEvent({
+      version: row.version,
+      eventId: row.event_id,
+      type: row.type,
+      occurredAt: row.occurred_at,
+      context: {
+        aggregate: { type: row.aggregate_type, id: row.aggregate_id },
+        correlationId: row.correlation_id,
+        ...(row.causation_id === null ? {} : { causationId: row.causation_id }),
+        recursion: { depth: row.recursion_depth, maxDepth: row.recursion_max_depth },
+        provenance,
+      },
+      payload,
+    });
+    const event = snapshot ? this.parse(LifecycleEventEnvelopeSchema, snapshot) : null;
+    if (
+      !event ||
+      !snapshot ||
+      !Number.isSafeInteger(row.event_sequence) ||
+      row.event_sequence < 1 ||
+      !Number.isSafeInteger(row.created_at)
+    ) {
+      throw new Error('invalid persisted lifecycle event row');
+    }
+    return {
+      ...row,
+      version: event.version,
+      // Serialize the descriptor-safe snapshot, not Zod's materialized output:
+      // object assignment in a schema implementation must not erase an own
+      // metadata key named "__proto__" during a database round trip.
+      provenance: JSON.stringify((snapshot.context as { provenance: unknown }).provenance),
+      payload: JSON.stringify(snapshot.payload),
+    };
+  }
+
+  private validateDeliveryRow(row: LifecycleDeliveryRow): LifecycleDeliveryRow {
+    if (
+      !validIdentity(row.handler_identity, row.handler_id) ||
+      !validFailurePolicy(row.failure_policy)
+    ) {
+      throw new Error('invalid persisted lifecycle delivery JSON');
+    }
+    const rawIdentity = this.parseJson(row.handler_identity, 'delivery handler identity');
+    const rawFailurePolicy = this.parseJson(row.failure_policy, 'delivery failure policy');
+    const snapshot = snapshotLifecycleDeliveries([
+      {
+        handlerId: row.handler_id,
+        persona: row.persona,
+        priority: row.priority,
+        identity: rawIdentity,
+        failurePolicy: rawFailurePolicy,
+        maxAttempts: row.max_attempts,
+      },
+    ]);
+    if (!snapshot) {
+      throw new Error('invalid persisted lifecycle delivery contracts');
+    }
+    const deliverySnapshot = snapshot[0];
+    if (!deliverySnapshot) {
+      throw new Error('invalid persisted lifecycle delivery contracts');
+    }
+    const identity = this.parse(LifecycleHandlerIdentityContractSchema, deliverySnapshot.identity);
+    const failurePolicy = this.parse(
+      LifecycleFailurePolicyContractSchema,
+      deliverySnapshot.failurePolicy,
+    );
+    if (
+      !identity ||
+      !failurePolicy ||
+      !hasDurableHandlerIdentityAuthority(identity) ||
+      !hasCompatibleLifecycleFailurePolicy(identity, failurePolicy) ||
+      identity.handlerId !== row.handler_id
+    ) {
+      throw new Error('invalid persisted lifecycle delivery contracts');
+    }
+    return {
+      ...row,
+      handler_identity: JSON.stringify(identity),
+      failure_policy: JSON.stringify(failurePolicy),
+    };
+  }
+
+  private parseJson(value: unknown, field: string): unknown {
+    if (typeof value !== 'string') {
+      throw new Error(`invalid persisted ${field}`);
+    }
+    try {
+      return JSON.parse(value) as unknown;
+    } catch {
+      throw new Error(`invalid persisted ${field}`);
+    }
+  }
+
+  private parse<T>(
+    schema: { safeParse(input: unknown): { success: true; data: T } | { success: false } },
+    input: unknown,
+  ): T | null {
+    try {
+      const parsed = schema.safeParse(input);
+      return parsed.success ? parsed.data : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private parses(
+    schema: { safeParse(input: unknown): { success: boolean } },
+    input: unknown,
+  ): boolean {
+    try {
+      return schema.safeParse(input).success;
+    } catch {
+      return false;
+    }
+  }
+
+  private isRuntimeId(value: unknown): boolean {
+    return (
+      typeof value === 'string' &&
+      isBoundedWellFormedUtf8(value, 256, 1024) &&
+      value.indexOf('\0') === -1 &&
+      this.parses(LifecycleRuntimeIdSchema, value)
+    );
+  }
+
+  private isIdentifier(value: unknown): boolean {
+    return (
+      typeof value === 'string' &&
+      isBoundedWellFormedUtf8(value, 128, 512) &&
+      value.indexOf('\0') === -1 &&
+      this.parses(LifecycleIdentifierSchema, value)
+    );
+  }
+
+  private isBoundedPersona(value: unknown): boolean {
+    return (
+      typeof value === 'string' &&
+      value.indexOf('\0') === -1 &&
+      isBoundedUnicodeScalarsUtf8(
+        value,
+        MAX_LIFECYCLE_DELIVERY_PERSONA_LENGTH,
+        MAX_LIFECYCLE_DELIVERY_PERSONA_UTF8_BYTES,
+      ) &&
+      this.parses(LifecycleFilterOwnerNameSchema, value)
+    );
+  }
+}

--- a/src/core/database/repositories/lifecycle-persistence-validation.ts
+++ b/src/core/database/repositories/lifecycle-persistence-validation.ts
@@ -1,0 +1,474 @@
+/** Bounded, descriptor-only lifecycle transport guards before SQLite sees caller data. */
+
+import { types } from 'node:util';
+
+const MAX_REFERENCES = 32;
+const MAX_METADATA_ENTRIES = 32;
+const MAX_DELIVERIES = 32;
+
+type DataRecord = Record<string, unknown>;
+
+/** Rejects lone UTF-16 surrogate code units without normalizing a string. */
+export function isWellFormedUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Bounds JavaScript UTF-16 code units and UTF-8 bytes in one pass. Zod's
+ * string limits are UTF-16 limits, so code points must not be substituted
+ * here (an emoji consumes two contract units).
+ */
+export function isBoundedWellFormedUtf8(
+  value: string,
+  maxCodeUnits: number,
+  maxBytes: number,
+): boolean {
+  if (value.length > maxCodeUnits) return false;
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    let byteLength: number;
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      index += 1;
+      byteLength = 4;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    } else if (codeUnit < 0x80) {
+      byteLength = 1;
+    } else if (codeUnit < 0x800) {
+      byteLength = 2;
+    } else {
+      byteLength = 3;
+    }
+    bytes += byteLength;
+    if (bytes > maxBytes) return false;
+  }
+  return true;
+}
+
+/** Bounds Unicode scalar values for the persona persistence limit. */
+export function isBoundedUnicodeScalarsUtf8(
+  value: string,
+  maxScalars: number,
+  maxBytes: number,
+): boolean {
+  let scalars = 0;
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    let byteLength: number;
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      index += 1;
+      byteLength = 4;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) return false;
+    else if (codeUnit < 0x80) byteLength = 1;
+    else if (codeUnit < 0x800) byteLength = 2;
+    else byteLength = 3;
+    scalars += 1;
+    bytes += byteLength;
+    if (scalars > maxScalars || bytes > maxBytes) return false;
+  }
+  return true;
+}
+
+function boundedString(value: unknown, maxCodeUnits: number, maxBytes: number): string | null {
+  if (typeof value !== 'string' || value.length > maxCodeUnits) return null;
+  if (!isBoundedWellFormedUtf8(value, maxCodeUnits, maxBytes)) return null;
+  // This scan intentionally happens only after the bounded UTF-16/UTF-8 pass.
+  return value.indexOf('\0') === -1 ? value : null;
+}
+
+/**
+ * Materializes at most maxKeys descriptors after a single own-key boundary.
+ * In particular, never use Object.getOwnPropertyDescriptors here: that builds
+ * one descriptor object for every hostile property before a size check can run.
+ */
+export function snapshotBoundedPlainDataRecord(value: unknown, maxKeys: number): DataRecord | null {
+  if (!value || typeof value !== 'object' || types.isProxy(value)) return null;
+  try {
+    const prototype = Reflect.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) return null;
+    const keys = Reflect.ownKeys(value);
+    if (keys.length > maxKeys || keys.some((key) => typeof key !== 'string')) return null;
+    const snapshot: DataRecord = Object.create(null) as DataRecord;
+    for (const key of keys) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor?.enumerable || !('value' in descriptor)) return null;
+      // defineProperty preserves a legitimate "__proto__" data key without
+      // invoking Object.prototype's legacy setter.
+      Object.defineProperty(snapshot, key, {
+        value: descriptor.value,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+/** Reads a bounded plain object without executing accessors, iteration, or proxy traps. */
+function readRecord(
+  value: unknown,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): DataRecord | null {
+  const allowed = new Set([...required, ...optional]);
+  const record = snapshotBoundedPlainDataRecord(value, allowed.size);
+  if (!record) return null;
+  const keys = Object.keys(record);
+  if (keys.some((key) => !allowed.has(key))) return null;
+  const snapshot: DataRecord = Object.create(null) as DataRecord;
+  for (const key of required) {
+    if (!Object.hasOwn(record, key)) return null;
+    Object.defineProperty(snapshot, key, {
+      value: record[key],
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
+  for (const key of optional) {
+    if (Object.hasOwn(record, key)) {
+      Object.defineProperty(snapshot, key, {
+        value: record[key],
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+  }
+  return snapshot;
+}
+
+/** Reads a bounded dense native array without consulting iterators or prototypes. */
+function readArray(value: unknown, maxLength: number): unknown[] | null {
+  if (!Array.isArray(value) || types.isProxy(value)) return null;
+  try {
+    if (Reflect.getPrototypeOf(value) !== Array.prototype) return null;
+    const length = Object.getOwnPropertyDescriptor(value, 'length');
+    if (!length || !('value' in length) || !Number.isSafeInteger(length.value)) return null;
+    if (length.value > maxLength) return null;
+    const keys = Reflect.ownKeys(value);
+    // A dense array has exactly its bounded indices plus the non-enumerable
+    // length descriptor. Check this before looking up any element descriptor.
+    if (keys.length !== length.value + 1 || keys.some((key) => typeof key !== 'string'))
+      return null;
+    const snapshot: unknown[] = [];
+    for (let index = 0; index < length.value; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      if (!descriptor?.enumerable || !('value' in descriptor)) return null;
+      snapshot.push(descriptor.value);
+    }
+    // Dense arrays have exactly one enumerable own data descriptor per index.
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+function snapshotReference(value: unknown): DataRecord | null {
+  const record = readRecord(value, ['type', 'id']);
+  if (!record) return null;
+  const type = boundedString(record.type, 128, 512);
+  const id = boundedString(record.id, 256, 1024);
+  return type === null || id === null ? null : { type, id };
+}
+
+function snapshotReferences(value: unknown): DataRecord[] | null {
+  const items = readArray(value, MAX_REFERENCES);
+  if (!items) return null;
+  const snapshots: DataRecord[] = [];
+  for (const item of items) {
+    const snapshot = snapshotReference(item);
+    if (!snapshot) return null;
+    snapshots.push(snapshot);
+  }
+  return snapshots;
+}
+
+function snapshotMetadata(value: unknown): DataRecord | null {
+  const record = snapshotBoundedPlainDataRecord(value, MAX_METADATA_ENTRIES);
+  if (!record) return null;
+  const snapshot: DataRecord = Object.create(null) as DataRecord;
+  const normalizedKeys = new Set<string>();
+  for (const key of Object.keys(record)) {
+    // Never normalize or trim an unbounded key.
+    if (boundedString(key, 128, 512) === null || key.trim() !== key) return null;
+    const normalized = key.normalize('NFKC');
+    if (normalizedKeys.has(normalized)) return null;
+    normalizedKeys.add(normalized);
+    const item: unknown = record[key];
+    if (typeof item === 'string') {
+      if (boundedString(item, 1024, 4096) === null) return null;
+    } else if (
+      item !== null &&
+      (typeof item !== 'number' || !Number.isFinite(item)) &&
+      typeof item !== 'boolean'
+    ) {
+      return null;
+    }
+    Object.defineProperty(snapshot, key, {
+      value: item,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
+  return snapshot;
+}
+
+function snapshotProvenance(value: unknown): DataRecord | null {
+  const record = readRecord(value, ['source'], ['sourceEventIds', 'sourceReferences']);
+  if (!record) return null;
+  const source = boundedString(record.source, 128, 512);
+  const sourceEventIds =
+    record.sourceEventIds === undefined ? [] : readArray(record.sourceEventIds, MAX_REFERENCES);
+  const sourceReferences =
+    record.sourceReferences === undefined ? [] : snapshotReferences(record.sourceReferences);
+  if (source === null || !sourceEventIds || !sourceReferences) return null;
+  const ids: string[] = [];
+  for (const id of sourceEventIds) {
+    const snapshot = boundedString(id, 256, 1024);
+    if (snapshot === null) return null;
+    ids.push(snapshot);
+  }
+  return { source, sourceEventIds: ids, sourceReferences };
+}
+
+/** Returns a contract-owned, finite plain-data event snapshot or null. */
+export function snapshotLifecycleEvent(value: unknown): DataRecord | null {
+  const event = readRecord(value, [
+    'version',
+    'eventId',
+    'type',
+    'occurredAt',
+    'context',
+    'payload',
+  ]);
+  if (!event) return null;
+  const context = readRecord(
+    event.context,
+    ['aggregate', 'correlationId', 'recursion', 'provenance'],
+    ['causationId'],
+  );
+  const aggregate = context && readRecord(context.aggregate, ['type', 'id']);
+  const recursion = context && readRecord(context.recursion, ['depth', 'maxDepth']);
+  const provenance = context && snapshotProvenance(context.provenance);
+  const payload = readRecord(event.payload, [], ['references', 'metadata']);
+  const references =
+    payload && (payload.references === undefined ? [] : snapshotReferences(payload.references));
+  const metadata =
+    payload && (payload.metadata === undefined ? {} : snapshotMetadata(payload.metadata));
+  const eventId = boundedString(event.eventId, 256, 1024);
+  const type = boundedString(event.type, 128, 512);
+  const occurredAt = boundedString(event.occurredAt, 64, 256);
+  const correlationId = context && boundedString(context.correlationId, 256, 1024);
+  const causationId =
+    context?.causationId === undefined ? undefined : boundedString(context.causationId, 256, 1024);
+  const aggregateType = aggregate && boundedString(aggregate.type, 128, 512);
+  const aggregateId = aggregate && boundedString(aggregate.id, 256, 1024);
+  if (
+    event.version !== 'v1' ||
+    eventId === null ||
+    type === null ||
+    occurredAt === null ||
+    !context ||
+    !aggregate ||
+    !recursion ||
+    !provenance ||
+    !payload ||
+    !references ||
+    !metadata ||
+    correlationId === null ||
+    (context.causationId !== undefined && causationId === null) ||
+    aggregateType === null ||
+    aggregateId === null ||
+    typeof recursion.depth !== 'number' ||
+    typeof recursion.maxDepth !== 'number'
+  )
+    return null;
+  return {
+    version: 'v1',
+    eventId,
+    type,
+    occurredAt,
+    context: {
+      aggregate: { type: aggregateType, id: aggregateId },
+      correlationId,
+      ...(causationId === undefined ? {} : { causationId }),
+      recursion: { depth: recursion.depth, maxDepth: recursion.maxDepth },
+      provenance,
+    },
+    payload: { references, metadata },
+  };
+}
+
+function snapshotIdentity(value: unknown): DataRecord | null {
+  const record = readRecord(
+    value,
+    [
+      'version',
+      'handlerId',
+      'runtimeKind',
+      'implementationRef',
+      'implementationVersion',
+      'mode',
+      'inputContract',
+      'outputContract',
+    ],
+    ['interceptorSafety'],
+  );
+  if (!record) return null;
+  for (const [key, units, bytes] of [
+    ['handlerId', 128, 512],
+    ['runtimeKind', 16, 64],
+    ['implementationRef', 128, 512],
+    ['implementationVersion', 256, 1024],
+    ['mode', 16, 64],
+    ['inputContract', 128, 512],
+    ['outputContract', 128, 512],
+  ] as const)
+    if (boundedString(record[key], units, bytes) === null) return null;
+  if (
+    record.version !== 'v1' ||
+    (record.interceptorSafety !== undefined &&
+      boundedString(record.interceptorSafety, 16, 64) === null)
+  )
+    return null;
+  return { ...record };
+}
+
+function snapshotFailurePolicy(value: unknown): DataRecord | null {
+  const record = readRecord(value, ['version', 'mode']);
+  return record && record.version === 'v1' && boundedString(record.mode, 32, 128) !== null
+    ? { ...record }
+    : null;
+}
+
+/** Snapshots a public failure diagnostic without allowing Zod to touch accessors. */
+export function snapshotLifecycleFailureDiagnostic(value: unknown): DataRecord | null {
+  const record = readRecord(value, ['code']);
+  const code = record && boundedString(record.code, 128, 512);
+  return code === null ? null : { code };
+}
+
+/** Security authority matrix for persisted handler identities. */
+export function hasDurableHandlerIdentityAuthority(value: {
+  mode: string;
+  runtimeKind: string;
+  inputContract: string;
+  outputContract: string;
+  interceptorSafety?: string;
+}): boolean {
+  if (value.mode === 'event') {
+    return (
+      value.inputContract === 'talon.lifecycle.event.envelope.v1' &&
+      value.outputContract === 'talon.lifecycle.signal.envelopes.v1' &&
+      value.interceptorSafety === undefined
+    );
+  }
+  if (value.mode === 'signal') {
+    return (
+      value.inputContract === 'talon.lifecycle.signal.envelope.v1' &&
+      value.outputContract === 'talon.lifecycle.signal.envelopes.v1' &&
+      value.interceptorSafety === undefined
+    );
+  }
+  if (
+    value.mode !== 'interceptor' ||
+    value.inputContract !== 'talon.lifecycle.interceptor.input.v1'
+  ) {
+    return false;
+  }
+  if (value.interceptorSafety === 'enforcing') {
+    return (
+      value.runtimeKind === 'native' &&
+      value.outputContract === 'talon.lifecycle.enforcing.interceptor.output.v1'
+    );
+  }
+  return (
+    (value.interceptorSafety === undefined || value.interceptorSafety === 'advisory') &&
+    value.outputContract === 'talon.lifecycle.advisory.interceptor.output.v1'
+  );
+}
+
+/** Frozen TASK-001 matrix binding a durable handler identity to its failure policy. */
+export function hasCompatibleLifecycleFailurePolicy(
+  identity: {
+    mode: string;
+    runtimeKind: string;
+    inputContract: string;
+    outputContract: string;
+    interceptorSafety?: string;
+  },
+  failurePolicy: { mode: string },
+): boolean {
+  if (!hasDurableHandlerIdentityAuthority(identity)) return false;
+  if (identity.mode === 'event' || identity.mode === 'signal') {
+    return failurePolicy.mode === 'dead_letter' || failurePolicy.mode === 'preserve_session';
+  }
+  return identity.interceptorSafety === 'enforcing'
+    ? failurePolicy.mode === 'fail_closed'
+    : failurePolicy.mode === 'fail_open';
+}
+
+/** Returns bounded plain-data fan-out snapshots or null without iterating caller data. */
+export function snapshotLifecycleDeliveries(value: unknown): DataRecord[] | null {
+  const deliveries = readArray(value, MAX_DELIVERIES);
+  if (!deliveries) return null;
+  const snapshots: DataRecord[] = [];
+  for (const candidate of deliveries) {
+    const delivery = readRecord(
+      candidate,
+      ['handlerId', 'persona', 'priority', 'identity', 'failurePolicy'],
+      ['maxAttempts'],
+    );
+    if (!delivery) return null;
+    const handlerId = boundedString(delivery.handlerId, 128, 512);
+    // Persona persistence intentionally permits 256 Unicode scalar values;
+    // the UTF-16 bound is therefore twice that count while UTF-8 remains 1KiB.
+    const persona =
+      typeof delivery.persona === 'string' &&
+      delivery.persona.indexOf('\0') === -1 &&
+      isBoundedUnicodeScalarsUtf8(delivery.persona, 256, 1024)
+        ? delivery.persona
+        : null;
+    const identity = snapshotIdentity(delivery.identity);
+    const failurePolicy = snapshotFailurePolicy(delivery.failurePolicy);
+    if (
+      handlerId === null ||
+      persona === null ||
+      !identity ||
+      !failurePolicy ||
+      typeof delivery.priority !== 'number' ||
+      (delivery.maxAttempts !== undefined && typeof delivery.maxAttempts !== 'number')
+    )
+      return null;
+    snapshots.push({
+      handlerId,
+      persona,
+      priority: delivery.priority,
+      identity,
+      failurePolicy,
+      ...(delivery.maxAttempts === undefined ? {} : { maxAttempts: delivery.maxAttempts }),
+    });
+  }
+  return snapshots;
+}

--- a/tests/unit/core/database/migrations/runner.test.ts
+++ b/tests/unit/core/database/migrations/runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { copyFileSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
@@ -106,10 +106,7 @@ describe('runMigrations', () => {
 
   it('rolls back partial changes from a failed migration', () => {
     // Migration 001 creates table_a successfully.
-    writeFileSync(
-      join(tmpDir, '001-setup.sql'),
-      'CREATE TABLE table_a (id TEXT PRIMARY KEY);',
-    );
+    writeFileSync(join(tmpDir, '001-setup.sql'), 'CREATE TABLE table_a (id TEXT PRIMARY KEY);');
     // Migration 002 creates table_b then fails — table_b should be rolled back.
     writeFileSync(
       join(tmpDir, '002-partial.sql'),
@@ -154,5 +151,741 @@ describe('runMigrations', () => {
       .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='channels'`)
       .get();
     expect(tbl).toBeDefined();
+  });
+
+  it('upgrades a pre-lifecycle schema with the durable event tables', () => {
+    const realMigrationsDir = join(
+      import.meta.dirname,
+      '../../../../../src/core/database/migrations',
+    );
+    const legacyDir = makeTmpDir();
+    for (const file of readdirSync(realMigrationsDir)) {
+      if (file.endsWith('.sql') && Number.parseInt(file, 10) <= 13) {
+        copyFileSync(join(realMigrationsDir, file), join(legacyDir, file));
+      }
+    }
+
+    expect(runMigrations(db, legacyDir)._unsafeUnwrap()).toBeGreaterThan(0);
+    expect(db.pragma('user_version', { simple: true })).toBe(13);
+
+    const upgrade = runMigrations(db, realMigrationsDir);
+    expect(upgrade._unsafeUnwrap()).toBe(1);
+    expect(db.pragma('user_version', { simple: true })).toBe(14);
+    for (const table of ['lifecycle_events', 'lifecycle_event_deliveries']) {
+      expect(
+        db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`).get(table),
+      ).toBeDefined();
+    }
+
+    const indexes = db.prepare(`PRAGMA index_list('lifecycle_event_deliveries')`).all() as Array<{
+      name: string;
+      partial: number;
+    }>;
+    expect(indexes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'idx_lifecycle_deliveries_ready', partial: 1 }),
+        expect.objectContaining({ name: 'idx_lifecycle_deliveries_expired_claims', partial: 1 }),
+      ]),
+    );
+    const expiredColumns = db
+      .prepare(`PRAGMA index_info('idx_lifecycle_deliveries_expired_claims')`)
+      .all() as Array<{ name: string }>;
+    expect(expiredColumns.map((column) => column.name)).toEqual([
+      'claim_expires_at',
+      'priority',
+      'created_at',
+    ]);
+
+    db.prepare(
+      `INSERT INTO lifecycle_events (
+        event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+        causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+        occurred_at, created_at
+      ) VALUES (?, 'v1', 'run.completed.v1', 'thread', 'thread-1', 'correlation-1',
+        NULL, 0, 1, '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}', '{"references":[],"metadata":{}}',
+        '2026-07-16T10:00:00.000Z', 1)`,
+    ).run('event-1');
+    const insertEventWithPayload = db.prepare(
+      `INSERT INTO lifecycle_events (
+        event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+        causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+        occurred_at, created_at
+      ) VALUES (@eventId, 'v1', 'run.completed.v1', 'thread', 'thread-1', @eventId,
+        NULL, @recursionDepth, @recursionMaxDepth,
+        '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}', @payload,
+        '2026-07-16T10:00:00.000Z', 1)`,
+    );
+    expect(() =>
+      insertEventWithPayload.run({
+        eventId: 'event-recursion-max-zero',
+        recursionDepth: 0,
+        recursionMaxDepth: 0,
+        payload: '{"references":[],"metadata":{}}',
+      }),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lifecycle_event_deliveries (
+          event_id, handler_id, persona, priority, handler_identity, failure_policy,
+          status, attempts, max_attempts, created_at, updated_at
+        ) VALUES ('event-1', 'handler-1', 'support', 0, '{"version":"v1"}',
+          '{"version":"v1","mode":"dead_letter"}', 'not-a-state', 0, 1, 1, 1)`,
+        )
+        .run(),
+    ).toThrow();
+    // Escaped lone surrogates cannot be faithfully represented by JSON1 and
+    // must fail, while ordinary escaped Unicode remains valid. Use INSERTs:
+    // the event outbox itself is intentionally immutable after persistence.
+    expect(() =>
+      insertEventWithPayload.run({
+        eventId: 'event-payload-lone-surrogate',
+        recursionDepth: 0,
+        recursionMaxDepth: 1,
+        payload: '{"references":[],"metadata":{"bad":"\\ud800"}}',
+      }),
+    ).toThrow();
+    for (const [index, payload] of [
+      '{"references":[{"type":"run"}],"metadata":{}}',
+      '{"references":[{"type":"run","id":null}],"metadata":{}}',
+      '{"references":[{"type":" bad","id":"reference-1"}],"metadata":{}}',
+      '{"references":[{"type":"run","id":" reference-1"}],"metadata":{}}',
+      '{"references":[],"metadata":{" unicode":"value"}}',
+      '{"references":["{\\"type\\":\\"run\\",\\"id\\":\\"reference-1\\"}"],"metadata":{}}',
+      '{"references":[],"metadata":{"a":1,"a":2}}',
+      '{"references":[],"metadata":{"huge":1e999}}',
+      '{"references":[],"metadata":{"negative":-1e999}}',
+      '{"references":[],"metadata":{"A":true,"Ａ":false}}',
+    ].entries()) {
+      expect(() =>
+        insertEventWithPayload.run({
+          eventId: `event-invalid-payload-${index}`,
+          recursionDepth: 0,
+          recursionMaxDepth: 1,
+          payload,
+        }),
+      ).toThrow();
+    }
+    for (const [index, payload] of [
+      '{"references":[],"metadata":{"café":"emoji 😀"}}',
+      '{"references":[],"metadata":{"escaped":"line\\nbreak\\tand \\u0001"}}',
+      '{"references":[],"metadata":{"literal":"\\\\u1234"}}',
+    ].entries()) {
+      expect(() =>
+        insertEventWithPayload.run({
+          eventId: `event-valid-payload-${index}`,
+          recursionDepth: 0,
+          recursionMaxDepth: 1,
+          payload,
+        }),
+      ).not.toThrow();
+      expect(
+        db
+          .prepare(`SELECT payload FROM lifecycle_events WHERE event_id = ?`)
+          .get(`event-valid-payload-${index}`),
+      ).toEqual({ payload });
+    }
+    expect(() =>
+      db
+        .prepare(`UPDATE lifecycle_events SET aggregate_type = 'Thread' WHERE event_id = 'event-1'`)
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_events SET aggregate_id = 'forged-thread' WHERE event_id = 'event-1'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(`UPDATE lifecycle_events SET provenance = ? WHERE event_id = 'event-1'`)
+        .run('{"source":"daemon","sourceEventIds":[],"sourceReferences":[{"type":"run"}]}'),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lifecycle_event_deliveries (
+          event_id, handler_id, persona, priority, handler_identity, failure_policy,
+          status, attempts, max_attempts, created_at, updated_at
+        ) VALUES ('event-1', 'handler-2', 'support', 0, '{not-json}',
+          '{"version":"v1","mode":"dead_letter"}', 'pending', 0, 1, 1, 1)`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lifecycle_event_deliveries (
+          event_id, handler_id, persona, priority, handler_identity, failure_policy,
+          status, attempts, max_attempts, created_at, updated_at
+        ) VALUES ('event-1', 'handler-3', 'support', 0,
+          '{"version":"v2"}', '{"version":"v1","mode":"dead_letter"}',
+          'pending', 0, 1, 1, 1)`,
+        )
+        .run(),
+    ).toThrow();
+
+    const insertValidDelivery = db.prepare(
+      `INSERT INTO lifecycle_event_deliveries (
+        event_id, handler_id, persona, priority, handler_identity, failure_policy,
+        status, attempts, max_attempts, created_at, updated_at
+      ) VALUES ('event-1', @handlerId, @persona, 0, @identity, @failurePolicy,
+        'pending', 0, 1, 1, 1)`,
+    );
+    const failurePolicy = '{"version":"v1","mode":"dead_letter"}';
+    const identityFor = (handlerId: string): string =>
+      JSON.stringify({
+        version: 'v1',
+        handlerId,
+        runtimeKind: 'native',
+        implementationRef: 'run-projector',
+        implementationVersion: '1.0.0',
+        mode: 'event',
+        inputContract: 'talon.lifecycle.event.envelope.v1',
+        outputContract: 'talon.lifecycle.signal.envelopes.v1',
+      });
+    const interceptorIdentity = (
+      handlerId: string,
+      overrides: Record<string, unknown> = {},
+    ): string =>
+      JSON.stringify({
+        version: 'v1',
+        handlerId,
+        runtimeKind: 'native',
+        implementationRef: 'run-projector',
+        implementationVersion: '1.0.0',
+        mode: 'interceptor',
+        inputContract: 'talon.lifecycle.interceptor.input.v1',
+        outputContract: 'talon.lifecycle.advisory.interceptor.output.v1',
+        interceptorSafety: 'advisory',
+        ...overrides,
+      });
+    for (const [handlerId, identity] of [
+      [
+        'handler-advisory-enforcing-output',
+        interceptorIdentity('handler-advisory-enforcing-output', {
+          outputContract: 'talon.lifecycle.enforcing.interceptor.output.v1',
+        }),
+      ],
+      [
+        'handler-enforcing-advisory-output',
+        interceptorIdentity('handler-enforcing-advisory-output', {
+          interceptorSafety: 'enforcing',
+        }),
+      ],
+      [
+        'handler-enforcing-subagent',
+        interceptorIdentity('handler-enforcing-subagent', {
+          interceptorSafety: 'enforcing',
+          outputContract: 'talon.lifecycle.enforcing.interceptor.output.v1',
+          runtimeKind: 'subagent',
+        }),
+      ],
+      [
+        'handler-enforcing-missing-safety',
+        interceptorIdentity('handler-enforcing-missing-safety', {
+          outputContract: 'talon.lifecycle.enforcing.interceptor.output.v1',
+          interceptorSafety: undefined,
+        }),
+      ],
+    ] as const) {
+      expect(() =>
+        insertValidDelivery.run({ handlerId, persona: 'support', identity, failurePolicy }),
+      ).toThrow();
+    }
+    expect(() =>
+      insertValidDelivery.run({
+        handlerId: 'handler-4',
+        persona: 'support',
+        identity: identityFor('handler-4'),
+        failurePolicy,
+      }),
+    ).not.toThrow();
+    // Identity and policy are one authority decision. A syntactically valid
+    // policy cannot be paired with the wrong handler mode on INSERT or UPDATE.
+    for (const [handlerId, identity, incompatiblePolicy] of [
+      ['handler-event-fail-open', identityFor('handler-event-fail-open'), 'fail_open'],
+      [
+        'handler-advisory-dead-letter',
+        interceptorIdentity('handler-advisory-dead-letter'),
+        'dead_letter',
+      ],
+      [
+        'handler-enforcing-fail-open',
+        interceptorIdentity('handler-enforcing-fail-open', {
+          interceptorSafety: 'enforcing',
+          outputContract: 'talon.lifecycle.enforcing.interceptor.output.v1',
+        }),
+        'fail_open',
+      ],
+    ] as const) {
+      expect(() =>
+        insertValidDelivery.run({
+          handlerId,
+          persona: 'support',
+          identity,
+          failurePolicy: JSON.stringify({ version: 'v1', mode: incompatiblePolicy }),
+        }),
+      ).toThrow();
+    }
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET failure_policy = '{"version":"v1","mode":"fail_open"}'
+           WHERE handler_id = 'handler-4'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET handler_identity = ?
+           WHERE handler_id = 'handler-4'`,
+        )
+        .run(interceptorIdentity('handler-4')),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries SET handler_identity = ? WHERE handler_id = 'handler-4'`,
+        )
+        .run(
+          JSON.stringify({
+            ...JSON.parse(identityFor('handler-4')),
+            mode: 'event',
+            inputContract: 'talon.lifecycle.signal.envelope.v1',
+          }),
+        ),
+    ).toThrow();
+    // Individually valid, policy-compatible replacements are still forged
+    // authority snapshots and must remain immutable after fan-out.
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries SET handler_identity = ? WHERE handler_id = 'handler-4'`,
+        )
+        .run(
+          JSON.stringify({
+            ...JSON.parse(identityFor('handler-4')),
+            implementationVersion: '2.0.0',
+          }),
+        ),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET failure_policy = '{"version":"v1","mode":"preserve_session"}'
+           WHERE handler_id = 'handler-4'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      insertValidDelivery.run({
+        handlerId: 'handler-policy-null',
+        persona: 'support',
+        identity: identityFor('handler-policy-null'),
+        failurePolicy: '{"version":"v1","mode":null}',
+      }),
+    ).toThrow();
+    expect(() =>
+      insertValidDelivery.run({
+        handlerId: 'handler-persona-boundary',
+        persona: 'p'.repeat(256),
+        identity: identityFor('handler-persona-boundary'),
+        failurePolicy,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      insertValidDelivery.run({
+        handlerId: 'handler-persona-overflow',
+        persona: 'p'.repeat(257),
+        identity: identityFor('handler-persona-overflow'),
+        failurePolicy,
+      }),
+    ).toThrow();
+    const maxUtf8Persona = '😀'.repeat(256);
+    expect(Array.from(maxUtf8Persona)).toHaveLength(256);
+    expect(Buffer.byteLength(maxUtf8Persona, 'utf8')).toBe(1_024);
+    expect(() =>
+      insertValidDelivery.run({
+        handlerId: 'handler-persona-utf8-boundary',
+        persona: maxUtf8Persona,
+        identity: identityFor('handler-persona-utf8-boundary'),
+        failurePolicy,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      insertValidDelivery.run({
+        handlerId: 'handler-persona-utf8-overflow',
+        persona: `${maxUtf8Persona}😀`,
+        identity: identityFor('handler-persona-utf8-overflow'),
+        failurePolicy,
+      }),
+    ).toThrow();
+    // Bind the value so this regression covers SQLite's TEXT handling without
+    // leaving an invalid fixture row behind for later assertions.
+    expect(() =>
+      insertValidDelivery.run({
+        handlerId: 'handler-persona-nul',
+        persona: 'support\0poison',
+        identity: identityFor('handler-persona-nul'),
+        failurePolicy,
+      }),
+    ).toThrow();
+    for (const [handlerId, persona, identity] of [
+      ['handler-5', 'support', '{"handlerId":"handler-5"}'],
+      ['handler-6', 'support', '[]'],
+      ['handler-7', 'support', identityFor('another-handler')],
+      ['handler-8', '', identityFor('handler-8')],
+    ]) {
+      expect(() =>
+        insertValidDelivery.run({ handlerId, persona, identity, failurePolicy }),
+      ).toThrow();
+    }
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lifecycle_event_deliveries (
+            event_id, handler_id, persona, priority, handler_identity, failure_policy,
+            status, attempts, max_attempts, created_at, updated_at
+          ) VALUES ('event-1', 'handler-9', 'support', 0, ?, ?, 'claimed', 0, 1, 1, 1)`,
+        )
+        .run(identityFor('handler-9'), failurePolicy),
+    ).toThrow();
+    expect(() =>
+      db.prepare(`UPDATE lifecycle_events SET causation_id = '' WHERE event_id = 'event-1'`).run(),
+    ).toThrow();
+
+    // The migration is also the durability boundary: direct SQL cannot bypass
+    // the bounded lifecycle contract even when repository validation is absent.
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_events SET type = 'unshipped.event.v1' WHERE event_id = 'event-1'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_events SET occurred_at = 'not-a-timestamp' WHERE event_id = 'event-1'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_events SET occurred_at = '2026-07-16T10:00:00.000+00:00' WHERE event_id = 'event-1'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(`UPDATE lifecycle_events SET recursion_max_depth = 17 WHERE event_id = 'event-1'`)
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(`UPDATE lifecycle_events SET provenance = ? WHERE event_id = 'event-1'`)
+        .run('{"source":"daemon","sourceEventIds":[1],"sourceReferences":[]}'),
+    ).toThrow();
+    expect(() =>
+      db.prepare(`UPDATE lifecycle_events SET payload = ? WHERE event_id = 'event-1'`).run(
+        JSON.stringify({
+          references: [],
+          metadata: Object.fromEntries(
+            Array.from({ length: 33 }, (_, index) => [`k${index}`, index]),
+          ),
+        }),
+      ),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(`UPDATE lifecycle_events SET payload = ? WHERE event_id = 'event-1'`)
+        .run(JSON.stringify({ references: [{ type: 'run', id: 1 }], metadata: {} })),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(`UPDATE lifecycle_events SET payload = ? WHERE event_id = 'event-1'`)
+        .run(JSON.stringify({ references: [], metadata: { body: 'x'.repeat(262_144) } })),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries SET handler_identity = ? WHERE handler_id = 'handler-4'`,
+        )
+        .run(JSON.stringify({ ...JSON.parse(identityFor('handler-4')), extra: true })),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries SET failure_policy = ? WHERE handler_id = 'handler-4'`,
+        )
+        .run('{"version":"v1","mode":"dead_letter","extra":true}'),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries SET handler_identity = ? WHERE handler_id = 'handler-4'`,
+        )
+        .run(
+          JSON.stringify({
+            ...JSON.parse(identityFor('handler-4')),
+            implementationRef: 'x'.repeat(129),
+          }),
+        ),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET status = 'completed', completed_at = 2, updated_at = 2
+           WHERE handler_id = 'handler-4'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET status = 'failed', attempts = 1, max_attempts = 2, next_retry_at = 2,
+               last_error = '{}'
+           WHERE handler_id = 'handler-4'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET status = 'failed', attempts = 1, max_attempts = 2, next_retry_at = 2,
+               last_error = ?
+           WHERE handler_id = 'handler-4'`,
+        )
+        .run(JSON.stringify({ code: 'x'.repeat(129) })),
+    ).toThrow();
+
+    // Direct SQL must not be able to create a terminal delivery or use
+    // conflict replacement to sidestep the immutable event/fan-out snapshots.
+    // These are real SQLite statements, rather than repository tests, because
+    // the migration is the final durability boundary.
+    const replaceEventId = 'event-replace-guard';
+    db.prepare(
+      `INSERT INTO lifecycle_events (
+        event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+        causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+        occurred_at, created_at
+      ) VALUES (?, 'v1', 'run.completed.v1', 'thread', 'original-thread', 'replace-correlation',
+        NULL, 0, 1, '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}',
+        '{"references":[],"metadata":{"original":true}}', '2026-07-16T10:00:00.000Z', 10)`,
+    ).run(replaceEventId);
+    const originalEvent = db
+      .prepare(
+        `SELECT event_sequence, aggregate_id, payload FROM lifecycle_events WHERE event_id = ?`,
+      )
+      .get(replaceEventId);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT OR REPLACE INTO lifecycle_events (
+            event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+            causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+            occurred_at, created_at
+          ) VALUES (?, 'v1', 'run.completed.v1', 'thread', 'forged-thread', 'replace-correlation',
+            NULL, 0, 1, '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}',
+            '{"references":[],"metadata":{"forged":true}}', '2026-07-16T10:00:00.000Z', 11)`,
+        )
+        .run(replaceEventId),
+    ).toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT event_sequence, aggregate_id, payload FROM lifecycle_events WHERE event_id = ?`,
+        )
+        .get(replaceEventId),
+    ).toEqual(originalEvent);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT OR REPLACE INTO lifecycle_events (
+            event_sequence, event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+            causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+            occurred_at, created_at
+          ) VALUES (?, 'forged-sequence-event', 'v1', 'run.completed.v1', 'thread',
+            'forged-thread', 'forged-sequence-correlation', NULL, 0, 1,
+            '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}',
+            '{"references":[],"metadata":{"forged":true}}', '2026-07-16T10:00:00.000Z', 11)`,
+        )
+        .run((originalEvent as { event_sequence: number }).event_sequence),
+    ).toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT event_sequence, aggregate_id, payload FROM lifecycle_events WHERE event_id = ?`,
+        )
+        .get(replaceEventId),
+    ).toEqual(originalEvent);
+
+    // SQLite exposes an omitted INTEGER PRIMARY KEY as -1 in a BEFORE INSERT
+    // trigger. The durable table must nevertheless reject direct sentinel
+    // sequences, while leaving a repository-shaped omitted insert functional.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lifecycle_events (
+            event_sequence, event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+            causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+            occurred_at, created_at
+          ) VALUES (-1, 'event-negative-sequence', 'v1', 'run.completed.v1', 'thread',
+            'thread-negative-sequence', 'correlation-negative-sequence', NULL, 0, 1,
+            '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}',
+            '{"references":[],"metadata":{}}', '2026-07-16T10:00:00.000Z', 12)`,
+        )
+        .run(),
+    ).toThrow();
+    expect(
+      db
+        .prepare(`SELECT event_sequence FROM lifecycle_events WHERE event_id = ?`)
+        .get('event-negative-sequence'),
+    ).toBeUndefined();
+    expect(() =>
+      insertEventWithPayload.run({
+        eventId: 'event-auto-after-negative-sequence',
+        recursionDepth: 0,
+        recursionMaxDepth: 1,
+        payload: '{"references":[],"metadata":{}}',
+      }),
+    ).not.toThrow();
+    const autoInsertedEvent = db
+      .prepare(`SELECT event_sequence FROM lifecycle_events WHERE event_id = ?`)
+      .get('event-auto-after-negative-sequence') as { event_sequence: number };
+    expect(autoInsertedEvent.event_sequence).toBeGreaterThan(0);
+
+    // A legacy or externally damaged database may already contain -1. Its
+    // replacement attempt still must be atomic: the failed statement cannot
+    // delete the original event and cascade-delete its existing delivery.
+    db.pragma('ignore_check_constraints = ON');
+    try {
+      db.prepare(
+        `INSERT INTO lifecycle_events (
+          event_sequence, event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+          causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+          occurred_at, created_at
+        ) VALUES (-1, 'legacy-negative-sequence', 'v1', 'run.completed.v1', 'thread',
+          'legacy-thread', 'legacy-correlation', NULL, 0, 1,
+          '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}',
+          '{"references":[],"metadata":{"original":true}}', '2026-07-16T10:00:00.000Z', 12)`,
+      ).run();
+    } finally {
+      db.pragma('ignore_check_constraints = OFF');
+    }
+    const legacyNegativeEvent = db
+      .prepare(
+        `SELECT event_sequence, aggregate_id, payload FROM lifecycle_events WHERE event_id = ?`,
+      )
+      .get('legacy-negative-sequence');
+    const legacyHandlerId = 'legacy-negative-handler';
+    db.prepare(
+      `INSERT INTO lifecycle_event_deliveries (
+        event_id, handler_id, persona, priority, handler_identity, failure_policy,
+        status, attempts, max_attempts, created_at, updated_at
+      ) VALUES (?, ?, 'support', 1, ?, ?, 'pending', 0, 2, 12, 12)`,
+    ).run('legacy-negative-sequence', legacyHandlerId, identityFor(legacyHandlerId), failurePolicy);
+    const legacyNegativeDelivery = db
+      .prepare(
+        `SELECT event_id, handler_id, persona, priority, status, attempts
+         FROM lifecycle_event_deliveries WHERE event_id = ? AND handler_id = ?`,
+      )
+      .get('legacy-negative-sequence', legacyHandlerId);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT OR REPLACE INTO lifecycle_events (
+            event_sequence, event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+            causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+            occurred_at, created_at
+          ) VALUES (-1, 'forged-negative-sequence', 'v1', 'run.completed.v1', 'thread',
+            'forged-thread', 'forged-correlation', NULL, 0, 1,
+            '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}',
+            '{"references":[],"metadata":{"forged":true}}', '2026-07-16T10:00:00.000Z', 13)`,
+        )
+        .run(),
+    ).toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT event_sequence, aggregate_id, payload FROM lifecycle_events WHERE event_id = ?`,
+        )
+        .get('legacy-negative-sequence'),
+    ).toEqual(legacyNegativeEvent);
+    expect(
+      db
+        .prepare(`SELECT event_id FROM lifecycle_events WHERE event_id = ?`)
+        .get('forged-negative-sequence'),
+    ).toBeUndefined();
+    expect(
+      db
+        .prepare(
+          `SELECT event_id, handler_id, persona, priority, status, attempts
+           FROM lifecycle_event_deliveries WHERE event_id = ? AND handler_id = ?`,
+        )
+        .get('legacy-negative-sequence', legacyHandlerId),
+    ).toEqual(legacyNegativeDelivery);
+
+    const replaceHandlerId = 'replace-guard-handler';
+    db.prepare(
+      `INSERT INTO lifecycle_event_deliveries (
+        event_id, handler_id, persona, priority, handler_identity, failure_policy,
+        status, attempts, max_attempts, created_at, updated_at
+      ) VALUES (?, ?, 'support', 1, ?, ?, 'pending', 0, 2, 10, 10)`,
+    ).run(replaceEventId, replaceHandlerId, identityFor(replaceHandlerId), failurePolicy);
+    const originalDelivery = db
+      .prepare(
+        `SELECT persona, priority, handler_identity, status, attempts
+         FROM lifecycle_event_deliveries WHERE event_id = ? AND handler_id = ?`,
+      )
+      .get(replaceEventId, replaceHandlerId);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT OR REPLACE INTO lifecycle_event_deliveries (
+            event_id, handler_id, persona, priority, handler_identity, failure_policy,
+            status, attempts, max_attempts, created_at, updated_at
+          ) VALUES (?, ?, 'forged', 99, ?, ?, 'pending', 0, 2, 11, 11)`,
+        )
+        .run(replaceEventId, replaceHandlerId, identityFor(replaceHandlerId), failurePolicy),
+    ).toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT persona, priority, handler_identity, status, attempts
+           FROM lifecycle_event_deliveries WHERE event_id = ? AND handler_id = ?`,
+        )
+        .get(replaceEventId, replaceHandlerId),
+    ).toEqual(originalDelivery);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lifecycle_event_deliveries (
+            event_id, handler_id, persona, priority, handler_identity, failure_policy,
+            status, attempts, max_attempts, completed_at, created_at, updated_at
+          ) VALUES (?, 'forged-terminal-handler', 'support', 0, ?, ?,
+            'completed', 0, 1, 12, 12, 12)`,
+        )
+        .run(replaceEventId, identityFor('forged-terminal-handler'), failurePolicy),
+    ).toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS count FROM lifecycle_event_deliveries
+           WHERE event_id = ? AND handler_id = 'forged-terminal-handler'`,
+        )
+        .get(replaceEventId),
+    ).toEqual({ count: 0 });
   });
 });

--- a/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
+++ b/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
@@ -1,0 +1,1372 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  BaseRepository,
+  LifecycleDeliveryRepository,
+  LifecycleEventRepository,
+  type ClaimLifecycleDeliveryOptions,
+  type LifecycleFailureDiagnostic,
+  type LifecycleDeliveryFanoutInput,
+} from '../../../../../src/core/database/repositories/index.js';
+import type { LifecycleEventEnvelope } from '../../../../../src/lifecycle/contracts/index.js';
+import { runMigrations } from '../../../../../src/core/database/migrations/runner.js';
+import { createTestDb, uuid } from './helpers.js';
+
+describe('lifecycle event persistence', () => {
+  let db: Database.Database;
+  let events: LifecycleEventRepository;
+  let deliveries: LifecycleDeliveryRepository;
+  let leaseNow: number;
+
+  beforeEach(() => {
+    BaseRepository.__resetMonotonicClockForTests();
+    db = createTestDb();
+    events = new LifecycleEventRepository(db);
+    leaseNow = 1_800_000_000_000;
+    deliveries = new LifecycleDeliveryRepository(db, () => leaseNow);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function event(overrides: Partial<LifecycleEventEnvelope> = {}): LifecycleEventEnvelope {
+    return {
+      version: 'v1',
+      eventId: uuid(),
+      type: 'run.completed.v1',
+      occurredAt: '2026-07-16T10:00:00.000Z',
+      context: {
+        aggregate: { type: 'thread', id: `thread-${uuid()}` },
+        correlationId: uuid(),
+        recursion: { depth: 0, maxDepth: 4 },
+        provenance: { source: 'daemon' },
+      },
+      payload: {
+        references: [{ type: 'run', id: uuid() }],
+        metadata: { outcome: 'completed' },
+      },
+      ...overrides,
+    };
+  }
+
+  function delivery(handlerId = 'run-projector'): LifecycleDeliveryFanoutInput {
+    return {
+      handlerId,
+      persona: 'support',
+      priority: 0,
+      identity: {
+        version: 'v1',
+        handlerId,
+        runtimeKind: 'native',
+        implementationRef: 'run-projector',
+        implementationVersion: '1.0.0',
+        mode: 'event',
+        inputContract: 'talon.lifecycle.event.envelope.v1',
+        outputContract: 'talon.lifecycle.signal.envelopes.v1',
+      },
+      failurePolicy: { version: 'v1', mode: 'dead_letter' },
+      maxAttempts: 2,
+    };
+  }
+
+  function openFileDb(path: string): Database.Database {
+    const fileDb = new Database(path);
+    fileDb.pragma('foreign_keys = ON');
+    const result = runMigrations(
+      fileDb,
+      join(import.meta.dirname, '../../../../../src/core/database/migrations'),
+    );
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return fileDb;
+  }
+
+  function withIgnoredCheckConstraints(operation: () => void): void {
+    // These fixtures model pre-existing corruption from an older build or a
+    // damaged SQLite file. Production migrations intentionally reject these
+    // updates; removing the guards in this isolated test database lets reload
+    // validation remain tested as a separate defense in depth.
+    db.exec('DROP TRIGGER IF EXISTS lifecycle_events_reject_updates');
+    db.exec('DROP TRIGGER IF EXISTS lifecycle_event_deliveries_guard_transitions');
+    db.pragma('ignore_check_constraints = ON');
+    try {
+      operation();
+    } finally {
+      db.pragma('ignore_check_constraints = OFF');
+    }
+  }
+
+  it('stores only a validated bounded event envelope', () => {
+    const input = event();
+    const inserted = events.insert(input);
+
+    expect(inserted.isOk()).toBe(true);
+    const stored = inserted._unsafeUnwrap();
+    expect(stored.event_id).toBe(input.eventId);
+    expect(JSON.parse(stored.payload)).toEqual(input.payload);
+    expect(JSON.parse(stored.provenance)).toEqual({
+      source: input.context.provenance.source,
+      sourceEventIds: [],
+      sourceReferences: [],
+    });
+    expect(stored.event_sequence).toBeGreaterThan(0);
+
+    const tooLarge = event({
+      payload: { references: [], metadata: { body: 'x'.repeat(1_025) } },
+    });
+    expect(events.insert(tooLarge).isErr()).toBe(true);
+    expect(events.findById(tooLarge.eventId)._unsafeUnwrap()).toBeNull();
+
+    const invalidRecursion = event({
+      context: {
+        ...event().context,
+        recursion: { depth: 0, maxDepth: 0 },
+      },
+    });
+    expect(events.insert(invalidRecursion).isErr()).toBe(true);
+    expect(events.findById(invalidRecursion.eventId)._unsafeUnwrap()).toBeNull();
+  });
+
+  it('rolls back a standalone insert when its SQLite sequence is not safely readable', () => {
+    const initial = events.insert(event())._unsafeUnwrap();
+    db.prepare(`DELETE FROM lifecycle_events WHERE event_id = ?`).run(initial.event_id);
+    db.prepare(`UPDATE sqlite_sequence SET seq = ? WHERE name = 'lifecycle_events'`).run(
+      Number.MAX_SAFE_INTEGER,
+    );
+
+    const input = event();
+    expect(events.insert(input).isErr()).toBe(true);
+    expect(events.findById(input.eventId)._unsafeUnwrap()).toBeNull();
+    expect(events.count()._unsafeUnwrap()).toBe(0);
+  });
+
+  it('atomically inserts an event and its unique handler fan-out', () => {
+    const input = event();
+    const result = events.insertWithDeliveries(input, [
+      delivery('first-handler'),
+      delivery('second-handler'),
+    ]);
+
+    expect(result.isOk()).toBe(true);
+    expect(deliveries.findByEventId(input.eventId)._unsafeUnwrap()).toHaveLength(2);
+    expect(events.insertWithDeliveries(input, [delivery('first-handler')]).isErr()).toBe(true);
+    expect(deliveries.findByEventId(input.eventId)._unsafeUnwrap()).toHaveLength(2);
+
+    db.exec(`
+      CREATE TRIGGER reject_lifecycle_delivery
+      BEFORE INSERT ON lifecycle_event_deliveries
+      WHEN NEW.handler_id = 'reject-handler'
+      BEGIN
+        SELECT RAISE(ABORT, 'simulated delivery insert failure');
+      END;
+    `);
+    const rejectedEvent = event();
+    expect(
+      events
+        .insertWithDeliveries(rejectedEvent, [
+          delivery('first-handler'),
+          delivery('reject-handler'),
+        ])
+        .isErr(),
+    ).toBe(true);
+    expect(events.findById(rejectedEvent.eventId)._unsafeUnwrap()).toBeNull();
+    expect(events.count()._unsafeUnwrap()).toBe(1);
+  });
+
+  it('fans out the same handler identity once for each new event', () => {
+    const first = event();
+    const second = event();
+    events.insertWithDeliveries(first, [delivery('shared-handler')])._unsafeUnwrap();
+    events.insertWithDeliveries(second, [delivery('shared-handler')])._unsafeUnwrap();
+
+    expect(deliveries.findByEventId(first.eventId)._unsafeUnwrap()).toHaveLength(1);
+    expect(deliveries.findByEventId(second.eventId)._unsafeUnwrap()).toHaveLength(1);
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS count FROM lifecycle_event_deliveries WHERE handler_id = 'shared-handler'`,
+        )
+        .get(),
+    ).toEqual({ count: 2 });
+  });
+
+  it('bounds persisted persona names at the public and reload boundaries', () => {
+    const atLimit = 'p'.repeat(256);
+    const maxUtf8Persona = '😀'.repeat(256);
+    const withinLimit = event();
+    expect(
+      events.insertWithDeliveries(withinLimit, [{ ...delivery(), persona: atLimit }]).isOk(),
+    ).toBe(true);
+
+    const utf8Boundary = event();
+    expect(Array.from(maxUtf8Persona)).toHaveLength(256);
+    expect(Buffer.byteLength(maxUtf8Persona, 'utf8')).toBe(1_024);
+    expect(
+      events
+        .insertWithDeliveries(utf8Boundary, [{ ...delivery(), persona: maxUtf8Persona }])
+        .isOk(),
+    ).toBe(true);
+
+    const overflow = event();
+    expect(
+      events.insertWithDeliveries(overflow, [{ ...delivery(), persona: `${atLimit}p` }]).isErr(),
+    ).toBe(true);
+    expect(events.findById(overflow.eventId)._unsafeUnwrap()).toBeNull();
+
+    const utf8Overflow = event();
+    expect(
+      events
+        .insertWithDeliveries(utf8Overflow, [{ ...delivery(), persona: `${maxUtf8Persona}😀` }])
+        .isErr(),
+    ).toBe(true);
+    expect(events.findById(utf8Overflow.eventId)._unsafeUnwrap()).toBeNull();
+
+    const embeddedNul = event();
+    expect(
+      events
+        .insertWithDeliveries(embeddedNul, [{ ...delivery(), persona: 'support\0poison' }])
+        .isErr(),
+    ).toBe(true);
+    expect(events.findById(embeddedNul.eventId)._unsafeUnwrap()).toBeNull();
+
+    withIgnoredCheckConstraints(() => {
+      db.prepare(`UPDATE lifecycle_event_deliveries SET persona = ? WHERE event_id = ?`).run(
+        `${atLimit}p`,
+        withinLimit.eventId,
+      );
+    });
+    expect(deliveries.findByEventId(withinLimit.eventId).isErr()).toBe(true);
+
+    // Reload validation remains defensive against corruption introduced by an
+    // older SQLite build or a damaged database, even though the SQL CHECK now
+    // rejects embedded NUL on normal writes.
+    withIgnoredCheckConstraints(() => {
+      db.prepare(`UPDATE lifecycle_event_deliveries SET persona = ? WHERE event_id = ?`).run(
+        'support\0poison',
+        utf8Boundary.eventId,
+      );
+    });
+    expect(deliveries.findByEventId(utf8Boundary.eventId).isErr()).toBe(true);
+  });
+
+  it('enforces the frozen identity and failure-policy matrix before fan-out persistence', () => {
+    const eventHandler = delivery('event-policy-handler');
+    expect(
+      events.insertWithDeliveries(event(), [
+        { ...eventHandler, failurePolicy: { version: 'v1', mode: 'fail_open' } },
+      ]),
+    ).toMatchObject({ error: expect.anything() });
+    expect(
+      events
+        .insertWithDeliveries(event(), [
+          { ...eventHandler, failurePolicy: { version: 'v1', mode: 'preserve_session' } },
+        ])
+        .isOk(),
+    ).toBe(true);
+
+    const advisory = delivery('advisory-policy-handler');
+    advisory.identity = {
+      ...advisory.identity,
+      mode: 'interceptor',
+      inputContract: 'talon.lifecycle.interceptor.input.v1',
+      outputContract: 'talon.lifecycle.advisory.interceptor.output.v1',
+      interceptorSafety: 'advisory',
+    };
+    expect(
+      events
+        .insertWithDeliveries(event(), [
+          { ...advisory, failurePolicy: { version: 'v1', mode: 'dead_letter' } },
+        ])
+        .isErr(),
+    ).toBe(true);
+    expect(
+      events
+        .insertWithDeliveries(event(), [
+          { ...advisory, failurePolicy: { version: 'v1', mode: 'fail_open' } },
+        ])
+        .isOk(),
+    ).toBe(true);
+
+    const enforcing = delivery('enforcing-policy-handler');
+    enforcing.identity = {
+      ...enforcing.identity,
+      mode: 'interceptor',
+      inputContract: 'talon.lifecycle.interceptor.input.v1',
+      outputContract: 'talon.lifecycle.enforcing.interceptor.output.v1',
+      interceptorSafety: 'enforcing',
+    };
+    expect(
+      events
+        .insertWithDeliveries(event(), [
+          { ...enforcing, failurePolicy: { version: 'v1', mode: 'fail_open' } },
+        ])
+        .isErr(),
+    ).toBe(true);
+    expect(
+      events
+        .insertWithDeliveries(event(), [
+          { ...enforcing, failurePolicy: { version: 'v1', mode: 'fail_closed' } },
+        ])
+        .isOk(),
+    ).toBe(true);
+  });
+
+  it('round-trips a valid metadata __proto__ key without changing object prototypes', () => {
+    const metadata = Object.create(null) as Record<string, unknown>;
+    Object.defineProperty(metadata, '__proto__', {
+      value: 'preserved',
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+    expect(Object.getPrototypeOf(metadata)).toBeNull();
+    const input = event({ payload: { references: [], metadata } });
+
+    const stored = events.insert(input)._unsafeUnwrap();
+    const storedMetadata = (
+      JSON.parse(stored.payload) as {
+        metadata: Record<string, unknown>;
+      }
+    ).metadata;
+    expect(Object.hasOwn(storedMetadata, '__proto__')).toBe(true);
+    expect(storedMetadata.__proto__).toBe('preserved');
+    expect(events.findById(input.eventId)._unsafeUnwrap()?.payload).toBe(stored.payload);
+
+    expect(() =>
+      db
+        .prepare(`UPDATE lifecycle_events SET payload = ? WHERE event_id = ?`)
+        .run('{"references":[],"metadata":{"__proto__":"forged"}}', input.eventId),
+    ).toThrow();
+  });
+
+  it('claims ready deliveries in aggregate order and reclaims an expired lease after restart', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const aggregate = { type: 'thread', id: `thread-${uuid()}` };
+    const first = event({ context: { ...event().context, aggregate } });
+    const second = event({ context: { ...event().context, aggregate } });
+    events.insertWithDeliveries(first, [delivery()])._unsafeUnwrap();
+    events.insertWithDeliveries(second, [delivery()])._unsafeUnwrap();
+
+    const callerSuppliedToken = uuid();
+    const firstClaim = deliveries
+      .claimNext({
+        leaseMs: 100,
+        claimToken: callerSuppliedToken,
+      } as unknown as ClaimLifecycleDeliveryOptions)
+      ._unsafeUnwrap();
+    expect(firstClaim?.delivery.event_id).toBe(first.eventId);
+    expect(firstClaim?.delivery.claim_token).not.toBe(callerSuppliedToken);
+    leaseNow = now + 50;
+    expect(deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()).toBeNull();
+
+    leaseNow = now + 101;
+    const reclaimed = deliveries
+      .claimNext({
+        leaseMs: 100,
+        claimToken: callerSuppliedToken,
+      } as unknown as ClaimLifecycleDeliveryOptions)
+      ._unsafeUnwrap();
+    expect(reclaimed?.delivery.event_id).toBe(first.eventId);
+    expect(reclaimed?.delivery.claim_token).not.toBe(firstClaim?.delivery.claim_token);
+    expect(
+      deliveries
+        .complete(first.eventId, 'run-projector', firstClaim!.delivery.claim_token!)
+        .isErr(),
+    ).toBe(true);
+
+    deliveries
+      .complete(first.eventId, 'run-projector', reclaimed!.delivery.claim_token!)
+      ._unsafeUnwrap();
+    leaseNow = now + 102;
+    const secondClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap();
+    expect(secondClaim?.delivery.event_id).toBe(second.eventId);
+  });
+
+  it('does not let a public claim timestamp expire another active lease', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const input = event();
+    events.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+
+    const activeClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    const before = db
+      .prepare(`SELECT * FROM lifecycle_event_deliveries WHERE event_id = ?`)
+      .get(input.eventId);
+
+    const forcedClaim = deliveries.claimNext({
+      leaseMs: 100,
+      now: now + 86_400_000,
+    } as unknown as ClaimLifecycleDeliveryOptions);
+
+    expect(forcedClaim._unsafeUnwrap()).toBeNull();
+    expect(
+      db.prepare(`SELECT * FROM lifecycle_event_deliveries WHERE event_id = ?`).get(input.eventId),
+    ).toEqual(before);
+    expect(deliveries.findByKey(input.eventId, 'run-projector')._unsafeUnwrap()).toMatchObject({
+      status: 'claimed',
+      attempts: 0,
+      claim_token: activeClaim.delivery.claim_token,
+      claim_expires_at: now + 100,
+    });
+  });
+
+  it('rejects terminal mutations at the lease boundary and recovers with a new claim', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const input = event();
+    events.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+    const staleClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+
+    leaseNow = now + 100;
+    expect(
+      deliveries.complete(input.eventId, 'run-projector', staleClaim.delivery.claim_token!).isErr(),
+    ).toBe(true);
+    expect(
+      deliveries
+        .fail(
+          input.eventId,
+          'run-projector',
+          staleClaim.delivery.claim_token!,
+          { code: 'lease-expired' },
+          now + 200,
+        )
+        .isErr(),
+    ).toBe(true);
+    expect(deliveries.findByKey(input.eventId, 'run-projector')._unsafeUnwrap()).toMatchObject({
+      status: 'claimed',
+      claim_token: staleClaim.delivery.claim_token,
+    });
+
+    leaseNow = now + 101;
+    const recoveredClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    expect(recoveredClaim.delivery.attempts).toBe(1);
+    expect(recoveredClaim.delivery.claim_token).not.toBe(staleClaim.delivery.claim_token);
+    expect(
+      deliveries
+        .complete(input.eventId, 'run-projector', recoveredClaim.delivery.claim_token!)
+        .isOk(),
+    ).toBe(true);
+  });
+
+  it('uses wall lease time rather than the monotonic write-order clock', () => {
+    const now = 1_800_000_000_000;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      leaseNow = now;
+      const input = event();
+      events.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+      const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+
+      // These writes deliberately advance BaseRepository's strict write clock
+      // beyond the lease duration while the wall lease clock remains frozen.
+      for (let index = 0; index < 101; index += 1) {
+        events.insert(event())._unsafeUnwrap();
+      }
+
+      expect(
+        deliveries.complete(input.eventId, 'run-projector', claim.delivery.claim_token!),
+      ).toMatchObject({ value: { status: 'completed' } });
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('charges abandoned leases against max attempts before advancing an aggregate', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const aggregate = { type: 'thread', id: `thread-${uuid()}` };
+    const first = event({ context: { ...event().context, aggregate } });
+    const second = event({ context: { ...event().context, aggregate } });
+    events.insertWithDeliveries(first, [delivery()])._unsafeUnwrap();
+    events.insertWithDeliveries(second, [delivery()])._unsafeUnwrap();
+
+    const firstAttempt = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    leaseNow = now + 101;
+    const secondAttempt = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    expect(secondAttempt.delivery.event_id).toBe(first.eventId);
+    expect(secondAttempt.delivery.attempts).toBe(1);
+
+    leaseNow = now + 202;
+    const later = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    expect(later.delivery.event_id).toBe(second.eventId);
+    expect(deliveries.findByKey(first.eventId, 'run-projector')._unsafeUnwrap()).toMatchObject({
+      status: 'dead_letter',
+      attempts: 2,
+      last_error: '{"code":"lease-expired"}',
+    });
+    expect(
+      deliveries.complete(first.eventId, 'run-projector', firstAttempt.delivery.claim_token!),
+    ).toMatchObject({ error: expect.anything() });
+    expect(
+      deliveries.complete(first.eventId, 'run-projector', secondAttempt.delivery.claim_token!),
+    ).toMatchObject({ error: expect.anything() });
+  });
+
+  it('rejects malformed UTF-16 before SQLite can normalize it into a collision', () => {
+    const replacementId = '\ufffd';
+    expect(events.insert(event({ eventId: replacementId })).isOk()).toBe(true);
+    expect(events.insert(event({ eventId: '\ud800' })).isErr()).toBe(true);
+    expect(events.insert(event({ eventId: '\udc00' })).isErr()).toBe(true);
+    expect(events.findById(replacementId)._unsafeUnwrap()).not.toBeNull();
+    expect(events.count()._unsafeUnwrap()).toBe(1);
+
+    const malformedEvents: Array<[string, LifecycleEventEnvelope]> = [
+      ['occurredAt', event({ occurredAt: '\udc00' })],
+      [
+        'aggregate id',
+        event({ context: { ...event().context, aggregate: { type: 'thread', id: '\ud800' } } }),
+      ],
+      ['correlation id', event({ context: { ...event().context, correlationId: '\udc00' } })],
+      ['causation id', event({ context: { ...event().context, causationId: '\ud800' } })],
+      [
+        'provenance source',
+        event({ context: { ...event().context, provenance: { source: '\ud800' } } }),
+      ],
+      [
+        'reference id',
+        event({ payload: { references: [{ type: 'run', id: '\udc00' }], metadata: {} } }),
+      ],
+      ['metadata key', event({ payload: { references: [], metadata: { '\ud800': 'value' } } })],
+      ['metadata value', event({ payload: { references: [], metadata: { value: '\udc00' } } })],
+    ];
+    for (const [field, malformed] of malformedEvents) {
+      expect(events.insert(malformed).isErr(), field).toBe(true);
+    }
+
+    const emoji = event({
+      context: { ...event().context, aggregate: { type: 'thread', id: 'thread-😀' } },
+      payload: {
+        references: [],
+        metadata: { café: '😀', escaped: 'line\nbreak\tand \u0001', literal: '\\u1234' },
+      },
+    });
+    expect(events.insert(emoji).isOk()).toBe(true);
+    expect(events.findById(emoji.eventId)._unsafeUnwrap()?.payload).toContain('"café":"😀"');
+    expect(
+      events
+        .insert(event({ payload: { references: [], metadata: { A: true, Ａ: false } } }))
+        .isErr(),
+    ).toBe(true);
+    expect(
+      events.insertWithDeliveries(event(), [{ ...delivery(), persona: 'support\ud800' }]).isErr(),
+    ).toBe(true);
+    expect(
+      events
+        .insertWithDeliveries(event(), [
+          {
+            ...delivery(),
+            identity: { ...delivery().identity, implementationRef: 'native\udc00' },
+          },
+        ])
+        .isErr(),
+    ).toBe(true);
+  });
+
+  it('rejects malformed runtime IDs on every lookup and mutation path without aliasing rows', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const replacementId = '\ufffd';
+    const input = event({ eventId: replacementId });
+    events.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+    const emojiInput = event({ eventId: '😀' });
+    events.insertWithDeliveries(emojiInput, [delivery('emoji-handler')])._unsafeUnwrap();
+    const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+
+    for (const malformed of ['\ud800', '\udc00']) {
+      expect(events.findById(malformed).isErr(), `event find ${JSON.stringify(malformed)}`).toBe(
+        true,
+      );
+      expect(deliveries.findByEventId(malformed).isErr()).toBe(true);
+      expect(deliveries.findByKey(malformed, 'run-projector').isErr()).toBe(true);
+      expect(
+        deliveries.complete(malformed, 'run-projector', claim.delivery.claim_token!).isErr(),
+      ).toBe(true);
+      expect(
+        deliveries
+          .fail(
+            malformed,
+            'run-projector',
+            claim.delivery.claim_token!,
+            { code: 'transient-failure' },
+            now + 200,
+          )
+          .isErr(),
+      ).toBe(true);
+      expect(deliveries.reopen(malformed, 'run-projector').isErr()).toBe(true);
+      expect(deliveries.complete(replacementId, 'run-projector', malformed).isErr()).toBe(true);
+    }
+    expect(events.findById(replacementId)._unsafeUnwrap()).not.toBeNull();
+    expect(events.findById(emojiInput.eventId)._unsafeUnwrap()).not.toBeNull();
+    expect(deliveries.findByEventId(emojiInput.eventId)._unsafeUnwrap()).toHaveLength(1);
+    expect(deliveries.findByKey(replacementId, 'run-projector')._unsafeUnwrap()).toMatchObject({
+      status: 'claimed',
+      claim_token: claim.delivery.claim_token,
+    });
+    expect(
+      deliveries.complete(replacementId, 'run-projector', claim.delivery.claim_token!).isOk(),
+    ).toBe(true);
+    leaseNow = now + 1;
+    const emojiClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    expect(emojiClaim.delivery.event_id).toBe(emojiInput.eventId);
+    expect(
+      deliveries
+        .complete(emojiInput.eventId, 'emoji-handler', emojiClaim.delivery.claim_token!)
+        .isOk(),
+    ).toBe(true);
+    expect(events.findByAggregate('thread', 'thread-😀').isOk()).toBe(true);
+  });
+
+  it('bounds hostile lifecycle transport shapes before schema parsing without throwing', () => {
+    const sparse: unknown[] = [];
+    sparse.length = 0xffffffff;
+    const accessor = [delivery()] as unknown[];
+    Object.defineProperty(accessor, '0', {
+      enumerable: true,
+      get() {
+        throw new Error('array accessor must not run');
+      },
+    });
+    const iterable = [delivery()] as unknown[];
+    Object.defineProperty(iterable, Symbol.iterator, {
+      value() {
+        throw new Error('iterator must not run');
+      },
+    });
+    const proxied = new Proxy(event(), {});
+    const revoked = Proxy.revocable(event(), {});
+    revoked.revoke();
+    const proxiedArray = new Proxy([delivery()], {});
+    const nonNativeArray = [delivery()];
+    Object.setPrototypeOf(nonNativeArray, {});
+    const hugeEventId = event({ eventId: 'x'.repeat(1_000_000) });
+    const hugeMetadataKey = event({
+      payload: { references: [], metadata: { ['x'.repeat(1_000_000)]: 'value' } },
+    });
+    const excessiveMetadata = event({
+      payload: {
+        references: [],
+        metadata: Object.fromEntries(
+          Array.from({ length: 33 }, (_, index) => [`k${index}`, index]),
+        ),
+      },
+    });
+    const cyclic = event();
+    (cyclic.payload.metadata as Record<string, unknown>).cycle = cyclic;
+    let deep: unknown = 'leaf';
+    for (let index = 0; index < 128; index += 1) {
+      deep = { nested: deep };
+    }
+    const excessiveDepth = event({ payload: { references: [], metadata: { deep } } });
+    const oversized = event({ payload: { references: [], metadata: { body: 'x'.repeat(1_025) } } });
+    const oversizedNamedEvent = event() as unknown as Record<string, unknown>;
+    for (let index = 0; index < 33; index += 1) oversizedNamedEvent[`extra${index}`] = index;
+    const oversizedSymbolEvent = event() as unknown as Record<PropertyKey, unknown>;
+    for (let index = 0; index < 33; index += 1)
+      oversizedSymbolEvent[Symbol(`extra${index}`)] = index;
+    const oversizedNamedDeliveries = [delivery()] as unknown as Record<string, unknown>;
+    const oversizedSymbolDeliveries = [delivery()] as unknown as Record<PropertyKey, unknown>;
+    for (let index = 0; index < 33; index += 1) {
+      oversizedNamedDeliveries[`extra${index}`] = index;
+      oversizedSymbolDeliveries[Symbol(`extra${index}`)] = index;
+    }
+
+    for (const candidate of [
+      proxied,
+      revoked.proxy,
+      excessiveMetadata,
+      cyclic,
+      excessiveDepth,
+      oversized,
+      hugeEventId,
+      hugeMetadataKey,
+      oversizedNamedEvent,
+      oversizedSymbolEvent,
+    ]) {
+      expect(() => events.insert(candidate as LifecycleEventEnvelope)).not.toThrow();
+      expect(events.insert(candidate as LifecycleEventEnvelope).isErr()).toBe(true);
+    }
+    for (const candidate of [
+      sparse,
+      accessor,
+      iterable,
+      proxiedArray,
+      nonNativeArray,
+      oversizedNamedDeliveries,
+      oversizedSymbolDeliveries,
+    ]) {
+      expect(() =>
+        events.insertWithDeliveries(event(), candidate as LifecycleDeliveryFanoutInput[]),
+      ).not.toThrow();
+      expect(
+        events.insertWithDeliveries(event(), candidate as LifecycleDeliveryFanoutInput[]).isErr(),
+      ).toBe(true);
+    }
+
+    const boundary = event({
+      payload: {
+        references: Array.from({ length: 32 }, (_, index) => ({ type: 'run', id: `run-${index}` })),
+        metadata: Object.fromEntries(
+          Array.from({ length: 32 }, (_, index) => [`key-${index}`, 'x'.repeat(1_024)]),
+        ),
+      },
+    });
+    expect(events.insert(boundary).isOk()).toBe(true);
+  });
+
+  it('retries, dead-letters, and reopens a delivery without duplicating its identity', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const input = event();
+    events.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+
+    const firstClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    const retry = deliveries.fail(
+      input.eventId,
+      'run-projector',
+      firstClaim.delivery.claim_token!,
+      { code: 'transient-failure' },
+      now + 500,
+    );
+    expect(retry._unsafeUnwrap().status).toBe('failed');
+    leaseNow = now + 499;
+    expect(deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()).toBeNull();
+
+    leaseNow = now + 500;
+    const secondClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    const deadLetter = deliveries.fail(
+      input.eventId,
+      'run-projector',
+      secondClaim.delivery.claim_token!,
+      { code: 'permanent-failure' },
+      now + 1_000,
+    );
+    expect(deadLetter._unsafeUnwrap().status).toBe('dead_letter');
+
+    const reopened = deliveries.reopen(input.eventId, 'run-projector')._unsafeUnwrap();
+    expect(reopened.status).toBe('pending');
+    expect(reopened.attempts).toBe(0);
+    expect(deliveries.findByEventId(input.eventId)._unsafeUnwrap()).toHaveLength(1);
+  });
+
+  it('returns Result errors for invalid and hostile public inputs without throwing', () => {
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('hostile getter');
+        },
+      },
+    );
+    const input = event();
+    events.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+    leaseNow = 1_000;
+    const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+
+    expect(() =>
+      deliveries.claimNext(null as unknown as ClaimLifecycleDeliveryOptions),
+    ).not.toThrow();
+    expect(deliveries.claimNext(null as unknown as ClaimLifecycleDeliveryOptions).isErr()).toBe(
+      true,
+    );
+    expect(deliveries.claimNext(hostile as ClaimLifecycleDeliveryOptions).isErr()).toBe(true);
+    expect(
+      deliveries
+        .claimNext({
+          leaseMs: 1,
+          now: Number.MAX_SAFE_INTEGER,
+        } as unknown as ClaimLifecycleDeliveryOptions)
+        .isOk(),
+    ).toBe(true);
+    expect(
+      deliveries
+        .fail(
+          input.eventId,
+          'run-projector',
+          claim.delivery.claim_token!,
+          42 as unknown as LifecycleFailureDiagnostic,
+          2_000,
+        )
+        .isErr(),
+    ).toBe(true);
+    expect(events.insert(hostile as LifecycleEventEnvelope).isErr()).toBe(true);
+    expect(
+      events.insertWithDeliveries(event(), [hostile as LifecycleDeliveryFanoutInput]).isErr(),
+    ).toBe(true);
+
+    const secretCause = new Error('Authorization: Bearer caller-controlled-secret');
+    const throwingOptions = Object.defineProperty({}, 'leaseMs', {
+      get() {
+        throw secretCause;
+      },
+    }) as ClaimLifecycleDeliveryOptions;
+    const rejected = deliveries.claimNext(throwingOptions);
+    expect(rejected.isErr()).toBe(true);
+    expect(rejected._unsafeUnwrapErr().cause).toBeUndefined();
+    expect(rejected._unsafeUnwrapErr().message).not.toContain('caller-controlled-secret');
+
+    const optionAccessor = Object.defineProperty({ leaseMs: 100 }, 'now', {
+      enumerable: true,
+      get() {
+        throw new Error('claim option accessor must not run');
+      },
+    }) as ClaimLifecycleDeliveryOptions;
+    const diagnosticAccessor = Object.defineProperty({}, 'code', {
+      enumerable: true,
+      get() {
+        throw new Error('diagnostic accessor must not run');
+      },
+    }) as LifecycleFailureDiagnostic;
+    const oversizedNamedOptions = { leaseMs: 100 } as Record<string, unknown>;
+    const oversizedSymbolOptions = { leaseMs: 100 } as Record<PropertyKey, unknown>;
+    for (let index = 0; index < 9; index += 1) {
+      oversizedNamedOptions[`extra${index}`] = index;
+      oversizedSymbolOptions[Symbol(`extra${index}`)] = index;
+    }
+    const diagnosticProxy = new Proxy(
+      { code: 'transient-failure' },
+      {
+        get() {
+          throw new Error('diagnostic proxy must not run');
+        },
+      },
+    ) as LifecycleFailureDiagnostic;
+    expect(() => deliveries.claimNext(optionAccessor)).not.toThrow();
+    expect(deliveries.claimNext(optionAccessor).isErr()).toBe(true);
+    expect(() =>
+      deliveries.claimNext(oversizedNamedOptions as ClaimLifecycleDeliveryOptions),
+    ).not.toThrow();
+    expect(
+      deliveries.claimNext(oversizedNamedOptions as ClaimLifecycleDeliveryOptions).isErr(),
+    ).toBe(true);
+    expect(
+      deliveries.claimNext(oversizedSymbolOptions as ClaimLifecycleDeliveryOptions).isErr(),
+    ).toBe(true);
+    expect(() =>
+      deliveries.fail(
+        input.eventId,
+        'run-projector',
+        claim.delivery.claim_token!,
+        diagnosticAccessor,
+        2_000,
+      ),
+    ).not.toThrow();
+    expect(
+      deliveries
+        .fail(
+          input.eventId,
+          'run-projector',
+          claim.delivery.claim_token!,
+          diagnosticAccessor,
+          2_000,
+        )
+        .isErr(),
+    ).toBe(true);
+    expect(
+      deliveries
+        .fail(input.eventId, 'run-projector', claim.delivery.claim_token!, diagnosticProxy, 2_000)
+        .isErr(),
+    ).toBe(true);
+  });
+
+  it('serializes parsed handler contracts and rejects corrupted delivery rows on reads', () => {
+    const input = event();
+    const hostileIdentity = new Proxy(delivery().identity, {
+      get(target, property, receiver) {
+        if (property === 'toJSON') {
+          throw new Error('toJSON must never be called');
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const hostileDelivery = {
+      ...delivery(),
+      identity: hostileIdentity,
+    } as LifecycleDeliveryFanoutInput;
+    // Proxies are rejected before reflection, so neither toJSON nor a getter
+    // can be invoked while making the durable snapshot.
+    expect(events.insertWithDeliveries(input, [hostileDelivery]).isErr()).toBe(true);
+
+    const stored = event();
+    events.insertWithDeliveries(stored, [delivery()])._unsafeUnwrap();
+    withIgnoredCheckConstraints(() => {
+      db.prepare(
+        `UPDATE lifecycle_event_deliveries SET handler_identity = ? WHERE event_id = ?`,
+      ).run('{"version":"v1"}', stored.eventId);
+    });
+    expect(deliveries.findByEventId(stored.eventId).isErr()).toBe(true);
+  });
+
+  it('rejects corrupt embedded data and every invalid delivery state on reload', () => {
+    const mismatchedIdentity = {
+      ...delivery().identity,
+      handlerId: 'other-handler',
+    };
+    const identityInput = event();
+    events.insertWithDeliveries(identityInput, [delivery()])._unsafeUnwrap();
+    withIgnoredCheckConstraints(() => {
+      db.prepare(
+        `UPDATE lifecycle_event_deliveries SET handler_identity = ? WHERE event_id = ?`,
+      ).run(JSON.stringify(mismatchedIdentity), identityInput.eventId);
+    });
+    expect(deliveries.findByEventId(identityInput.eventId).isErr()).toBe(true);
+
+    const scenarios = [
+      {
+        status: 'pending',
+        attempts: 1,
+        nextRetryAt: null,
+        claimToken: null,
+        claimExpiresAt: null,
+        lastError: null,
+        completedAt: null,
+      },
+      {
+        status: 'claimed',
+        attempts: 0,
+        nextRetryAt: null,
+        claimToken: null,
+        claimExpiresAt: 2_000,
+        lastError: null,
+        completedAt: null,
+      },
+      {
+        status: 'claimed',
+        attempts: 0,
+        nextRetryAt: null,
+        claimToken: ' not-a-valid-claim-token ',
+        claimExpiresAt: 2_000,
+        lastError: null,
+        completedAt: null,
+      },
+      {
+        status: 'failed',
+        attempts: 1,
+        nextRetryAt: null,
+        claimToken: null,
+        claimExpiresAt: null,
+        lastError: '{"code":"transient-failure"}',
+        completedAt: null,
+      },
+      {
+        status: 'failed',
+        attempts: 1,
+        nextRetryAt: 1.5,
+        claimToken: null,
+        claimExpiresAt: null,
+        lastError: '{"code":"transient-failure"}',
+        completedAt: null,
+      },
+      {
+        status: 'completed',
+        attempts: 0,
+        nextRetryAt: null,
+        claimToken: null,
+        claimExpiresAt: null,
+        lastError: null,
+        completedAt: null,
+      },
+      {
+        status: 'dead_letter',
+        attempts: 1,
+        nextRetryAt: null,
+        claimToken: null,
+        claimExpiresAt: null,
+        lastError: '{"code":"permanent-failure"}',
+        completedAt: null,
+      },
+    ];
+    for (const scenario of scenarios) {
+      const input = event();
+      events.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+      withIgnoredCheckConstraints(() => {
+        db.prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET status = ?, attempts = ?, next_retry_at = ?, claim_token = ?,
+               claim_expires_at = ?, last_error = ?, completed_at = ?
+           WHERE event_id = ?`,
+        ).run(
+          scenario.status,
+          scenario.attempts,
+          scenario.nextRetryAt,
+          scenario.claimToken,
+          scenario.claimExpiresAt,
+          scenario.lastError,
+          scenario.completedAt,
+          input.eventId,
+        );
+      });
+      expect(deliveries.findByEventId(input.eventId).isErr()).toBe(true);
+    }
+
+    const emptyPersona = event();
+    events.insertWithDeliveries(emptyPersona, [delivery()])._unsafeUnwrap();
+    withIgnoredCheckConstraints(() => {
+      db.prepare(`UPDATE lifecycle_event_deliveries SET persona = '' WHERE event_id = ?`).run(
+        emptyPersona.eventId,
+      );
+    });
+    expect(deliveries.findByEventId(emptyPersona.eventId).isErr()).toBe(true);
+
+    const malformedPolicy = event();
+    events.insertWithDeliveries(malformedPolicy, [delivery()])._unsafeUnwrap();
+    withIgnoredCheckConstraints(() => {
+      db.prepare(
+        `UPDATE lifecycle_event_deliveries SET failure_policy = '{}' WHERE event_id = ?`,
+      ).run(malformedPolicy.eventId);
+    });
+    expect(deliveries.findByEventId(malformedPolicy.eventId).isErr()).toBe(true);
+
+    const emptyCausation = event();
+    events.insert(emptyCausation)._unsafeUnwrap();
+    withIgnoredCheckConstraints(() => {
+      db.prepare(`UPDATE lifecycle_events SET causation_id = '' WHERE event_id = ?`).run(
+        emptyCausation.eventId,
+      );
+    });
+    expect(events.findById(emptyCausation.eventId).isErr()).toBe(true);
+
+    const malformedTimestamp = event();
+    events.insert(malformedTimestamp)._unsafeUnwrap();
+    withIgnoredCheckConstraints(() => {
+      db.prepare(`UPDATE lifecycle_events SET created_at = 1.5 WHERE event_id = ?`).run(
+        malformedTimestamp.eventId,
+      );
+    });
+    expect(events.findById(malformedTimestamp.eventId).isErr()).toBe(true);
+  });
+
+  it('rolls back state transitions when a returned row or related event is invalid', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const claimInput = event();
+    events.insertWithDeliveries(claimInput, [delivery()])._unsafeUnwrap();
+    withIgnoredCheckConstraints(() => {
+      db.prepare(`UPDATE lifecycle_events SET causation_id = '' WHERE event_id = ?`).run(
+        claimInput.eventId,
+      );
+    });
+    expect(deliveries.claimNext({ leaseMs: 100 }).isErr()).toBe(true);
+    expect(deliveries.findByKey(claimInput.eventId, 'run-projector')._unsafeUnwrap()?.status).toBe(
+      'pending',
+    );
+    db.prepare(`UPDATE lifecycle_events SET causation_id = NULL WHERE event_id = ?`).run(
+      claimInput.eventId,
+    );
+    db.prepare(
+      `UPDATE lifecycle_event_deliveries
+       SET status = 'completed', completed_at = 1_000, updated_at = 1_000
+       WHERE event_id = ?`,
+    ).run(claimInput.eventId);
+
+    const completeInput = event();
+    events.insertWithDeliveries(completeInput, [delivery()])._unsafeUnwrap();
+    leaseNow = now + 1;
+    const completeClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    withIgnoredCheckConstraints(() => {
+      db.prepare(`UPDATE lifecycle_event_deliveries SET persona = '' WHERE event_id = ?`).run(
+        completeInput.eventId,
+      );
+    });
+    expect(
+      deliveries
+        .complete(completeInput.eventId, 'run-projector', completeClaim.delivery.claim_token!)
+        .isErr(),
+    ).toBe(true);
+    expect(
+      db
+        .prepare(`SELECT status, claim_token FROM lifecycle_event_deliveries WHERE event_id = ?`)
+        .get(completeInput.eventId),
+    ).toEqual({ status: 'claimed', claim_token: completeClaim.delivery.claim_token });
+    db.prepare(`UPDATE lifecycle_event_deliveries SET persona = 'support' WHERE event_id = ?`).run(
+      completeInput.eventId,
+    );
+    deliveries
+      .complete(completeInput.eventId, 'run-projector', completeClaim.delivery.claim_token!)
+      ._unsafeUnwrap();
+
+    const failInput = event();
+    events.insertWithDeliveries(failInput, [delivery()])._unsafeUnwrap();
+    leaseNow = now + 2;
+    const failClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    withIgnoredCheckConstraints(() => {
+      db.prepare(`UPDATE lifecycle_event_deliveries SET persona = '' WHERE event_id = ?`).run(
+        failInput.eventId,
+      );
+    });
+    expect(
+      deliveries
+        .fail(
+          failInput.eventId,
+          'run-projector',
+          failClaim.delivery.claim_token!,
+          { code: 'transient-failure' },
+          now + 1_000,
+        )
+        .isErr(),
+    ).toBe(true);
+    expect(
+      db
+        .prepare(`SELECT status, claim_token FROM lifecycle_event_deliveries WHERE event_id = ?`)
+        .get(failInput.eventId),
+    ).toEqual({ status: 'claimed', claim_token: failClaim.delivery.claim_token });
+    db.prepare(`UPDATE lifecycle_event_deliveries SET persona = 'support' WHERE event_id = ?`).run(
+      failInput.eventId,
+    );
+    deliveries
+      .fail(
+        failInput.eventId,
+        'run-projector',
+        failClaim.delivery.claim_token!,
+        { code: 'transient-failure' },
+        now + 1_000,
+      )
+      ._unsafeUnwrap();
+
+    const reopenInput = event();
+    events.insertWithDeliveries(reopenInput, [{ ...delivery(), maxAttempts: 1 }])._unsafeUnwrap();
+    leaseNow = now + 3;
+    const reopenClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    deliveries
+      .fail(
+        reopenInput.eventId,
+        'run-projector',
+        reopenClaim.delivery.claim_token!,
+        { code: 'permanent-failure' },
+        now + 1_000,
+      )
+      ._unsafeUnwrap();
+    withIgnoredCheckConstraints(() => {
+      db.prepare(`UPDATE lifecycle_event_deliveries SET persona = '' WHERE event_id = ?`).run(
+        reopenInput.eventId,
+      );
+    });
+    expect(deliveries.reopen(reopenInput.eventId, 'run-projector').isErr()).toBe(true);
+    expect(
+      db
+        .prepare(`SELECT status FROM lifecycle_event_deliveries WHERE event_id = ?`)
+        .get(reopenInput.eventId),
+    ).toEqual({ status: 'dead_letter' });
+  });
+
+  it('persists only a safe structured failure code, never raw handler error text', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const input = event();
+    events.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+    const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    const secret = 'Authorization: Bearer super-secret-token';
+
+    expect(
+      deliveries
+        .fail(
+          input.eventId,
+          'run-projector',
+          claim.delivery.claim_token!,
+          { code: 'provider-timeout', message: secret } as unknown as LifecycleFailureDiagnostic,
+          now + 1_000,
+        )
+        .isErr(),
+    ).toBe(true);
+
+    deliveries
+      .fail(
+        input.eventId,
+        'run-projector',
+        claim.delivery.claim_token!,
+        { code: 'provider-timeout' },
+        now + 1_000,
+      )
+      ._unsafeUnwrap();
+
+    const stored = db
+      .prepare(`SELECT last_error FROM lifecycle_event_deliveries WHERE event_id = ?`)
+      .get(input.eventId) as { last_error: string };
+    expect(stored.last_error).toBe('{"code":"provider-timeout"}');
+    expect(stored.last_error).not.toContain(secret);
+  });
+
+  it('recovers an expired lease after a real close and reopen', () => {
+    const dbPath = join(mkdtempSync(join(tmpdir(), 'talon-lifecycle-reopen-')), 'talon.sqlite');
+    const firstDb = openFileDb(dbPath);
+    const firstEvents = new LifecycleEventRepository(firstDb);
+    const firstLeaseNow = 1_000;
+    const firstDeliveries = new LifecycleDeliveryRepository(firstDb, () => firstLeaseNow);
+    const input = event();
+    firstEvents.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+    const firstClaim = firstDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    firstDb.close();
+
+    const secondDb = openFileDb(dbPath);
+    try {
+      const secondDeliveries = new LifecycleDeliveryRepository(secondDb, () => 1_101);
+      const reclaimed = secondDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap();
+      expect(reclaimed?.delivery.event_id).toBe(input.eventId);
+      expect(reclaimed?.delivery.claim_token).not.toBe(firstClaim.delivery.claim_token);
+    } finally {
+      secondDb.close();
+    }
+  });
+
+  it('allows only one claim across two competing database connections', () => {
+    const dbPath = join(mkdtempSync(join(tmpdir(), 'talon-lifecycle-claim-')), 'talon.sqlite');
+    const firstDb = openFileDb(dbPath);
+    const secondDb = openFileDb(dbPath);
+    try {
+      const firstEvents = new LifecycleEventRepository(firstDb);
+      const firstDeliveries = new LifecycleDeliveryRepository(firstDb, () => 1_000);
+      const secondDeliveries = new LifecycleDeliveryRepository(secondDb, () => 1_000);
+      const input = event();
+      firstEvents.insertWithDeliveries(input, [delivery()])._unsafeUnwrap();
+
+      const firstClaim = firstDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap();
+      const competingClaim = secondDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap();
+      expect(firstClaim?.delivery.event_id).toBe(input.eventId);
+      expect(competingClaim).toBeNull();
+    } finally {
+      secondDb.close();
+      firstDb.close();
+    }
+  });
+
+  it('does not reopen an earlier aggregate delivery while a later delivery has a valid lease', () => {
+    const dbPath = join(
+      mkdtempSync(join(tmpdir(), 'talon-lifecycle-replay-order-')),
+      'talon.sqlite',
+    );
+    const firstDb = openFileDb(dbPath);
+    const secondDb = openFileDb(dbPath);
+    const now = 1_800_000_000_000;
+    let replayLeaseNow = now;
+    try {
+      const firstEvents = new LifecycleEventRepository(firstDb);
+      const firstDeliveries = new LifecycleDeliveryRepository(firstDb, () => replayLeaseNow);
+      const secondDeliveries = new LifecycleDeliveryRepository(secondDb, () => replayLeaseNow);
+      const aggregate = { type: 'thread', id: `thread-${uuid()}` };
+      const first = event({ context: { ...event().context, aggregate } });
+      const second = event({ context: { ...event().context, aggregate } });
+      firstEvents.insertWithDeliveries(first, [delivery()])._unsafeUnwrap();
+      firstEvents.insertWithDeliveries(second, [delivery()])._unsafeUnwrap();
+
+      const firstClaim = firstDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      firstDeliveries
+        .complete(first.eventId, 'run-projector', firstClaim.delivery.claim_token!)
+        ._unsafeUnwrap();
+      replayLeaseNow = now + 1;
+      const laterClaim = secondDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      expect(laterClaim.delivery.event_id).toBe(second.eventId);
+
+      expect(firstDeliveries.reopen(first.eventId, 'run-projector').isErr()).toBe(true);
+      expect(
+        secondDeliveries.findByKey(second.eventId, 'run-projector')._unsafeUnwrap()?.claim_token,
+      ).toBe(laterClaim.delivery.claim_token);
+      replayLeaseNow = now + 2;
+      expect(firstDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()).toBeNull();
+      expect(secondDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()).toBeNull();
+
+      // Once the later lease expires, reopening the first event is safe and
+      // aggregate ordering claims it before the expired later delivery. The
+      // stale later token is explicitly invalidated before replay is opened.
+      replayLeaseNow = now + 102;
+      expect(firstDeliveries.reopen(first.eventId, 'run-projector').isOk()).toBe(true);
+      expect(
+        secondDeliveries.findByKey(second.eventId, 'run-projector')._unsafeUnwrap()?.claim_token,
+      ).not.toBe(laterClaim.delivery.claim_token);
+      expect(
+        secondDeliveries
+          .complete(second.eventId, 'run-projector', laterClaim.delivery.claim_token!)
+          .isErr(),
+      ).toBe(true);
+      expect(
+        secondDeliveries
+          .fail(
+            second.eventId,
+            'run-projector',
+            laterClaim.delivery.claim_token!,
+            { code: 'stale-worker' },
+            now + 200,
+          )
+          .isErr(),
+      ).toBe(true);
+      const replayClaim = firstDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap();
+      expect(replayClaim?.delivery.event_id).toBe(first.eventId);
+      expect(secondDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()).toBeNull();
+
+      firstDeliveries
+        .complete(first.eventId, 'run-projector', replayClaim!.delivery.claim_token!)
+        ._unsafeUnwrap();
+      replayLeaseNow = now + 106;
+      const recoveredLaterClaim = secondDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap();
+      expect(recoveredLaterClaim?.delivery.event_id).toBe(second.eventId);
+      expect(recoveredLaterClaim?.delivery.claim_token).not.toBe(laterClaim.delivery.claim_token);
+      secondDeliveries
+        .complete(second.eventId, 'run-projector', recoveredLaterClaim!.delivery.claim_token!)
+        ._unsafeUnwrap();
+    } finally {
+      secondDb.close();
+      firstDb.close();
+    }
+  });
+
+  it('leaves unrelated stale claims unchanged when replay is not eligible', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const replayTarget = event();
+    const unrelated = event();
+    events.insertWithDeliveries(replayTarget, [delivery('replay-handler')])._unsafeUnwrap();
+    events
+      .insertWithDeliveries(unrelated, [{ ...delivery('unrelated-handler'), priority: 1 }])
+      ._unsafeUnwrap();
+
+    const unrelatedClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    expect(unrelatedClaim.delivery.event_id).toBe(unrelated.eventId);
+    const before = db
+      .prepare(`SELECT * FROM lifecycle_event_deliveries WHERE event_id = ?`)
+      .get(unrelated.eventId);
+
+    leaseNow = now + 101;
+    expect(deliveries.reopen(replayTarget.eventId, 'replay-handler').isErr()).toBe(true);
+    expect(
+      db
+        .prepare(`SELECT * FROM lifecycle_event_deliveries WHERE event_id = ?`)
+        .get(unrelated.eventId),
+    ).toEqual(before);
+    expect(
+      deliveries.findByKey(unrelated.eventId, 'unrelated-handler')._unsafeUnwrap(),
+    ).toMatchObject({
+      status: 'claimed',
+      attempts: 0,
+      claim_token: unrelatedClaim.delivery.claim_token,
+      claim_expires_at: now + 100,
+    });
+  });
+
+  it('seeds lifecycle timestamps across a clock rewind before writing again', () => {
+    const future = 1_800_000_000_000;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(future);
+    try {
+      const firstInput = event();
+      const first = events.insertWithDeliveries(firstInput, [delivery()])._unsafeUnwrap();
+      clock.mockReturnValue(future + 10_000);
+      leaseNow = future + 10_000;
+      const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      const completed = deliveries
+        .complete(firstInput.eventId, 'run-projector', claim.delivery.claim_token!)
+        ._unsafeUnwrap();
+      BaseRepository.__resetMonotonicClockForTests();
+      clock.mockReturnValue(future - 60_000);
+      BaseRepository.seedMonotonicClockFromDb(db);
+
+      const second = events.insert(event())._unsafeUnwrap();
+      expect(first.event.created_at).toBe(future);
+      expect(second.created_at).toBeGreaterThan(completed.updated_at);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add bounded lifecycle event and per-handler delivery persistence
- add claims, leases, retries, dead-letter, replay, and migration guards
- add focused real-SQLite regressions

## Verification
- Sol/high final review: C0/H0/M0
- Sol/high epic-refresh review: C0/H0/M0
- 37 focused real-SQLite tests
- Node 24 build, TypeScript, scoped ESLint, Prettier, and diff checks

Targets the WDD epic branch for issue #256.