### PR TITLE
feat(lifecycle): add transactional event bus

### DIFF
--- a/src/lifecycle/lifecycle-event-bus.ts
+++ b/src/lifecycle/lifecycle-event-bus.ts
@@ -1,0 +1,447 @@
+/** Transaction-aware publication of durable lifecycle events. */
+
+import { types } from 'node:util';
+import { err, ok, type Result } from 'neverthrow';
+
+import {
+  LifecycleEventRepository,
+  type LifecycleDeliveryFanoutInput,
+  type LifecycleEventFanoutResult,
+} from '../core/database/repositories/index.js';
+import {
+  snapshotBoundedPlainDataRecord,
+  snapshotLifecycleDeliveries,
+  snapshotLifecycleEvent,
+} from '../core/database/repositories/lifecycle-persistence-validation.js';
+import { DbError, LifecycleError } from '../core/errors/index.js';
+import {
+  LifecycleEventEnvelopeSchema,
+  LifecycleFilterOwnerNameSchema,
+  LifecycleItemOriginSchema,
+  LifecycleItemTypeSchema,
+  LifecycleMessageSourceSchema,
+  LifecycleScheduleSourceSchema,
+  type LifecycleEventEnvelope,
+  type LifecycleItemOrigin,
+  type LifecycleItemType,
+  type LifecycleMessageSource,
+  type LifecycleScheduleSource,
+} from './contracts/index.js';
+import type {
+  LifecycleEventResolutionQuery,
+  ResolvedLifecycleHandler,
+} from './handler-registry.js';
+import { TransactionContext } from './transaction-context.js';
+
+/** The stable, registry-owned subset needed to resolve event subscribers. */
+export interface LifecycleEventHandlerResolver {
+  resolveEventHandlers(query: LifecycleEventResolutionQuery): ResolvedLifecycleHandler[];
+}
+
+/** A bounded event envelope plus the scope used to resolve explicit subscriptions. */
+export interface LifecycleEventPublishInput {
+  event: LifecycleEventEnvelope;
+  persona: string;
+  itemOrigin?: LifecycleItemOrigin;
+  itemType?: LifecycleItemType;
+  channel?: string;
+  messageSource?: LifecycleMessageSource;
+  scheduleSource?: LifecycleScheduleSource;
+}
+
+/** Optional nudge for an independent durable dispatcher. */
+export type LifecycleDispatcherWake = (eventId: string) => void | Promise<void>;
+
+type LifecycleEventPublishError = DbError | LifecycleError;
+type LifecycleTransactionError<E> = E | DbError | LifecycleError;
+type DataRecord = Record<string, unknown>;
+type SqliteConnection = { readonly inTransaction: boolean };
+type TransactionState = 'open' | 'committed' | 'rolled_back';
+type AfterCommitCallback = () => void | Promise<void>;
+
+interface OwnedTransactionContext {
+  owner: object;
+  connection: SqliteConnection;
+  state: TransactionState;
+  afterCommitCallbacks: AfterCommitCallback[];
+}
+
+const PUBLISH_INPUT_KEYS = new Set([
+  'event',
+  'persona',
+  'itemOrigin',
+  'itemType',
+  'channel',
+  'messageSource',
+  'scheduleSource',
+]);
+const MAX_RESOLVED_HANDLERS = 32;
+const ownedTransactionContexts = new WeakMap<TransactionContext, OwnedTransactionContext>();
+
+class TransactionRollback<E> extends Error {
+  constructor(readonly error: E) {
+    super('Lifecycle transaction callback returned Err');
+  }
+}
+
+function createOwnedTransactionContext(
+  owner: object,
+  connection: SqliteConnection,
+): TransactionContext {
+  const context = new TransactionContext();
+  ownedTransactionContexts.set(context, {
+    owner,
+    connection,
+    state: 'open',
+    afterCommitCallbacks: [],
+  });
+  return context;
+}
+
+function getOpenOwnedTransactionContext(
+  context: TransactionContext,
+  owner: object,
+  connection: SqliteConnection,
+): OwnedTransactionContext | null {
+  const state = ownedTransactionContexts.get(context);
+  return state?.owner === owner && state.connection === connection && state.state === 'open'
+    ? state
+    : null;
+}
+
+function registerAfterCommit(
+  context: TransactionContext,
+  owner: object,
+  connection: SqliteConnection,
+  callback: AfterCommitCallback,
+): Result<void, LifecycleError> {
+  const state = getOpenOwnedTransactionContext(context, owner, connection);
+  if (!state) {
+    return err(new LifecycleError('Cannot register an after-commit callback on this transaction'));
+  }
+  state.afterCommitCallbacks.push(callback);
+  return ok(undefined);
+}
+
+function commitOwnedTransactionContext(
+  context: TransactionContext,
+  owner: object,
+  connection: SqliteConnection,
+): void {
+  const state = getOpenOwnedTransactionContext(context, owner, connection);
+  if (!state) return;
+
+  state.state = 'committed';
+  const callbacks = state.afterCommitCallbacks.splice(0);
+  for (const callback of callbacks) {
+    try {
+      // A wake is an optimization over durable state. Consume async failures
+      // as well as sync throws so they cannot become unhandled rejections.
+      void Promise.resolve(callback()).catch(() => undefined);
+    } catch {
+      // Pending deliveries remain recoverable by dispatcher polling.
+    }
+  }
+}
+
+function rollbackOwnedTransactionContext(
+  context: TransactionContext,
+  owner: object,
+  connection: SqliteConnection,
+): void {
+  const state = getOpenOwnedTransactionContext(context, owner, connection);
+  if (!state) return;
+  state.state = 'rolled_back';
+  state.afterCommitCallbacks.splice(0);
+}
+
+function getRepositoryConnection(repository: LifecycleEventRepository): SqliteConnection {
+  const connection = (repository as unknown as { db?: unknown }).db;
+  if (!connection || typeof connection !== 'object' || types.isProxy(connection)) {
+    throw new TypeError('Lifecycle event repository has no usable SQLite connection');
+  }
+  return connection as SqliteConnection;
+}
+
+function snapshotRecord(value: unknown, maxKeys: number): DataRecord | null {
+  return snapshotBoundedPlainDataRecord(value, maxKeys);
+}
+
+function snapshotNativeArray(value: unknown, maxLength: number): unknown[] | null {
+  if (types.isProxy(value) || !Array.isArray(value)) return null;
+  try {
+    if (Reflect.getPrototypeOf(value) !== Array.prototype) return null;
+    const length = Object.getOwnPropertyDescriptor(value, 'length');
+    if (!length || !('value' in length) || !Number.isSafeInteger(length.value)) return null;
+    if (length.value > maxLength) return null;
+    const keys = Reflect.ownKeys(value);
+    if (keys.length !== length.value + 1 || keys.some((key) => typeof key !== 'string')) {
+      return null;
+    }
+    const snapshot: unknown[] = [];
+    for (let index = 0; index < length.value; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      if (!descriptor?.enumerable || !('value' in descriptor)) return null;
+      snapshot.push(descriptor.value);
+    }
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+function parseOptional<T>(
+  value: unknown,
+  parser: { safeParse(candidate: unknown): { success: boolean; data?: T } },
+): T | undefined | null {
+  if (value === undefined) return undefined;
+  const parsed = parser.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+/** Materializes all caller-owned publish data without evaluating accessors. */
+function materializePublishInput(value: unknown): LifecycleEventPublishInput | null {
+  try {
+    const input = snapshotRecord(value, PUBLISH_INPUT_KEYS.size);
+    if (!input || Object.keys(input).some((key) => !PUBLISH_INPUT_KEYS.has(key))) return null;
+    const event = snapshotLifecycleEvent(input.event);
+    const parsedEvent = event && LifecycleEventEnvelopeSchema.safeParse(event);
+    const persona = LifecycleFilterOwnerNameSchema.safeParse(input.persona);
+    const itemOrigin = parseOptional(input.itemOrigin, LifecycleItemOriginSchema);
+    const itemType = parseOptional(input.itemType, LifecycleItemTypeSchema);
+    const channel = parseOptional(input.channel, LifecycleFilterOwnerNameSchema);
+    const messageSource = parseOptional(input.messageSource, LifecycleMessageSourceSchema);
+    const scheduleSource = parseOptional(input.scheduleSource, LifecycleScheduleSourceSchema);
+    if (
+      !parsedEvent?.success ||
+      !persona.success ||
+      itemOrigin === null ||
+      itemType === null ||
+      channel === null ||
+      messageSource === null ||
+      scheduleSource === null
+    ) {
+      return null;
+    }
+    return {
+      event: parsedEvent.data,
+      persona: persona.data,
+      ...(itemOrigin === undefined ? {} : { itemOrigin }),
+      ...(itemType === undefined ? {} : { itemType }),
+      ...(channel === undefined ? {} : { channel }),
+      ...(messageSource === undefined ? {} : { messageSource }),
+      ...(scheduleSource === undefined ? {} : { scheduleSource }),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function materializeEvent(value: unknown): LifecycleEventEnvelope | null {
+  try {
+    const snapshot = snapshotLifecycleEvent(value);
+    const parsed = snapshot && LifecycleEventEnvelopeSchema.safeParse(snapshot);
+    return parsed?.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Materializes bounded resolver output before repository fan-out validation. */
+function materializeResolvedDeliveries(value: unknown): LifecycleDeliveryFanoutInput[] | null {
+  const handlers = snapshotNativeArray(value, MAX_RESOLVED_HANDLERS);
+  if (!handlers) return null;
+  try {
+    const candidates: unknown[] = [];
+    for (const candidate of handlers) {
+      const resolved = snapshotRecord(candidate, 16);
+      const handler = resolved && snapshotRecord(resolved.handler, 16);
+      const identity = resolved && snapshotRecord(resolved.identity, 16);
+      const failurePolicy = resolved && snapshotRecord(resolved.failurePolicy, 4);
+      if (!resolved || !handler || !identity || !failurePolicy) return null;
+      candidates.push({
+        handlerId: handler.id,
+        persona: resolved.persona,
+        priority: resolved.priority,
+        identity,
+        failurePolicy,
+      });
+    }
+    const deliveries = snapshotLifecycleDeliveries(candidates);
+    return deliveries ? (deliveries as unknown as LifecycleDeliveryFanoutInput[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persists a versioned lifecycle event and its stable subscriber snapshot.
+ *
+ * A publication with no subscribers remains a valid durable event. Dispatcher
+ * wake-ups are deferred until a bus-owned SQLite transaction has committed.
+ */
+export class LifecycleEventBus {
+  readonly #transactionOwner = {};
+  readonly #connection: SqliteConnection;
+
+  constructor(
+    private readonly eventRepository: LifecycleEventRepository,
+    private readonly handlerResolver: LifecycleEventHandlerResolver,
+    private readonly wakeDispatcher?: LifecycleDispatcherWake,
+  ) {
+    this.#connection = getRepositoryConnection(eventRepository);
+  }
+
+  /**
+   * Owns SQLite transaction lifecycle and its matching TransactionContext.
+   * Returning Err rolls back SQLite while preserving the callback's typed error.
+   */
+  transaction<T, E>(
+    callback: (transaction: TransactionContext) => Result<T, E>,
+  ): Result<T, LifecycleTransactionError<E>> {
+    try {
+      if (this.#connection.inTransaction) {
+        return err(
+          new LifecycleError(
+            'Cannot start a lifecycle transaction inside an active SQLite transaction',
+          ),
+        );
+      }
+    } catch {
+      return err(new DbError('Failed to inspect lifecycle SQLite transaction state'));
+    }
+
+    const transaction = createOwnedTransactionContext(this.#transactionOwner, this.#connection);
+    let value: T | undefined;
+    try {
+      this.eventRepository.transaction(() => {
+        if (!this.#connection.inTransaction) {
+          throw new DbError('Lifecycle transaction is not running on its bound SQLite connection');
+        }
+        let result: Result<T, E>;
+        try {
+          result = callback(transaction);
+        } catch {
+          throw new DbError('Failed to execute lifecycle transaction');
+        }
+        if (result.isErr()) throw new TransactionRollback(result.error);
+        value = result.value;
+      });
+    } catch (cause) {
+      rollbackOwnedTransactionContext(transaction, this.#transactionOwner, this.#connection);
+      if (cause instanceof TransactionRollback) {
+        return err(cause.error as LifecycleTransactionError<E>);
+      }
+      return err(
+        cause instanceof LifecycleError || cause instanceof DbError
+          ? cause
+          : new DbError('Failed to execute lifecycle transaction'),
+      );
+    }
+
+    commitOwnedTransactionContext(transaction, this.#transactionOwner, this.#connection);
+    return ok(value as T);
+  }
+
+  /** Publishes in a standalone transaction or the active bus-owned transaction. */
+  publish(
+    input: LifecycleEventPublishInput,
+    transaction?: TransactionContext,
+  ): Result<LifecycleEventFanoutResult, LifecycleEventPublishError> {
+    try {
+      if (transaction) return this.publishInTransaction(input, transaction);
+      return this.transaction((context) => this.publishInTransaction(input, context));
+    } catch {
+      return err(new LifecycleError('Failed to publish lifecycle event'));
+    }
+  }
+
+  /**
+   * Validates a supplied derived event against its parent before publication.
+   * Derived events retain aggregate, correlation and max depth, use the parent
+   * event ID as causation, and advance recursion depth exactly once.
+   */
+  publishDerived(
+    parent: LifecycleEventEnvelope,
+    input: LifecycleEventPublishInput,
+    transaction?: TransactionContext,
+  ): Result<LifecycleEventFanoutResult, LifecycleEventPublishError> {
+    try {
+      const parentEvent = materializeEvent(parent);
+      const derived = materializePublishInput(input);
+      if (!parentEvent || !derived) {
+        return err(new LifecycleError('Cannot publish an invalid derived lifecycle event'));
+      }
+      const parentContext = parentEvent.context;
+      const context = derived.event.context;
+      if (
+        parentContext.recursion.depth >= parentContext.recursion.maxDepth ||
+        context.aggregate.type !== parentContext.aggregate.type ||
+        context.aggregate.id !== parentContext.aggregate.id ||
+        context.correlationId !== parentContext.correlationId ||
+        context.recursion.maxDepth !== parentContext.recursion.maxDepth ||
+        context.recursion.depth !== parentContext.recursion.depth + 1 ||
+        context.causationId !== parentEvent.eventId
+      ) {
+        return err(new LifecycleError('Derived lifecycle event has invalid causal context'));
+      }
+      return this.publish(derived, transaction);
+    } catch {
+      return err(new LifecycleError('Failed to publish derived lifecycle event'));
+    }
+  }
+
+  /** Publishes within the currently active transaction owned by this bus. */
+  publishInTransaction(
+    input: LifecycleEventPublishInput,
+    transaction: TransactionContext,
+  ): Result<LifecycleEventFanoutResult, LifecycleEventPublishError> {
+    try {
+      if (
+        !this.#connection.inTransaction ||
+        !getOpenOwnedTransactionContext(transaction, this.#transactionOwner, this.#connection)
+      ) {
+        return err(new LifecycleError('Cannot publish outside this lifecycle transaction'));
+      }
+      const materialized = materializePublishInput(input);
+      if (!materialized) {
+        return err(new LifecycleError('Cannot publish an invalid lifecycle event input'));
+      }
+
+      let handlers: ResolvedLifecycleHandler[];
+      try {
+        handlers = this.handlerResolver.resolveEventHandlers({
+          persona: materialized.persona,
+          eventType: materialized.event.type,
+          itemOrigin: materialized.itemOrigin,
+          itemType: materialized.itemType,
+          channel: materialized.channel,
+          messageSource: materialized.messageSource,
+          scheduleSource: materialized.scheduleSource,
+        });
+      } catch {
+        return err(new LifecycleError('Failed to resolve lifecycle event subscribers'));
+      }
+      const deliveries = materializeResolvedDeliveries(handlers);
+      if (!deliveries) {
+        return err(new LifecycleError('Failed to snapshot lifecycle event subscribers'));
+      }
+
+      const publication = this.eventRepository.insertWithDeliveries(materialized.event, deliveries);
+      if (publication.isErr()) return publication;
+
+      if (publication.value.deliveries.length > 0 && this.wakeDispatcher) {
+        const registered = registerAfterCommit(
+          transaction,
+          this.#transactionOwner,
+          this.#connection,
+          () => this.wakeDispatcher?.(publication.value.event.event_id),
+        );
+        if (registered.isErr()) return err(registered.error);
+      }
+      return ok(publication.value);
+    } catch {
+      return err(new LifecycleError('Failed to publish lifecycle event'));
+    }
+  }
+}

--- a/src/lifecycle/transaction-context.ts
+++ b/src/lifecycle/transaction-context.ts
@@ -1,0 +1,8 @@
+/** Opaque capability passed only to a LifecycleEventBus transaction callback. */
+
+/**
+ * This class deliberately exposes no lifecycle methods. LifecycleEventBus keeps
+ * the authentic context state in a module-private WeakMap, so lookalikes,
+ * proxies, and shadowed properties cannot grant transaction authority.
+ */
+export class TransactionContext {}

--- a/tests/unit/lifecycle/lifecycle-event-bus.test.ts
+++ b/tests/unit/lifecycle/lifecycle-event-bus.test.ts
@@ -1,0 +1,468 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type Database from 'better-sqlite3';
+
+import {
+  BaseRepository,
+  LifecycleDeliveryRepository,
+  LifecycleEventRepository,
+} from '../../../src/core/database/repositories/index.js';
+import type { LifecycleEventEnvelope } from '../../../src/lifecycle/contracts/index.js';
+import type {
+  LifecycleEventResolutionQuery,
+  ResolvedLifecycleHandler,
+} from '../../../src/lifecycle/handler-registry.js';
+import {
+  LifecycleEventBus,
+  type LifecycleDispatcherWake,
+  type LifecycleEventHandlerResolver,
+  type LifecycleEventPublishInput,
+} from '../../../src/lifecycle/lifecycle-event-bus.js';
+import { TransactionContext } from '../../../src/lifecycle/transaction-context.js';
+import { createTestDb, uuid } from '../core/database/repositories/helpers.js';
+
+describe('LifecycleEventBus', () => {
+  let db: Database.Database;
+  let events: LifecycleEventRepository;
+  let deliveries: LifecycleDeliveryRepository;
+  let handlers: ResolvedLifecycleHandler[];
+  let resolver: LifecycleEventHandlerResolver;
+  let wakeDispatcher: ReturnType<typeof vi.fn<LifecycleDispatcherWake>>;
+
+  beforeEach(() => {
+    BaseRepository.__resetMonotonicClockForTests();
+    db = createTestDb();
+    events = new LifecycleEventRepository(db);
+    deliveries = new LifecycleDeliveryRepository(db);
+    handlers = [];
+    resolver = {
+      resolveEventHandlers: (query: LifecycleEventResolutionQuery): ResolvedLifecycleHandler[] => {
+        expect(query).toMatchObject({ persona: 'support', eventType: 'run.completed.v1' });
+        return handlers;
+      },
+    };
+    wakeDispatcher = vi.fn<LifecycleDispatcherWake>();
+  });
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  function event(overrides: Partial<LifecycleEventEnvelope> = {}): LifecycleEventEnvelope {
+    return {
+      version: 'v1',
+      eventId: uuid(),
+      type: 'run.completed.v1',
+      occurredAt: '2026-07-16T10:00:00.000Z',
+      context: {
+        aggregate: { type: 'thread', id: `thread-${uuid()}` },
+        correlationId: uuid(),
+        causationId: uuid(),
+        recursion: { depth: 1, maxDepth: 4 },
+        provenance: { source: 'daemon', sourceEventIds: [uuid()] },
+      },
+      payload: {
+        references: [{ type: 'run', id: uuid() }],
+        metadata: { outcome: 'completed' },
+      },
+      ...overrides,
+    };
+  }
+
+  function handler(handlerId: string, priority: number): ResolvedLifecycleHandler {
+    return {
+      persona: 'support',
+      priority,
+      handler: {
+        id: handlerId,
+        version: 'v1',
+        displayName: handlerId,
+        runtimeKind: 'native',
+        implementationRef: handlerId,
+        implementationVersion: '1.0.0',
+        mode: 'event',
+        inputContract: 'talon.lifecycle.event.envelope.v1',
+        outputContract: 'talon.lifecycle.signal.envelopes.v1',
+      },
+      identity: {
+        version: 'v1',
+        handlerId,
+        runtimeKind: 'native',
+        implementationRef: handlerId,
+        implementationVersion: '1.0.0',
+        mode: 'event',
+        inputContract: 'talon.lifecycle.event.envelope.v1',
+        outputContract: 'talon.lifecycle.signal.envelopes.v1',
+      },
+      subscription: {
+        kind: 'event',
+        events: [{ version: 'v1', type: 'run.completed.v1' }],
+      },
+      failurePolicy: { version: 'v1', mode: 'dead_letter' },
+    };
+  }
+
+  function writeDomainRow(name: string): void {
+    db.prepare(
+      `INSERT INTO channels (id, type, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+    ).run(uuid(), 'terminal', name, Date.now(), Date.now());
+  }
+
+  function domainRowCount(name: string): number {
+    return (
+      db.prepare(`SELECT COUNT(*) AS count FROM channels WHERE name = ?`).get(name) as {
+        count: number;
+      }
+    ).count;
+  }
+
+  function input(eventValue: LifecycleEventEnvelope): LifecycleEventPublishInput {
+    return { event: eventValue, persona: 'support' };
+  }
+
+  it('atomically commits a domain write, event, and stable handler snapshot before waking', () => {
+    handlers = [handler('first-handler', 1), handler('second-handler', 10)];
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const eventValue = event();
+    const domainName = `domain-${uuid()}`;
+
+    const published = bus.transaction((transaction) => {
+      writeDomainRow(domainName);
+      const result = bus.publish(input(eventValue), transaction);
+      expect(wakeDispatcher).not.toHaveBeenCalled();
+      expect((transaction as unknown as { commit?: unknown }).commit).toBeUndefined();
+      return result;
+    });
+
+    expect(published.isOk()).toBe(true);
+    expect(domainRowCount(domainName)).toBe(1);
+    expect(published._unsafeUnwrap().deliveries.map((delivery) => delivery.handler_id)).toEqual([
+      'second-handler',
+      'first-handler',
+    ]);
+    expect(deliveries.findByEventId(eventValue.eventId)._unsafeUnwrap()).toHaveLength(2);
+    expect(wakeDispatcher).toHaveBeenCalledOnce();
+    expect(wakeDispatcher).toHaveBeenCalledWith(eventValue.eventId);
+  });
+
+  it('rolls back a domain write when publication returns Err and preserves the typed Err', () => {
+    handlers = [handler('run-handler', 0)];
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const invalid = event({ payload: { references: [], metadata: { detail: 'x'.repeat(1_025) } } });
+    const domainName = `rollback-${uuid()}`;
+
+    const published = bus.transaction((transaction) => {
+      writeDomainRow(domainName);
+      return bus.publish(input(invalid), transaction);
+    });
+
+    expect(published.isErr()).toBe(true);
+    expect(published._unsafeUnwrapErr().code).toBe('LIFECYCLE_ERROR');
+    expect(domainRowCount(domainName)).toBe(0);
+    expect(events.findById(invalid.eventId)._unsafeUnwrap()).toBeNull();
+    expect(wakeDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the owned transaction when its callback throws', () => {
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const domainName = `throw-${uuid()}`;
+
+    const outcome = bus.transaction(() => {
+      writeDomainRow(domainName);
+      throw new Error('transaction callback failure');
+    });
+
+    expect(outcome.isErr()).toBe(true);
+    expect(outcome._unsafeUnwrapErr().code).toBe('DB_ERROR');
+    expect(domainRowCount(domainName)).toBe(0);
+    expect(wakeDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('rejects a transaction context owned by a different event bus', () => {
+    const owner = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const foreignBus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const inputEvent = event();
+
+    const published = owner.transaction((transaction) =>
+      foreignBus.publish(input(inputEvent), transaction),
+    );
+
+    expect(published.isErr()).toBe(true);
+    expect(published._unsafeUnwrapErr().code).toBe('LIFECYCLE_ERROR');
+    expect(events.findById(inputEvent.eventId)._unsafeUnwrap()).toBeNull();
+  });
+
+  it('does not trust shadowed transaction methods when a foreign bus publishes', () => {
+    const owner = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const foreignBus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const inputEvent = event();
+    const shadowedAfterCommit = vi.fn();
+
+    const published = owner.transaction((transaction) => {
+      Object.assign(transaction, {
+        isOpenFor: () => true,
+        afterCommit: shadowedAfterCommit,
+      });
+      return foreignBus.publish(input(inputEvent), transaction);
+    });
+
+    expect(published.isErr()).toBe(true);
+    expect(shadowedAfterCommit).not.toHaveBeenCalled();
+    expect(events.findById(inputEvent.eventId)._unsafeUnwrap()).toBeNull();
+    expect(wakeDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('rejects proxied and forged transaction contexts without invoking proxy traps', () => {
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const inputEvent = event();
+    const proxyTrap = vi.fn(() => {
+      throw new Error('transaction context proxy trap must not run');
+    });
+    const forged = new TransactionContext();
+
+    expect(bus.publish(input(inputEvent), forged).isErr()).toBe(true);
+    const proxied = bus.transaction((transaction) =>
+      bus.publish(
+        input(inputEvent),
+        new Proxy(transaction, {
+          get: proxyTrap,
+          getOwnPropertyDescriptor: proxyTrap,
+          getPrototypeOf: proxyTrap,
+          ownKeys: proxyTrap,
+        }),
+      ),
+    );
+
+    expect(proxied.isErr()).toBe(true);
+    expect(proxyTrap).not.toHaveBeenCalled();
+    expect(events.findById(inputEvent.eventId)._unsafeUnwrap()).toBeNull();
+  });
+
+  it('rolls back the owner transaction and never writes through a different SQLite connection', () => {
+    const foreignDb = createTestDb();
+    try {
+      handlers = [handler('run-handler', 0)];
+      const owner = new LifecycleEventBus(events, resolver, wakeDispatcher);
+      const foreignEvents = new LifecycleEventRepository(foreignDb);
+      const foreignBus = new LifecycleEventBus(foreignEvents, resolver, wakeDispatcher);
+      const foreignEvent = event();
+      const domainName = `cross-connection-${uuid()}`;
+
+      const published = owner.transaction((transaction) => {
+        writeDomainRow(domainName);
+        return foreignBus.publish(input(foreignEvent), transaction);
+      });
+
+      expect(published.isErr()).toBe(true);
+      expect(domainRowCount(domainName)).toBe(0);
+      expect(foreignEvents.findById(foreignEvent.eventId)._unsafeUnwrap()).toBeNull();
+      expect(wakeDispatcher).not.toHaveBeenCalled();
+    } finally {
+      foreignDb.close();
+    }
+  });
+
+  it('rejects nested lifecycle transactions even if the surrounding SQLite transaction commits', () => {
+    handlers = [handler('run-handler', 0)];
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const inputEvent = event();
+
+    const nested = events.transaction(() =>
+      bus.transaction((transaction) => bus.publish(input(inputEvent), transaction)),
+    );
+
+    expect(nested.isErr()).toBe(true);
+    expect(events.findById(inputEvent.eventId)._unsafeUnwrap()).toBeNull();
+    expect(wakeDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('rejects nested lifecycle transactions when the surrounding SQLite transaction rolls back', () => {
+    handlers = [handler('run-handler', 0)];
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const inputEvent = event();
+
+    expect(() =>
+      events.transaction(() => {
+        const nested = bus.transaction((transaction) =>
+          bus.publish(input(inputEvent), transaction),
+        );
+        expect(nested.isErr()).toBe(true);
+        throw new Error('outer transaction rollback');
+      }),
+    ).toThrow('outer transaction rollback');
+
+    expect(events.findById(inputEvent.eventId)._unsafeUnwrap()).toBeNull();
+    expect(wakeDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('rejects standalone publication inside an existing SQLite transaction', () => {
+    handlers = [handler('run-handler', 0)];
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const inputEvent = event();
+
+    const published = events.transaction(() => bus.publish(input(inputEvent)));
+
+    expect(published.isErr()).toBe(true);
+    expect(events.findById(inputEvent.eventId)._unsafeUnwrap()).toBeNull();
+    expect(wakeDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('preserves causation and recursion metadata through standalone publication', () => {
+    const bus = new LifecycleEventBus(events, resolver);
+    const inputEvent = event();
+
+    expect(bus.publish(input(inputEvent)).isOk()).toBe(true);
+
+    const stored = events.findById(inputEvent.eventId)._unsafeUnwrap();
+    expect(stored?.correlation_id).toBe(inputEvent.context.correlationId);
+    expect(stored?.causation_id).toBe(inputEvent.context.causationId);
+    expect(stored?.recursion_depth).toBe(1);
+    expect(stored?.recursion_max_depth).toBe(4);
+  });
+
+  it('persists a valid event without waking when no subscriber matches', () => {
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const inputEvent = event();
+
+    const published = bus.publish(input(inputEvent));
+
+    expect(published.isOk()).toBe(true);
+    expect(published._unsafeUnwrap().deliveries).toEqual([]);
+    expect(events.findById(inputEvent.eventId)._unsafeUnwrap()).not.toBeNull();
+    expect(wakeDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('contains synchronous and asynchronous wake failures after a successful commit', async () => {
+    handlers = [handler('run-handler', 0)];
+    const syncWake = vi.fn<LifecycleDispatcherWake>(() => {
+      throw new Error('sync wake failure');
+    });
+    const syncBus = new LifecycleEventBus(events, resolver, syncWake);
+    expect(syncBus.publish(input(event())).isOk()).toBe(true);
+    expect(syncWake).toHaveBeenCalledOnce();
+
+    const asyncWake = vi.fn<LifecycleDispatcherWake>(async () => {
+      throw new Error('async wake failure');
+    });
+    const asyncBus = new LifecycleEventBus(events, resolver, asyncWake);
+    expect(asyncBus.publish(input(event())).isOk()).toBe(true);
+    expect(asyncWake).toHaveBeenCalledOnce();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  });
+
+  it('returns typed errors without invoking hostile input accessors or proxy traps', () => {
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const accessorInput = {};
+    Object.defineProperty(accessorInput, 'event', {
+      enumerable: true,
+      get: () => {
+        throw new Error('input accessor must not run');
+      },
+    });
+    Object.defineProperty(accessorInput, 'persona', { enumerable: true, value: 'support' });
+    const proxyTrap = vi.fn(() => {
+      throw new Error('proxy trap must not run');
+    });
+    const hostileInput = new Proxy(
+      {},
+      {
+        get: proxyTrap,
+        getOwnPropertyDescriptor: proxyTrap,
+        getPrototypeOf: proxyTrap,
+        ownKeys: proxyTrap,
+      },
+    );
+
+    expect(bus.publish(accessorInput as LifecycleEventPublishInput).isErr()).toBe(true);
+    expect(bus.publish(hostileInput as LifecycleEventPublishInput).isErr()).toBe(true);
+    expect(proxyTrap).not.toHaveBeenCalled();
+    expect(wakeDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('rejects hostile resolver snapshots without executing proxy traps', () => {
+    const proxyTrap = vi.fn(() => {
+      throw new Error('resolver proxy trap must not run');
+    });
+    resolver = {
+      resolveEventHandlers: () =>
+        new Proxy([], {
+          get: proxyTrap,
+          getOwnPropertyDescriptor: proxyTrap,
+          getPrototypeOf: proxyTrap,
+          ownKeys: proxyTrap,
+        }) as unknown as ResolvedLifecycleHandler[],
+    };
+    const bus = new LifecycleEventBus(events, resolver, wakeDispatcher);
+    const inputEvent = event();
+
+    expect(bus.publish(input(inputEvent)).isErr()).toBe(true);
+    expect(proxyTrap).not.toHaveBeenCalled();
+    expect(events.findById(inputEvent.eventId)._unsafeUnwrap()).toBeNull();
+  });
+
+  it('publishes a derived event only with the parent causal context and exact depth increment', () => {
+    const bus = new LifecycleEventBus(events, resolver);
+    const parent = event();
+    const derived = event({
+      context: {
+        ...parent.context,
+        causationId: parent.eventId,
+        recursion: {
+          depth: parent.context.recursion.depth + 1,
+          maxDepth: parent.context.recursion.maxDepth,
+        },
+      },
+    });
+
+    expect(bus.publishDerived(parent, input(derived)).isOk()).toBe(true);
+    const stored = events.findById(derived.eventId)._unsafeUnwrap();
+    expect(stored).toMatchObject({
+      aggregate_type: parent.context.aggregate.type,
+      aggregate_id: parent.context.aggregate.id,
+      correlation_id: parent.context.correlationId,
+      causation_id: parent.eventId,
+      recursion_depth: parent.context.recursion.depth + 1,
+      recursion_max_depth: parent.context.recursion.maxDepth,
+    });
+  });
+
+  it('rejects reset depth, altered causal fields, and exhausted derived-event depth', () => {
+    const bus = new LifecycleEventBus(events, resolver);
+    const parent = event();
+    const derivedContext = {
+      ...parent.context,
+      causationId: parent.eventId,
+      recursion: {
+        depth: parent.context.recursion.depth + 1,
+        maxDepth: parent.context.recursion.maxDepth,
+      },
+    };
+    const resetDepth = event({
+      context: { ...derivedContext, recursion: { ...derivedContext.recursion, depth: 0 } },
+    });
+    const changedAggregate = event({
+      context: { ...derivedContext, aggregate: { ...derivedContext.aggregate, id: uuid() } },
+    });
+    const changedCorrelation = event({
+      context: { ...derivedContext, correlationId: uuid() },
+    });
+    const changedCausation = event({
+      context: { ...derivedContext, causationId: uuid() },
+    });
+    const exhaustedParent = event({
+      context: { ...parent.context, recursion: { depth: 4, maxDepth: 4 } },
+    });
+    const exhaustedChild = event({
+      context: {
+        ...exhaustedParent.context,
+        causationId: exhaustedParent.eventId,
+        recursion: { depth: 4, maxDepth: 4 },
+      },
+    });
+
+    expect(bus.publishDerived(parent, input(resetDepth)).isErr()).toBe(true);
+    expect(bus.publishDerived(parent, input(changedAggregate)).isErr()).toBe(true);
+    expect(bus.publishDerived(parent, input(changedCorrelation)).isErr()).toBe(true);
+    expect(bus.publishDerived(parent, input(changedCausation)).isErr()).toBe(true);
+    expect(bus.publishDerived(exhaustedParent, input(exhaustedChild)).isErr()).toBe(true);
+  });
+});


### PR DESCRIPTION
Implements WDD TASK-005 transactional lifecycle publication.

- owns SQLite transaction and rollback boundaries
- binds opaque transaction authority to the exact bus and connection
- atomically persists event and subscriber fan-out
- defers dispatcher wakes until commit and preserves derived-event causality
- rejects hostile inputs and nested/external transactions

Verification:
- 43 focused tests passed under Node 24, including 26 real-SQLite repository tests
- build, scoped lint, Prettier, and diff checks passed
- final gpt-5.6-sol/high review 019f6a04-bb9c-7aa0-89f2-c3413c2f30c2 passed C0/H0/M0/L1

The non-blocking Low concerns standalone strict type-check hygiene in the test fixture and is intentionally not remediated under the WDD Low/P3 policy.