### PR TITLE
feat(lifecycle): add durable event dispatcher

### DIFF
--- a/src/core/database/migrations/015-lifecycle-delivery-nonretryable.sql
+++ b/src/core/database/migrations/015-lifecycle-delivery-nonretryable.sql
@@ -1,0 +1,136 @@
+-- Permit a claimed non-retryable execution to terminally dead-letter after
+-- its one consumed attempt, without weakening lease or immutable-row guards.
+
+DROP TRIGGER lifecycle_event_deliveries_guard_initial_insert;
+DROP TRIGGER lifecycle_event_deliveries_reject_replacements;
+DROP TRIGGER lifecycle_event_deliveries_guard_transitions;
+
+CREATE TABLE lifecycle_event_deliveries_new (
+  event_id          TEXT NOT NULL REFERENCES lifecycle_events(event_id) ON DELETE CASCADE,
+  handler_id        TEXT NOT NULL CHECK (typeof(handler_id) = 'text' AND lifecycle_identifier_valid(handler_id)),
+  persona           TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  priority          INTEGER NOT NULL DEFAULT 0 CHECK (typeof(priority) = 'integer' AND priority BETWEEN -1000 AND 1000),
+  handler_identity  TEXT NOT NULL CHECK (typeof(handler_identity) = 'text' AND lifecycle_json_valid_handler_identity(handler_identity, handler_id)),
+  failure_policy    TEXT NOT NULL CHECK (typeof(failure_policy) = 'text' AND lifecycle_json_valid_failure_policy(failure_policy)),
+  status            TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'claimed', 'failed', 'completed', 'dead_letter')),
+  attempts          INTEGER NOT NULL DEFAULT 0 CHECK (typeof(attempts) = 'integer' AND attempts >= 0),
+  max_attempts      INTEGER NOT NULL DEFAULT 3 CHECK (typeof(max_attempts) = 'integer' AND max_attempts BETWEEN 1 AND 100),
+  next_retry_at     INTEGER CHECK (next_retry_at IS NULL OR (typeof(next_retry_at) = 'integer' AND next_retry_at BETWEEN -9007199254740991 AND 9007199254740991)),
+  claim_token       TEXT CHECK (claim_token IS NULL OR (typeof(claim_token) = 'text' AND lifecycle_runtime_id_valid(claim_token))),
+  claim_expires_at  INTEGER CHECK (claim_expires_at IS NULL OR (typeof(claim_expires_at) = 'integer' AND claim_expires_at BETWEEN -9007199254740991 AND 9007199254740991)),
+  last_error        TEXT CHECK (last_error IS NULL OR (typeof(last_error) = 'text' AND lifecycle_json_valid_diagnostic(last_error))),
+  completed_at      INTEGER CHECK (completed_at IS NULL OR (typeof(completed_at) = 'integer' AND completed_at BETWEEN -9007199254740991 AND 9007199254740991)),
+  created_at        INTEGER NOT NULL CHECK (typeof(created_at) = 'integer' AND created_at BETWEEN -9007199254740991 AND 9007199254740991),
+  updated_at        INTEGER NOT NULL CHECK (typeof(updated_at) = 'integer' AND updated_at BETWEEN -9007199254740991 AND 9007199254740991),
+  CHECK (lifecycle_json_valid_delivery_contract(handler_identity, failure_policy, handler_id)),
+  PRIMARY KEY (event_id, handler_id),
+  CHECK (attempts <= max_attempts),
+  CHECK ((status = 'pending' AND attempts = 0 AND next_retry_at IS NULL AND claim_token IS NULL AND claim_expires_at IS NULL AND last_error IS NULL AND completed_at IS NULL) OR (status = 'claimed' AND attempts < max_attempts AND next_retry_at IS NULL AND claim_token IS NOT NULL AND claim_expires_at IS NOT NULL AND last_error IS NULL AND completed_at IS NULL) OR (status = 'failed' AND attempts >= 1 AND attempts < max_attempts AND next_retry_at IS NOT NULL AND claim_token IS NULL AND claim_expires_at IS NULL AND last_error IS NOT NULL AND completed_at IS NULL) OR (status = 'completed' AND attempts < max_attempts AND claim_token IS NULL AND claim_expires_at IS NULL AND next_retry_at IS NULL AND last_error IS NULL AND completed_at IS NOT NULL) OR (status = 'dead_letter' AND attempts >= 1 AND attempts <= max_attempts AND next_retry_at IS NULL AND claim_token IS NULL AND claim_expires_at IS NULL AND last_error IS NOT NULL AND completed_at IS NULL))
+);
+
+INSERT INTO lifecycle_event_deliveries_new (
+  event_id, handler_id, persona, priority, handler_identity, failure_policy,
+  status, attempts, max_attempts, next_retry_at, claim_token, claim_expires_at,
+  last_error, completed_at, created_at, updated_at
+)
+SELECT
+  event_id, handler_id, persona, priority, handler_identity, failure_policy,
+  status, attempts, max_attempts, next_retry_at, claim_token, claim_expires_at,
+  last_error, completed_at, created_at, updated_at
+FROM lifecycle_event_deliveries;
+
+DROP TABLE lifecycle_event_deliveries;
+ALTER TABLE lifecycle_event_deliveries_new RENAME TO lifecycle_event_deliveries;
+
+CREATE INDEX idx_lifecycle_deliveries_ready ON lifecycle_event_deliveries(status, next_retry_at, priority DESC, created_at) WHERE status IN ('pending', 'failed');
+CREATE INDEX idx_lifecycle_deliveries_expired_claims ON lifecycle_event_deliveries(claim_expires_at, priority DESC, created_at) WHERE status = 'claimed' AND claim_expires_at IS NOT NULL;
+CREATE INDEX idx_lifecycle_deliveries_handler_status ON lifecycle_event_deliveries(handler_id, status, created_at);
+
+CREATE TRIGGER lifecycle_event_deliveries_guard_initial_insert
+BEFORE INSERT ON lifecycle_event_deliveries
+FOR EACH ROW
+WHEN NOT (
+  NEW.status IS 'pending'
+  AND NEW.attempts IS 0
+  AND NEW.next_retry_at IS NULL
+  AND NEW.claim_token IS NULL
+  AND NEW.claim_expires_at IS NULL
+  AND NEW.last_error IS NULL
+  AND NEW.completed_at IS NULL
+)
+BEGIN
+  SELECT RAISE(ABORT, 'lifecycle deliveries must be inserted pending');
+END;
+
+CREATE TRIGGER lifecycle_event_deliveries_reject_replacements
+BEFORE INSERT ON lifecycle_event_deliveries
+FOR EACH ROW
+WHEN EXISTS (
+  SELECT 1
+  FROM lifecycle_event_deliveries
+  WHERE event_id IS NEW.event_id AND handler_id IS NEW.handler_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'lifecycle deliveries cannot be replaced');
+END;
+
+CREATE TRIGGER lifecycle_event_deliveries_guard_transitions
+BEFORE UPDATE ON lifecycle_event_deliveries
+FOR EACH ROW
+WHEN NOT (
+  NEW.event_id IS OLD.event_id
+  AND NEW.handler_id IS OLD.handler_id
+  AND NEW.persona IS OLD.persona
+  AND NEW.priority IS OLD.priority
+  AND NEW.handler_identity IS OLD.handler_identity
+  AND NEW.failure_policy IS OLD.failure_policy
+  AND NEW.max_attempts IS OLD.max_attempts
+  AND NEW.created_at IS OLD.created_at
+  AND (
+    (
+      OLD.status IN ('pending', 'failed')
+      AND NEW.status = 'claimed'
+      AND NEW.attempts IS OLD.attempts
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NOT NULL
+      AND NEW.claim_expires_at IS NOT NULL
+      AND NEW.last_error IS NULL
+      AND NEW.completed_at IS OLD.completed_at
+    )
+    OR
+    (
+      OLD.status = 'claimed'
+      AND NEW.status = 'completed'
+      AND NEW.attempts IS OLD.attempts
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IS NULL
+      AND NEW.completed_at IS NOT NULL
+    )
+    OR
+    (
+      OLD.status = 'claimed'
+      AND NEW.status IN ('failed', 'dead_letter')
+      AND NEW.attempts = OLD.attempts + 1
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IS NOT NULL
+      AND NEW.completed_at IS OLD.completed_at
+    )
+    OR
+    (
+      OLD.status IN ('completed', 'dead_letter')
+      AND NEW.status = 'pending'
+      AND NEW.attempts = 0
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IS NULL
+      AND NEW.completed_at IS NULL
+    )
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid lifecycle delivery update');
+END;

--- a/src/core/database/repositories/lifecycle-delivery-repository.ts
+++ b/src/core/database/repositories/lifecycle-delivery-repository.ts
@@ -3,6 +3,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import type Database from 'better-sqlite3';
 import { err, ok, type Result } from 'neverthrow';
+import { types } from 'node:util';
 import { z } from 'zod';
 import {
   LifecycleEventEnvelopeSchema,
@@ -82,6 +83,8 @@ export interface ClaimedLifecycleDelivery {
 
 export interface ClaimLifecycleDeliveryOptions {
   leaseMs: number;
+  /** Handler IDs temporarily unavailable to this dispatcher instance. */
+  excludedHandlerIds?: readonly string[];
 }
 
 /** Trusted clock supplied by repository composition; production defaults to Date.now. */
@@ -137,7 +140,12 @@ export class LifecycleDeliveryRepository extends BaseRepository {
         JOIN lifecycle_events e ON e.event_id = d.event_id
         WHERE d.status IN ('pending', 'failed')
           AND (d.next_retry_at IS NULL OR d.next_retry_at <= @lease_now)
-        AND NOT EXISTS (
+          AND NOT EXISTS (
+            SELECT 1
+            FROM json_each(@excluded_handler_ids) excluded_handler
+            WHERE excluded_handler.value = d.handler_id
+          )
+          AND NOT EXISTS (
           SELECT 1
           FROM lifecycle_event_deliveries previous_delivery
           JOIN lifecycle_events previous_event ON previous_event.event_id = previous_delivery.event_id
@@ -177,9 +185,11 @@ export class LifecycleDeliveryRepository extends BaseRepository {
     `);
     this.failStmt = db.prepare(`
       UPDATE lifecycle_event_deliveries
-      SET status = CASE WHEN attempts + 1 >= max_attempts THEN 'dead_letter' ELSE 'failed' END,
+      SET status = CASE WHEN @retryable = 0 OR attempts + 1 >= max_attempts THEN 'dead_letter' ELSE 'failed' END,
+          -- Every claimed execution consumes exactly one attempt. Non-retryable
+          -- outcomes terminally dead-letter that attempted lease immediately.
           attempts = attempts + 1,
-          next_retry_at = CASE WHEN attempts + 1 >= max_attempts THEN NULL ELSE @next_retry_at END,
+          next_retry_at = CASE WHEN @retryable = 0 OR attempts + 1 >= max_attempts THEN NULL ELSE @next_retry_at END,
           claim_token = NULL, claim_expires_at = NULL, last_error = @last_error,
           updated_at = @write_now
       WHERE event_id = @event_id AND handler_id = @handler_id
@@ -276,6 +286,7 @@ export class LifecycleDeliveryRepository extends BaseRepository {
           write_now: writeNow,
           claim_token: claimToken,
           claim_expires_at: claimExpiresAt,
+          excluded_handler_ids: JSON.stringify(normalizedOptions.excludedHandlerIds),
         }) as LifecycleDeliveryRow | undefined;
         if (!row) {
           return null;
@@ -339,6 +350,7 @@ export class LifecycleDeliveryRepository extends BaseRepository {
     claimToken: string,
     failureDiagnostic: LifecycleFailureDiagnostic,
     nextRetryAt: number,
+    retryable = true,
   ): Result<LifecycleDeliveryRow, DbError> {
     try {
       const diagnosticSnapshot = snapshotLifecycleFailureDiagnostic(failureDiagnostic);
@@ -350,7 +362,8 @@ export class LifecycleDeliveryRepository extends BaseRepository {
         !this.isRuntimeId(eventId) ||
         !this.isIdentifier(handlerId) ||
         !this.isRuntimeId(claimToken) ||
-        !Number.isSafeInteger(nextRetryAt)
+        !Number.isSafeInteger(nextRetryAt) ||
+        typeof retryable !== 'boolean'
       ) {
         return err(
           new DbError(
@@ -365,6 +378,7 @@ export class LifecycleDeliveryRepository extends BaseRepository {
           handler_id: handlerId,
           claim_token: claimToken,
           next_retry_at: nextRetryAt,
+          retryable: retryable ? 1 : 0,
           // Never persist arbitrary handler error text; it may contain prompts,
           // tokens, headers, or other secrets. A parsed contract-owned code is
           // sufficient for retry policy and operator aggregation.
@@ -472,7 +486,38 @@ export class LifecycleDeliveryRepository extends BaseRepository {
     ) {
       return null;
     }
-    return { leaseMs };
+    const excludedHandlerIds = this.normalizeExcludedHandlerIds(snapshot.excludedHandlerIds);
+    if (!excludedHandlerIds) return null;
+    return { leaseMs, excludedHandlerIds };
+  }
+
+  private normalizeExcludedHandlerIds(value: unknown): string[] | null {
+    if (value === undefined) return [];
+    try {
+      if (
+        !Array.isArray(value) ||
+        types.isProxy(value) ||
+        Reflect.getPrototypeOf(value) !== Array.prototype ||
+        value.length > 4_096
+      ) {
+        return null;
+      }
+      const ids: string[] = [];
+      const seen = new Set<string>();
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) return null;
+        const handlerId: unknown = descriptor.value;
+        if (typeof handlerId !== 'string' || !this.isIdentifier(handlerId) || seen.has(handlerId)) {
+          return null;
+        }
+        seen.add(handlerId);
+        ids.push(handlerId);
+      }
+      return ids;
+    } catch {
+      return null;
+    }
   }
 
   /** Lease mutation time is repository-owned, never supplied by a claim caller. */
@@ -712,7 +757,8 @@ export class LifecycleDeliveryRepository extends BaseRepository {
         );
       case 'dead_letter':
         return (
-          row.attempts === row.max_attempts &&
+          row.attempts >= 1 &&
+          row.attempts <= row.max_attempts &&
           row.next_retry_at === null &&
           row.claim_token === null &&
           row.claim_expires_at === null &&

--- a/src/lifecycle/dispatcher-policy.ts
+++ b/src/lifecycle/dispatcher-policy.ts
@@ -1,0 +1,121 @@
+/** Bounded, deterministic scheduling policy for durable lifecycle delivery. */
+
+import { err, ok, type Result } from 'neverthrow';
+import { types } from 'node:util';
+import { LifecycleError } from '../core/errors/index.js';
+
+export interface LifecycleDispatcherPolicy {
+  readonly leaseMs: number;
+  readonly pollIntervalMs: number;
+  readonly maxConcurrency: number;
+  readonly maxConcurrencyPerHandler: number;
+  readonly retryBaseDelayMs: number;
+  readonly retryMaxDelayMs: number;
+  readonly circuitFailureThreshold: number;
+  readonly circuitCooldownMs: number;
+  readonly maxSnapshotHandlers: number;
+  /** A handler must be cancelled before its lease can expire. */
+  readonly handlerTimeoutMs: number;
+  /** Shutdown only waits for the cancellation window, never an unbounded handler. */
+  readonly shutdownTimeoutMs: number;
+}
+
+export type LifecycleDispatcherPolicyInput = Partial<LifecycleDispatcherPolicy>;
+
+export const DEFAULT_LIFECYCLE_DISPATCHER_POLICY: Readonly<LifecycleDispatcherPolicy> =
+  Object.freeze({
+    leaseMs: 30_000,
+    pollIntervalMs: 1_000,
+    maxConcurrency: 8,
+    maxConcurrencyPerHandler: 2,
+    retryBaseDelayMs: 1_000,
+    retryMaxDelayMs: 60_000,
+    circuitFailureThreshold: 5,
+    circuitCooldownMs: 30_000,
+    maxSnapshotHandlers: 64,
+    handlerTimeoutMs: 20_000,
+    shutdownTimeoutMs: 25_000,
+  });
+
+const POSITIVE_LIMITS: Readonly<
+  Record<keyof LifecycleDispatcherPolicy, readonly [number, number]>
+> = Object.freeze({
+  leaseMs: [1, 86_400_000],
+  pollIntervalMs: [1, 86_400_000],
+  maxConcurrency: [1, 256],
+  maxConcurrencyPerHandler: [1, 256],
+  retryBaseDelayMs: [1, 86_400_000],
+  retryMaxDelayMs: [1, 86_400_000],
+  circuitFailureThreshold: [1, 100],
+  circuitCooldownMs: [1, 86_400_000],
+  maxSnapshotHandlers: [1, 256],
+  handlerTimeoutMs: [1, 86_399_999],
+  shutdownTimeoutMs: [1, 86_399_999],
+});
+
+function ownDataInput(input: unknown): Record<string, unknown> | undefined {
+  try {
+    if (
+      input === undefined ||
+      !input ||
+      typeof input !== 'object' ||
+      Array.isArray(input) ||
+      types.isProxy(input) ||
+      Object.getPrototypeOf(input) !== Object.prototype
+    ) {
+      return input === undefined ? {} : undefined;
+    }
+    // Own-key enumeration is bounded before collecting descriptors so a hostile
+    // but non-proxy record cannot force unbounded descriptor materialization.
+    const keys = Reflect.ownKeys(input);
+    if (
+      keys.length > Object.keys(POSITIVE_LIMITS).length ||
+      keys.some((key) => typeof key !== 'string' || !Object.hasOwn(POSITIVE_LIMITS, key))
+    ) {
+      return undefined;
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(input);
+    const snapshot: Record<string, unknown> = {};
+    for (const key of keys) {
+      const descriptor = descriptors[key as string];
+      if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) return undefined;
+      snapshot[key as string] = descriptor.value;
+    }
+    return snapshot;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Result-returning, descriptor-safe policy factory for public composition boundaries. */
+export function createLifecycleDispatcherPolicy(
+  input: LifecycleDispatcherPolicyInput | undefined,
+): Result<LifecycleDispatcherPolicy, LifecycleError> {
+  const supplied = ownDataInput(input);
+  if (!supplied) return err(new LifecycleError('invalid lifecycle dispatcher policy'));
+  const candidate = {
+    ...DEFAULT_LIFECYCLE_DISPATCHER_POLICY,
+    ...supplied,
+  } as Record<keyof LifecycleDispatcherPolicy, number>;
+  for (const [key, [minimum, maximum]] of Object.entries(POSITIVE_LIMITS) as Array<
+    [keyof LifecycleDispatcherPolicy, readonly [number, number]]
+  >) {
+    const value = candidate[key];
+    if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+      return err(new LifecycleError('invalid lifecycle dispatcher policy'));
+    }
+  }
+  if (
+    candidate.retryBaseDelayMs > candidate.retryMaxDelayMs ||
+    candidate.handlerTimeoutMs >= candidate.leaseMs ||
+    candidate.shutdownTimeoutMs >= candidate.leaseMs
+  ) {
+    return err(new LifecycleError('invalid lifecycle dispatcher policy'));
+  }
+  return ok(Object.freeze(candidate as LifecycleDispatcherPolicy));
+}
+
+export function lifecycleRetryDelay(attempts: number, policy: LifecycleDispatcherPolicy): number {
+  const exponent = Math.min(Math.max(attempts, 0), 16);
+  return Math.min(policy.retryBaseDelayMs * 2 ** exponent, policy.retryMaxDelayMs);
+}

--- a/src/lifecycle/handler-executor.ts
+++ b/src/lifecycle/handler-executor.ts
@@ -1,0 +1,417 @@
+/** Executes the immutable implementation identity captured on a durable lifecycle delivery. */
+
+import { err, ok, type Result } from 'neverthrow';
+import { types } from 'node:util';
+import {
+  LifecycleEventEnvelopeSchema,
+  LifecycleHandlerIdentityContractSchema,
+  parseLifecycleHandlerResult,
+  type LifecycleEventEnvelope,
+  type LifecycleHandlerIdentityContract,
+  type LifecycleHandlerResult,
+} from './contracts/index.js';
+import { LifecycleError } from '../core/errors/index.js';
+import type { ClaimedLifecycleDelivery } from '../core/database/repositories/lifecycle-delivery-repository.js';
+
+export interface LifecycleSubagentCapabilityScope {
+  readonly persona: string;
+  readonly capabilities: Readonly<Record<string, unknown>>;
+}
+
+/** This is intentionally token-free: only the dispatcher owns a lease. */
+export interface LifecycleHandlerExecution {
+  readonly event: LifecycleEventEnvelope;
+  readonly identity: LifecycleHandlerIdentityContract;
+  /** Persisted delivery persona, detached from the claim row. */
+  readonly persona: string;
+  readonly idempotencyKey: string;
+  readonly signal: AbortSignal;
+  /** Loader-owned scope is available only to a matching sub-agent capability. */
+  readonly subagentScope?: LifecycleSubagentCapabilityScope;
+}
+
+export type LifecycleRuntimeHandler = (
+  execution: LifecycleHandlerExecution,
+) => Promise<Result<LifecycleHandlerResult, LifecycleError>>;
+
+export interface LifecycleHandlerExecutor {
+  execute(
+    execution: LifecycleHandlerExecution,
+  ): Promise<Result<LifecycleHandlerResult, LifecycleError>>;
+}
+
+export interface LifecycleRuntimeCapability {
+  readonly identity: LifecycleHandlerIdentityContract;
+  readonly handler: LifecycleRuntimeHandler;
+  readonly subagentScope?: LifecycleSubagentCapabilityScope;
+}
+
+export interface CapturedLifecycleHandlerExecutorOptions {
+  /** Bootstrap-owned native capabilities, never configuration-derived refs. */
+  readonly nativeCatalog?: readonly LifecycleRuntimeCapability[];
+  /** Loader-owned sub-agent capabilities with their exact persona scope. */
+  readonly subagentCatalog?: readonly LifecycleRuntimeCapability[];
+}
+
+const MAX_CATALOG_ENTRIES = 256;
+const MAX_SCOPE_NODES = 256;
+const MAX_SCOPE_DEPTH = 12;
+
+interface PlainDataRecord {
+  readonly [key: string]: PlainData;
+}
+
+interface PlainDataArray extends ReadonlyArray<PlainData> {
+  readonly __plainDataArrayBrand?: never;
+}
+
+type PlainData = string | number | boolean | null | PlainDataArray | PlainDataRecord;
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+  if (value instanceof AbortSignal) return value;
+  if (!value || typeof value !== 'object' || seen.has(value)) return value;
+  seen.add(value);
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor && 'value' in descriptor) deepFreeze(descriptor.value, seen);
+  }
+  return Object.freeze(value);
+}
+
+function snapshotPlainData(
+  value: unknown,
+  depth = 0,
+  budget: { nodes: number } = { nodes: 0 },
+): PlainData | undefined {
+  try {
+    if (
+      value === null ||
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      return value;
+    }
+    if (
+      typeof value !== 'object' ||
+      types.isProxy(value) ||
+      depth > MAX_SCOPE_DEPTH ||
+      ++budget.nodes > MAX_SCOPE_NODES
+    ) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      if (Reflect.getPrototypeOf(value) !== Array.prototype || value.length > 128) return undefined;
+      const result: PlainData[] = [];
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) return undefined;
+        const item = snapshotPlainData(descriptor.value, depth + 1, budget);
+        if (item === undefined) return undefined;
+        result.push(item);
+      }
+      return deepFreeze(result);
+    }
+    if (Reflect.getPrototypeOf(value) !== Object.prototype) return undefined;
+    const keys = Reflect.ownKeys(value);
+    if (keys.length > 64 || keys.some((key) => typeof key !== 'string')) return undefined;
+    const result: Record<string, PlainData> = {};
+    for (const key of keys) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) return undefined;
+      const item = snapshotPlainData(descriptor.value, depth + 1, budget);
+      if (item === undefined) return undefined;
+      result[key as string] = item;
+    }
+    return deepFreeze(result);
+  } catch {
+    return undefined;
+  }
+}
+
+function sameIdentity(
+  left: LifecycleHandlerIdentityContract,
+  right: LifecycleHandlerIdentityContract,
+): boolean {
+  return (
+    left.version === right.version &&
+    left.handlerId === right.handlerId &&
+    left.runtimeKind === right.runtimeKind &&
+    left.implementationRef === right.implementationRef &&
+    left.implementationVersion === right.implementationVersion &&
+    left.mode === right.mode &&
+    left.inputContract === right.inputContract &&
+    left.outputContract === right.outputContract &&
+    left.interceptorSafety === right.interceptorSafety
+  );
+}
+
+function materializeCatalog(
+  input: unknown,
+  kind: 'native' | 'subagent',
+): readonly LifecycleRuntimeCapability[] | undefined {
+  try {
+    if (input === undefined) return Object.freeze([]);
+    if (
+      !Array.isArray(input) ||
+      types.isProxy(input) ||
+      Reflect.getPrototypeOf(input) !== Array.prototype ||
+      input.length > MAX_CATALOG_ENTRIES
+    ) {
+      return undefined;
+    }
+    const result: LifecycleRuntimeCapability[] = [];
+    const tuples = new Set<string>();
+    for (let index = 0; index < input.length; index += 1) {
+      const entry = Object.getOwnPropertyDescriptor(input, String(index));
+      if (!entry || !('value' in entry) || !entry.enumerable) return undefined;
+      const candidate: unknown = entry.value;
+      if (
+        !candidate ||
+        typeof candidate !== 'object' ||
+        Array.isArray(candidate) ||
+        types.isProxy(candidate) ||
+        Reflect.getPrototypeOf(candidate) !== Object.prototype
+      ) {
+        return undefined;
+      }
+      const allowed = new Set(['identity', 'handler', 'subagentScope']);
+      const keys = Reflect.ownKeys(candidate);
+      if (
+        keys.length > allowed.size ||
+        keys.some((key) => typeof key !== 'string' || !allowed.has(key))
+      ) {
+        return undefined;
+      }
+      const identityDescriptor = Object.getOwnPropertyDescriptor(candidate, 'identity');
+      const handlerDescriptor = Object.getOwnPropertyDescriptor(candidate, 'handler');
+      const scopeDescriptor = Object.getOwnPropertyDescriptor(candidate, 'subagentScope');
+      if (
+        !identityDescriptor ||
+        !('value' in identityDescriptor) ||
+        !identityDescriptor.enumerable ||
+        !handlerDescriptor ||
+        !('value' in handlerDescriptor) ||
+        !handlerDescriptor.enumerable ||
+        typeof handlerDescriptor.value !== 'function' ||
+        types.isProxy(handlerDescriptor.value) ||
+        (scopeDescriptor && (!('value' in scopeDescriptor) || !scopeDescriptor.enumerable))
+      ) {
+        return undefined;
+      }
+      const identitySnapshot = snapshotPlainData(identityDescriptor.value);
+      const parsedIdentity = LifecycleHandlerIdentityContractSchema.safeParse(identitySnapshot);
+      if (!parsedIdentity.success || parsedIdentity.data.runtimeKind !== kind) return undefined;
+      const scopeSnapshot = scopeDescriptor ? snapshotPlainData(scopeDescriptor.value) : undefined;
+      let scopePersona = '';
+      if (kind === 'subagent') {
+        if (!scopeSnapshot || typeof scopeSnapshot !== 'object' || Array.isArray(scopeSnapshot))
+          return undefined;
+        const scope = scopeSnapshot as Record<string, unknown>;
+        if (
+          typeof scope.persona !== 'string' ||
+          !scope.capabilities ||
+          typeof scope.capabilities !== 'object'
+        ) {
+          return undefined;
+        }
+        scopePersona = scope.persona;
+      } else if (scopeDescriptor) {
+        return undefined;
+      }
+      // Sub-agent authority is attached per persona. The same immutable
+      // implementation identity may safely serve distinct explicit personas,
+      // but may only be registered once for each persona attachment.
+      const tuple =
+        kind === 'subagent'
+          ? `${JSON.stringify(parsedIdentity.data)}\u0000${scopePersona}`
+          : JSON.stringify(parsedIdentity.data);
+      if (tuples.has(tuple)) return undefined;
+      tuples.add(tuple);
+      result.push(
+        deepFreeze({
+          identity: deepFreeze(parsedIdentity.data),
+          handler: handlerDescriptor.value as LifecycleRuntimeHandler,
+          ...(scopeSnapshot
+            ? { subagentScope: scopeSnapshot as unknown as LifecycleSubagentCapabilityScope }
+            : {}),
+        }),
+      );
+    }
+    return deepFreeze(result);
+  } catch {
+    return undefined;
+  }
+}
+
+function materializeCatalogOptions(
+  options: unknown,
+): Readonly<{ nativeCatalog: unknown; subagentCatalog: unknown }> | undefined {
+  try {
+    if (
+      options === undefined ||
+      !options ||
+      typeof options !== 'object' ||
+      Array.isArray(options) ||
+      types.isProxy(options) ||
+      Reflect.getPrototypeOf(options) !== Object.prototype
+    ) {
+      return options === undefined
+        ? Object.freeze({ nativeCatalog: undefined, subagentCatalog: undefined })
+        : undefined;
+    }
+    const keys = Reflect.ownKeys(options);
+    if (
+      keys.length > 2 ||
+      keys.some((key) => key !== 'nativeCatalog' && key !== 'subagentCatalog')
+    ) {
+      return undefined;
+    }
+    const nativeCatalog = Object.getOwnPropertyDescriptor(options, 'nativeCatalog');
+    const subagentCatalog = Object.getOwnPropertyDescriptor(options, 'subagentCatalog');
+    if (
+      (nativeCatalog && !('value' in nativeCatalog)) ||
+      (nativeCatalog && !nativeCatalog.enumerable) ||
+      (subagentCatalog && (!('value' in subagentCatalog) || !subagentCatalog.enumerable))
+    ) {
+      return undefined;
+    }
+    return Object.freeze({
+      nativeCatalog:
+        nativeCatalog && 'value' in nativeCatalog ? (nativeCatalog.value as unknown) : undefined,
+      subagentCatalog:
+        subagentCatalog && 'value' in subagentCatalog
+          ? (subagentCatalog.value as unknown)
+          : undefined,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Native and sub-agent implementations are selected from a one-time immutable
+ * authority catalog. A persisted ref alone can never select a mutable handler.
+ */
+export class CapturedLifecycleHandlerExecutor implements LifecycleHandlerExecutor {
+  private constructor(
+    private readonly nativeCatalog: readonly LifecycleRuntimeCapability[],
+    private readonly subagentCatalog: readonly LifecycleRuntimeCapability[],
+  ) {}
+
+  static create(
+    options: CapturedLifecycleHandlerExecutorOptions = {},
+  ): Result<CapturedLifecycleHandlerExecutor, LifecycleError> {
+    const catalogOptions = materializeCatalogOptions(options);
+    if (!catalogOptions)
+      return err(new LifecycleError('invalid lifecycle runtime capability catalog'));
+    const nativeCatalog = materializeCatalog(catalogOptions.nativeCatalog, 'native');
+    const subagentCatalog = materializeCatalog(catalogOptions.subagentCatalog, 'subagent');
+    if (!nativeCatalog || !subagentCatalog) {
+      return err(new LifecycleError('invalid lifecycle runtime capability catalog'));
+    }
+    return ok(new CapturedLifecycleHandlerExecutor(nativeCatalog, subagentCatalog));
+  }
+
+  async execute(
+    execution: LifecycleHandlerExecution,
+  ): Promise<Result<LifecycleHandlerResult, LifecycleError>> {
+    try {
+      const catalog =
+        execution.identity.runtimeKind === 'native' ? this.nativeCatalog : this.subagentCatalog;
+      const capability = catalog.find(
+        (candidate) =>
+          sameIdentity(candidate.identity, execution.identity) &&
+          (execution.identity.runtimeKind === 'native' ||
+            candidate.subagentScope?.persona === execution.persona),
+      );
+      if (
+        !capability ||
+        (execution.identity.runtimeKind === 'subagent' &&
+          capability.subagentScope?.persona !== execution.persona)
+      ) {
+        return err(new LifecycleError('captured lifecycle handler implementation is unavailable'));
+      }
+      const result = await capability.handler(
+        deepFreeze({
+          ...execution,
+          ...(capability.subagentScope ? { subagentScope: capability.subagentScope } : {}),
+        }),
+      );
+      if (result.isErr()) return result;
+      const parsed = parseLifecycleHandlerResult(
+        {
+          version: execution.identity.version,
+          id: execution.identity.handlerId,
+          mode: execution.identity.mode,
+          inputContract: execution.identity.inputContract,
+          outputContract: execution.identity.outputContract,
+          runtime: {
+            kind: execution.identity.runtimeKind,
+            ref: execution.identity.implementationRef,
+            implementationVersion: execution.identity.implementationVersion,
+          },
+          ...(execution.identity.interceptorSafety
+            ? { interceptorSafety: execution.identity.interceptorSafety }
+            : {}),
+        },
+        execution.event,
+        result.value,
+      );
+      return parsed.success
+        ? ok(parsed.data)
+        : err(new LifecycleError('captured lifecycle handler returned invalid output'));
+    } catch {
+      return err(new LifecycleError('captured lifecycle handler execution failed'));
+    }
+  }
+}
+
+/** Rehydrates and validates detached persisted records before crossing an executor boundary. */
+export function materializeLifecycleHandlerExecution(
+  claim: ClaimedLifecycleDelivery,
+  signal: AbortSignal,
+): Result<LifecycleHandlerExecution, LifecycleError> {
+  try {
+    const identity = LifecycleHandlerIdentityContractSchema.safeParse(
+      JSON.parse(claim.delivery.handler_identity) as unknown,
+    );
+    const provenance = JSON.parse(claim.event.provenance) as unknown;
+    const payload = JSON.parse(claim.event.payload) as unknown;
+    const event = LifecycleEventEnvelopeSchema.safeParse({
+      version: claim.event.version,
+      eventId: claim.event.event_id,
+      type: claim.event.type,
+      occurredAt: claim.event.occurred_at,
+      context: {
+        aggregate: { type: claim.event.aggregate_type, id: claim.event.aggregate_id },
+        correlationId: claim.event.correlation_id,
+        ...(claim.event.causation_id ? { causationId: claim.event.causation_id } : {}),
+        recursion: {
+          depth: claim.event.recursion_depth,
+          maxDepth: claim.event.recursion_max_depth,
+        },
+        provenance,
+      },
+      payload,
+    });
+    if (
+      !identity.success ||
+      !event.success ||
+      identity.data.handlerId !== claim.delivery.handler_id
+    ) {
+      return err(new LifecycleError('persisted lifecycle execution is invalid'));
+    }
+    return ok(
+      deepFreeze({
+        event: deepFreeze(structuredClone(event.data)),
+        identity: deepFreeze(structuredClone(identity.data)),
+        persona: claim.delivery.persona,
+        idempotencyKey: `${claim.delivery.event_id}:${claim.delivery.handler_id}`,
+        signal,
+      }),
+    );
+  } catch {
+    return err(new LifecycleError('persisted lifecycle execution is invalid'));
+  }
+}

--- a/src/lifecycle/lifecycle-dispatcher.ts
+++ b/src/lifecycle/lifecycle-dispatcher.ts
@@ -1,0 +1,637 @@
+/** Independent, durable scheduler for lifecycle handler deliveries. */
+
+import { err, ok, type Result } from 'neverthrow';
+import { types } from 'node:util';
+import { LifecycleError } from '../core/errors/index.js';
+import type {
+  ClaimedLifecycleDelivery,
+  LifecycleDeliveryRepository,
+  LifecycleDeliveryRow,
+} from '../core/database/repositories/lifecycle-delivery-repository.js';
+import {
+  LifecycleFailurePolicyContractSchema,
+  type LifecycleHandlerResult,
+} from './contracts/index.js';
+import {
+  createLifecycleDispatcherPolicy,
+  lifecycleRetryDelay,
+  type LifecycleDispatcherPolicy,
+  type LifecycleDispatcherPolicyInput,
+} from './dispatcher-policy.js';
+import {
+  materializeLifecycleHandlerExecution,
+  type LifecycleHandlerExecutor,
+} from './handler-executor.js';
+
+export interface LifecycleDispatcherClock {
+  now(): number;
+}
+
+export interface LifecycleSignalHandoff {
+  readonly eventId: string;
+  readonly handlerId: string;
+  /** Stable key lets the durable projection boundary de-duplicate crash recovery. */
+  readonly idempotencyKey: string;
+  readonly signals: readonly unknown[];
+}
+
+/** Trusted durable boundary. It must acknowledge idempotently before completion may occur. */
+export interface LifecycleSignalRouter {
+  handoff(handoff: LifecycleSignalHandoff): Promise<Result<void, LifecycleError>>;
+}
+
+export interface LifecycleDispatcherSnapshot {
+  readonly running: boolean;
+  readonly stopping: boolean;
+  readonly inFlight: number;
+  readonly handlers: readonly LifecycleDispatcherHandlerSnapshot[];
+}
+
+export interface LifecycleDispatcherHandlerSnapshot {
+  readonly handlerId: string;
+  readonly inFlight: number;
+  readonly circuit: 'closed' | 'open';
+  readonly openUntil?: number;
+}
+
+export interface LifecycleDispatcherOptions {
+  readonly deliveries: Pick<LifecycleDeliveryRepository, 'claimNext' | 'complete' | 'fail'>;
+  readonly executor: LifecycleHandlerExecutor;
+  readonly signalRouter: LifecycleSignalRouter;
+  readonly policy?: LifecycleDispatcherPolicyInput;
+  readonly clock?: LifecycleDispatcherClock;
+}
+
+interface LifecycleDispatcherAuthority {
+  readonly claimNext: LifecycleDeliveryRepository['claimNext'];
+  readonly complete: LifecycleDeliveryRepository['complete'];
+  readonly fail: LifecycleDeliveryRepository['fail'];
+  readonly execute: LifecycleHandlerExecutor['execute'];
+  readonly handoff: LifecycleSignalRouter['handoff'];
+  readonly now: LifecycleDispatcherClock['now'];
+}
+
+interface HandlerState {
+  inFlight: number;
+  consecutiveFailures: number;
+  openUntil: number;
+}
+
+interface Lease {
+  readonly eventId: string;
+  readonly handlerId: string;
+  readonly claimToken: string;
+}
+
+class InFlightSlot {
+  private pending = 1;
+  private resolveSettled!: () => void;
+  readonly settled = new Promise<void>((resolve) => {
+    this.resolveSettled = resolve;
+  });
+
+  holdExecution(): void {
+    this.pending += 1;
+  }
+
+  release(): void {
+    this.pending -= 1;
+    if (this.pending === 0) this.resolveSettled();
+  }
+}
+
+const FAILURE_EXECUTION = 'handler-execution-failed';
+const FAILURE_INVALID = 'invalid-persisted-execution';
+const FAILURE_RESULT = 'handler-reported-error';
+const FAILURE_TIMEOUT = 'handler-timeout';
+const FAILURE_SIGNAL_HANDOFF = 'signal-handoff-failed';
+const MAX_EXCLUDED_HANDLERS = 4_096;
+
+function resultSignals(result: LifecycleHandlerResult): readonly unknown[] {
+  if (result.outcome === 'error') return [];
+  return result.outputContract === 'talon.lifecycle.signal.envelopes.v1'
+    ? result.signals
+    : result.result.signals;
+}
+
+function failureMode(delivery: LifecycleDeliveryRow): 'dead_letter' | 'preserve_session' {
+  try {
+    const parsed = LifecycleFailurePolicyContractSchema.safeParse(
+      JSON.parse(delivery.failure_policy),
+    );
+    return parsed.success && parsed.data.mode === 'preserve_session'
+      ? 'preserve_session'
+      : 'dead_letter';
+  } catch {
+    return 'dead_letter';
+  }
+}
+
+const MAX_DISPATCHER_OPTION_KEYS = 5;
+const MAX_AUTHORITY_PROTOTYPE_DEPTH = 16;
+
+function boundMethod<T extends (...args: never[]) => unknown>(
+  source: unknown,
+  key: PropertyKey,
+): T | undefined {
+  try {
+    if (!source || typeof source !== 'object' || types.isProxy(source)) return undefined;
+    let current: object | null = source;
+    for (let depth = 0; current && depth <= MAX_AUTHORITY_PROTOTYPE_DEPTH; depth += 1) {
+      if (types.isProxy(current)) return undefined;
+      const descriptor = Object.getOwnPropertyDescriptor(current, key);
+      if (descriptor) {
+        const candidate: unknown = 'value' in descriptor ? descriptor.value : undefined;
+        if (
+          !('value' in descriptor) ||
+          typeof candidate !== 'function' ||
+          types.isProxy(candidate)
+        ) {
+          return undefined;
+        }
+        const callable = candidate as (...args: never[]) => unknown;
+        return Function.prototype.bind.call(callable, source) as T;
+      }
+      const prototype: unknown = Object.getPrototypeOf(current);
+      if (prototype !== null && typeof prototype !== 'object') return undefined;
+      current = prototype;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function materializeDispatcherOptions(
+  input: unknown,
+): Readonly<{ authority: LifecycleDispatcherAuthority; policy: unknown }> | undefined {
+  try {
+    if (
+      !input ||
+      typeof input !== 'object' ||
+      Array.isArray(input) ||
+      types.isProxy(input) ||
+      Object.getPrototypeOf(input) !== Object.prototype
+    ) {
+      return undefined;
+    }
+    // Bound keys before descriptors: this is the public hostile-input fence.
+    const keys = Reflect.ownKeys(input);
+    const allowed = new Set(['deliveries', 'executor', 'signalRouter', 'policy', 'clock']);
+    if (
+      keys.length > MAX_DISPATCHER_OPTION_KEYS ||
+      keys.some((key) => typeof key !== 'string' || !allowed.has(key))
+    ) {
+      return undefined;
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(input);
+    const deliveries = descriptors.deliveries;
+    const executor = descriptors.executor;
+    const signalRouter = descriptors.signalRouter;
+    const policy = descriptors.policy;
+    const clock = descriptors.clock;
+    if (
+      !deliveries ||
+      !('value' in deliveries) ||
+      !deliveries.enumerable ||
+      !executor ||
+      !('value' in executor) ||
+      !executor.enumerable ||
+      !signalRouter ||
+      !('value' in signalRouter) ||
+      !signalRouter.enumerable ||
+      (policy && (!('value' in policy) || !policy.enumerable)) ||
+      (clock && (!('value' in clock) || !clock.enumerable))
+    ) {
+      return undefined;
+    }
+    const deliveriesValue: unknown = deliveries.value;
+    const executorValue: unknown = executor.value;
+    const signalRouterValue: unknown = signalRouter.value;
+    const policyValue: unknown = policy && 'value' in policy ? policy.value : undefined;
+    const clockValue: unknown = clock && 'value' in clock ? clock.value : undefined;
+    const claimNext = boundMethod<LifecycleDeliveryRepository['claimNext']>(
+      deliveriesValue,
+      'claimNext',
+    );
+    const complete = boundMethod<LifecycleDeliveryRepository['complete']>(
+      deliveriesValue,
+      'complete',
+    );
+    const fail = boundMethod<LifecycleDeliveryRepository['fail']>(deliveriesValue, 'fail');
+    const execute = boundMethod<LifecycleHandlerExecutor['execute']>(executorValue, 'execute');
+    const handoff = boundMethod<LifecycleSignalRouter['handoff']>(signalRouterValue, 'handoff');
+    const now = clock ? boundMethod<LifecycleDispatcherClock['now']>(clockValue, 'now') : Date.now;
+    if (!claimNext || !complete || !fail || !execute || !handoff || !now) return undefined;
+    return Object.freeze({
+      authority: Object.freeze({ claimNext, complete, fail, execute, handoff, now }),
+      policy: policyValue,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function safeClaimValue(value: unknown): ClaimedLifecycleDelivery | null | undefined {
+  try {
+    if (value === null) return null;
+    if (!value || typeof value !== 'object' || types.isProxy(value)) return undefined;
+    const keys = Reflect.ownKeys(value);
+    if (keys.length !== 2 || keys.some((key) => key !== 'delivery' && key !== 'event')) {
+      return undefined;
+    }
+    const delivery = Object.getOwnPropertyDescriptor(value, 'delivery');
+    const event = Object.getOwnPropertyDescriptor(value, 'event');
+    if (
+      !delivery ||
+      !('value' in delivery) ||
+      !delivery.enumerable ||
+      !event ||
+      !('value' in event) ||
+      !event.enumerable ||
+      !delivery.value ||
+      typeof delivery.value !== 'object' ||
+      types.isProxy(delivery.value) ||
+      !event.value ||
+      typeof event.value !== 'object' ||
+      types.isProxy(event.value)
+    ) {
+      return undefined;
+    }
+    return value as ClaimedLifecycleDelivery;
+  } catch {
+    return undefined;
+  }
+}
+
+function inspectClaimResult(
+  value: unknown,
+): Result<ClaimedLifecycleDelivery | null, LifecycleError> {
+  try {
+    if (!value || typeof value !== 'object' || types.isProxy(value)) {
+      return err(new LifecycleError('failed to claim lifecycle delivery'));
+    }
+    const isErr = boundMethod<() => unknown>(value, 'isErr');
+    const isOk = boundMethod<() => unknown>(value, 'isOk');
+    if (!isErr || !isOk || isErr() !== false || isOk() !== true) {
+      return err(new LifecycleError('failed to claim lifecycle delivery'));
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, 'value');
+    if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
+      return err(new LifecycleError('failed to claim lifecycle delivery'));
+    }
+    const claim = safeClaimValue(descriptor.value);
+    return claim === undefined
+      ? err(new LifecycleError('failed to claim lifecycle delivery'))
+      : ok(claim);
+  } catch {
+    return err(new LifecycleError('failed to claim lifecycle delivery'));
+  }
+}
+
+function safeClaimHandlerId(claim: ClaimedLifecycleDelivery): string | undefined {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(claim.delivery, 'handler_id');
+    return descriptor && 'value' in descriptor && typeof descriptor.value === 'string'
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Poll/wake dispatcher. Lease tokens remain private to this class; handlers
+ * receive only frozen detached event data and an AbortSignal.
+ */
+export class LifecycleDispatcher {
+  private readonly clock: LifecycleDispatcherClock;
+  private readonly handlers = new Map<string, HandlerState>();
+  private readonly active = new Set<InFlightSlot>();
+  private readonly controllers = new Set<AbortController>();
+  private timer: NodeJS.Timeout | undefined;
+  private running = false;
+  private stopping = false;
+  private draining = false;
+  private wakeRequested = false;
+
+  private constructor(
+    private readonly authority: LifecycleDispatcherAuthority,
+    private readonly policy: LifecycleDispatcherPolicy,
+  ) {
+    this.clock = Object.freeze({ now: authority.now });
+  }
+
+  static create(options: LifecycleDispatcherOptions): Result<LifecycleDispatcher, LifecycleError> {
+    try {
+      const materialized = materializeDispatcherOptions(options);
+      if (!materialized) return err(new LifecycleError('invalid lifecycle dispatcher options'));
+      const policy = createLifecycleDispatcherPolicy(
+        materialized.policy as LifecycleDispatcherPolicyInput,
+      );
+      if (policy.isErr()) return err(policy.error);
+      return ok(new LifecycleDispatcher(materialized.authority, policy.value));
+    } catch {
+      return err(new LifecycleError('invalid lifecycle dispatcher options'));
+    }
+  }
+
+  start(): void {
+    if (this.running || this.stopping) return;
+    this.running = true;
+    this.wake();
+  }
+
+  wake(): void {
+    if (!this.running || this.stopping) return;
+    if (this.draining) {
+      this.wakeRequested = true;
+      return;
+    }
+    this.draining = true;
+    void this.drain().finally(() => {
+      this.draining = false;
+      if (this.running && !this.stopping) {
+        if (this.wakeRequested) {
+          this.wakeRequested = false;
+          this.wake();
+        } else {
+          this.schedulePoll();
+        }
+      }
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    this.stopping = true;
+    this.wakeRequested = false;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+    for (const controller of this.controllers) controller.abort();
+    let shutdownTimer: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        Promise.allSettled([...this.active].map((slot) => slot.settled)).then(() => undefined),
+        new Promise<void>((resolve) => {
+          shutdownTimer = setTimeout(resolve, this.policy.shutdownTimeoutMs);
+        }),
+      ]);
+    } finally {
+      if (shutdownTimer) clearTimeout(shutdownTimer);
+      this.stopping = false;
+    }
+  }
+
+  snapshot(): LifecycleDispatcherSnapshot {
+    const now = this.clock.now();
+    this.pruneHandlerStates(now);
+    const handlers = [...this.handlers.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .slice(0, this.policy.maxSnapshotHandlers)
+      .map(([handlerId, state]) =>
+        Object.freeze({
+          handlerId,
+          inFlight: state.inFlight,
+          circuit: state.openUntil > now ? ('open' as const) : ('closed' as const),
+          ...(state.openUntil > now ? { openUntil: state.openUntil } : {}),
+        }),
+      );
+    return Object.freeze({
+      running: this.running,
+      stopping: this.stopping,
+      inFlight: this.active.size,
+      handlers: Object.freeze(handlers),
+    });
+  }
+
+  dispatchOnce(): Promise<Result<boolean, LifecycleError>> {
+    if (this.stopping || this.active.size >= this.policy.maxConcurrency) {
+      return Promise.resolve(ok(false));
+    }
+    const excludedHandlerIds = this.excludedHandlerIds();
+    let rawClaim: unknown;
+    try {
+      rawClaim = this.authority.claimNext({
+        leaseMs: this.policy.leaseMs,
+        ...(excludedHandlerIds.length > 0 ? { excludedHandlerIds } : {}),
+      });
+    } catch {
+      return Promise.resolve(err(new LifecycleError('failed to claim lifecycle delivery')));
+    }
+    const claim = inspectClaimResult(rawClaim);
+    if (claim.isErr())
+      return Promise.resolve(err(new LifecycleError('failed to claim lifecycle delivery')));
+    if (!claim.value) return Promise.resolve(ok(false));
+    const handlerId = safeClaimHandlerId(claim.value);
+    if (!handlerId)
+      return Promise.resolve(err(new LifecycleError('failed to claim lifecycle delivery')));
+    const state = this.handlerState(handlerId);
+    const controller = new AbortController();
+    const slot = new InFlightSlot();
+    this.active.add(slot);
+    this.controllers.add(controller);
+    state.inFlight += 1;
+    void slot.settled.then(() => {
+      state.inFlight -= 1;
+      this.active.delete(slot);
+      this.controllers.delete(controller);
+      if (this.running && !this.stopping) this.wake();
+    });
+    void this.executeClaim(claim.value, handlerId, controller, slot);
+    return Promise.resolve(ok(true));
+  }
+
+  private async drain(): Promise<void> {
+    do {
+      this.wakeRequested = false;
+      while (!this.stopping && this.active.size < this.policy.maxConcurrency) {
+        const dispatched = await this.dispatchOnce();
+        if (dispatched.isErr() || !dispatched.value) break;
+      }
+    } while (!this.stopping && this.wakeRequested && this.active.size < this.policy.maxConcurrency);
+  }
+
+  private async executeClaim(
+    claim: ClaimedLifecycleDelivery,
+    handlerId: string,
+    controller: AbortController,
+    slot: InFlightSlot,
+  ): Promise<void> {
+    let lease: Lease | undefined;
+    try {
+      lease = this.lease(claim.delivery);
+      if (!lease) return;
+      const execution = materializeLifecycleHandlerExecution(claim, controller.signal);
+      if (execution.isErr()) {
+        this.transitionFailure(claim.delivery, lease, FAILURE_INVALID, true);
+        this.recordFailure(handlerId);
+        return;
+      }
+      const result = await this.executeBounded(execution.value, controller, slot);
+      if (result.isErr()) {
+        this.transitionFailure(
+          claim.delivery,
+          lease,
+          controller.signal.aborted ? FAILURE_TIMEOUT : FAILURE_EXECUTION,
+          true,
+        );
+        this.recordFailure(handlerId);
+        return;
+      }
+      if (result.value.outcome === 'error') {
+        this.transitionFailure(claim.delivery, lease, FAILURE_RESULT, result.value.retryable);
+        this.recordFailure(handlerId);
+        return;
+      }
+      const handoff = await this.authority.handoff({
+        eventId: lease.eventId,
+        handlerId: lease.handlerId,
+        idempotencyKey: execution.value.idempotencyKey,
+        signals: resultSignals(result.value),
+      });
+      if (handoff.isErr()) {
+        this.transitionFailure(claim.delivery, lease, FAILURE_SIGNAL_HANDOFF, true);
+        this.recordFailure(handlerId);
+        return;
+      }
+      // Handoff precedes completion. If we crash here, the next lease retries
+      // the same stable handoff key and the trusted boundary de-duplicates it.
+      const completed = this.authority.complete(lease.eventId, lease.handlerId, lease.claimToken);
+      if (completed.isOk()) this.recordSuccess(handlerId);
+    } catch {
+      if (lease) this.transitionFailure(claim.delivery, lease, FAILURE_EXECUTION, true);
+      this.recordFailure(handlerId);
+    } finally {
+      slot.release();
+    }
+  }
+
+  private async executeBounded(
+    execution: Parameters<LifecycleHandlerExecutor['execute']>[0],
+    controller: AbortController,
+    slot: InFlightSlot,
+  ): Promise<Result<LifecycleHandlerResult, LifecycleError>> {
+    let timeout: NodeJS.Timeout | undefined;
+    const cancelled = new Promise<Result<LifecycleHandlerResult, LifecycleError>>((resolve) => {
+      controller.signal.addEventListener(
+        'abort',
+        () => resolve(err(new LifecycleError('lifecycle handler cancelled'))),
+        { once: true },
+      );
+    });
+    const deadline = new Promise<Result<LifecycleHandlerResult, LifecycleError>>((resolve) => {
+      timeout = setTimeout(() => {
+        controller.abort();
+        resolve(err(new LifecycleError('lifecycle handler deadline exceeded')));
+      }, this.policy.handlerTimeoutMs);
+      timeout.unref();
+    });
+    let underlying: Promise<Result<LifecycleHandlerResult, LifecycleError>>;
+    try {
+      slot.holdExecution();
+      underlying = Promise.resolve(this.authority.execute(execution));
+    } catch {
+      slot.release();
+      return err(new LifecycleError('lifecycle handler execution failed'));
+    }
+    // The deadline race is deliberately not the execution lifetime. A handler
+    // that ignores cancellation still occupies its capacity until its actual
+    // promise settles; this handler absorbs any late resolve/reject.
+    void underlying.then(
+      () => slot.release(),
+      () => slot.release(),
+    );
+    try {
+      return await Promise.race([underlying, deadline, cancelled]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+
+  private transitionFailure(
+    delivery: LifecycleDeliveryRow,
+    lease: Lease,
+    code: string,
+    retryable: boolean,
+  ): void {
+    const preserveSession = failureMode(delivery) === 'preserve_session';
+    const terminal = !retryable || delivery.attempts + 1 >= delivery.max_attempts;
+    if (preserveSession && terminal) {
+      this.authority.complete(lease.eventId, lease.handlerId, lease.claimToken);
+      return;
+    }
+    const nextRetryAt = this.clock.now() + lifecycleRetryDelay(delivery.attempts, this.policy);
+    this.authority.fail(
+      lease.eventId,
+      lease.handlerId,
+      lease.claimToken,
+      { code },
+      nextRetryAt,
+      retryable,
+    );
+  }
+
+  private lease(delivery: LifecycleDeliveryRow): Lease | undefined {
+    return delivery.claim_token
+      ? Object.freeze({
+          eventId: delivery.event_id,
+          handlerId: delivery.handler_id,
+          claimToken: delivery.claim_token,
+        })
+      : undefined;
+  }
+
+  private excludedHandlerIds(): string[] {
+    const now = this.clock.now();
+    this.pruneHandlerStates(now);
+    const excluded: string[] = [];
+    for (const [handlerId, state] of this.handlers) {
+      if (state.inFlight >= this.policy.maxConcurrencyPerHandler || state.openUntil > now) {
+        excluded.push(handlerId);
+      }
+    }
+    // Busy handlers are globally bounded and cooling circuits are pruned only
+    // after expiry, so this cannot silently make an excluded handler eligible.
+    return excluded.slice(0, MAX_EXCLUDED_HANDLERS);
+  }
+
+  private pruneHandlerStates(now: number): void {
+    for (const [handlerId, state] of this.handlers) {
+      if (state.inFlight === 0 && state.openUntil <= now && state.consecutiveFailures === 0) {
+        this.handlers.delete(handlerId);
+      }
+    }
+  }
+
+  private handlerState(handlerId: string): HandlerState {
+    const existing = this.handlers.get(handlerId);
+    if (existing) return existing;
+    const state: HandlerState = { inFlight: 0, consecutiveFailures: 0, openUntil: 0 };
+    this.handlers.set(handlerId, state);
+    return state;
+  }
+
+  private recordSuccess(handlerId: string): void {
+    const state = this.handlerState(handlerId);
+    state.consecutiveFailures = 0;
+    state.openUntil = 0;
+  }
+
+  private recordFailure(handlerId: string): void {
+    const state = this.handlerState(handlerId);
+    state.consecutiveFailures += 1;
+    if (state.consecutiveFailures >= this.policy.circuitFailureThreshold) {
+      state.openUntil = this.clock.now() + this.policy.circuitCooldownMs;
+    }
+  }
+
+  private schedulePoll(): void {
+    if (this.timer || this.stopping) return;
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.wake();
+    }, this.policy.pollIntervalMs);
+    this.timer.unref();
+  }
+}

--- a/tests/unit/core/database/migrations/runner.test.ts
+++ b/tests/unit/core/database/migrations/runner.test.ts
@@ -169,8 +169,8 @@ describe('runMigrations', () => {
     expect(db.pragma('user_version', { simple: true })).toBe(13);
 
     const upgrade = runMigrations(db, realMigrationsDir);
-    expect(upgrade._unsafeUnwrap()).toBe(1);
-    expect(db.pragma('user_version', { simple: true })).toBe(14);
+    expect(upgrade._unsafeUnwrap()).toBe(2);
+    expect(db.pragma('user_version', { simple: true })).toBe(15);
     for (const table of ['lifecycle_events', 'lifecycle_event_deliveries']) {
       expect(
         db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`).get(table),
@@ -185,6 +185,7 @@ describe('runMigrations', () => {
       expect.arrayContaining([
         expect.objectContaining({ name: 'idx_lifecycle_deliveries_ready', partial: 1 }),
         expect.objectContaining({ name: 'idx_lifecycle_deliveries_expired_claims', partial: 1 }),
+        expect.objectContaining({ name: 'idx_lifecycle_deliveries_handler_status', partial: 0 }),
       ]),
     );
     const expiredColumns = db
@@ -195,6 +196,31 @@ describe('runMigrations', () => {
       'priority',
       'created_at',
     ]);
+    const triggers = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'lifecycle_event_deliveries'`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(triggers.map((trigger) => trigger.name)).toEqual(
+      expect.arrayContaining([
+        'lifecycle_event_deliveries_guard_initial_insert',
+        'lifecycle_event_deliveries_reject_replacements',
+        'lifecycle_event_deliveries_guard_transitions',
+      ]),
+    );
+    const foreignKeys = db
+      .prepare(`PRAGMA foreign_key_list('lifecycle_event_deliveries')`)
+      .all() as Array<{ table: string; from: string; to: string; on_delete: string }>;
+    expect(foreignKeys).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: 'lifecycle_events',
+          from: 'event_id',
+          to: 'event_id',
+          on_delete: 'CASCADE',
+        }),
+      ]),
+    );
 
     db.prepare(
       `INSERT INTO lifecycle_events (
@@ -361,6 +387,66 @@ describe('runMigrations', () => {
         interceptorSafety: 'advisory',
         ...overrides,
       });
+    // A database already at v14 receives only the additive rebuild. Its valid
+    // durable rows must survive while the rebuilt indexes, foreign key, and
+    // transition triggers remain present.
+    const v14Dir = makeTmpDir();
+    for (const file of readdirSync(realMigrationsDir)) {
+      if (file.endsWith('.sql') && Number.parseInt(file, 10) <= 14) {
+        copyFileSync(join(realMigrationsDir, file), join(v14Dir, file));
+      }
+    }
+    const preservedDb = freshDb();
+    try {
+      expect(runMigrations(preservedDb, legacyDir)._unsafeUnwrap()).toBeGreaterThan(0);
+      expect(runMigrations(preservedDb, v14Dir)._unsafeUnwrap()).toBe(1);
+      expect(preservedDb.pragma('user_version', { simple: true })).toBe(14);
+      preservedDb
+        .prepare(
+          `INSERT INTO lifecycle_events (
+            event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+            causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+            occurred_at, created_at
+          ) VALUES ('preserved-event', 'v1', 'run.completed.v1', 'thread', 'preserved-thread',
+            'preserved-correlation', NULL, 0, 1,
+            '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}',
+            '{"references":[],"metadata":{}}', '2026-07-16T10:00:00.000Z', 1)`,
+        )
+        .run();
+      preservedDb
+        .prepare(
+          `INSERT INTO lifecycle_event_deliveries (
+            event_id, handler_id, persona, priority, handler_identity, failure_policy,
+            status, attempts, max_attempts, created_at, updated_at
+          ) VALUES ('preserved-event', 'preserved-handler', 'support', 0, ?,
+            '{"version":"v1","mode":"dead_letter"}', 'pending', 0, 3, 1, 1)`,
+        )
+        .run(identityFor('preserved-handler'));
+
+      expect(runMigrations(preservedDb, realMigrationsDir)._unsafeUnwrap()).toBe(1);
+      expect(preservedDb.pragma('user_version', { simple: true })).toBe(15);
+      expect(
+        preservedDb
+          .prepare(
+            `SELECT status, attempts, max_attempts FROM lifecycle_event_deliveries
+             WHERE event_id = 'preserved-event' AND handler_id = 'preserved-handler'`,
+          )
+          .get(),
+      ).toEqual({ status: 'pending', attempts: 0, max_attempts: 3 });
+      expect(
+        preservedDb
+          .prepare(
+            `SELECT name FROM sqlite_master WHERE type = 'trigger'
+             AND name = 'lifecycle_event_deliveries_guard_transitions'`,
+          )
+          .get(),
+      ).toBeDefined();
+      expect(
+        preservedDb.prepare(`PRAGMA foreign_key_list('lifecycle_event_deliveries')`).all(),
+      ).toEqual(expect.arrayContaining([expect.objectContaining({ table: 'lifecycle_events' })]));
+    } finally {
+      preservedDb.close();
+    }
     for (const [handlerId, identity] of [
       [
         'handler-advisory-enforcing-output',

--- a/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
+++ b/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Database from 'better-sqlite3';
-import { mkdtempSync } from 'node:fs';
+import { copyFileSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -84,6 +85,30 @@ describe('lifecycle event persistence', () => {
       throw result.error;
     }
     return fileDb;
+  }
+
+  function committedV14Migrations(): string {
+    const currentMigrations = join(
+      import.meta.dirname,
+      '../../../../../src/core/database/migrations',
+    );
+    const legacyMigrations = mkdtempSync(join(tmpdir(), 'talon-lifecycle-v14-'));
+    for (const file of readdirSync(currentMigrations)) {
+      const version = Number.parseInt(file.slice(0, 3), 10);
+      if (Number.isSafeInteger(version) && version <= 13) {
+        copyFileSync(join(currentMigrations, file), join(legacyMigrations, file));
+      }
+    }
+    const baseMigration = execFileSync(
+      'git',
+      ['show', 'fbe4f08:src/core/database/migrations/014-lifecycle-events.sql'],
+      {
+        cwd: join(import.meta.dirname, '../../../../../'),
+        encoding: 'utf8',
+      },
+    );
+    writeFileSync(join(legacyMigrations, '014-lifecycle-events.sql'), baseMigration);
+    return legacyMigrations;
   }
 
   function withIgnoredCheckConstraints(operation: () => void): void {
@@ -386,6 +411,44 @@ describe('lifecycle event persistence', () => {
     leaseNow = now + 102;
     const secondClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap();
     expect(secondClaim?.delivery.event_id).toBe(second.eventId);
+  });
+
+  it('skips dispatcher-excluded handlers without consuming an attempt', () => {
+    const first = event();
+    const second = event();
+    events.insertWithDeliveries(first, [delivery('busy-handler')])._unsafeUnwrap();
+    events.insertWithDeliveries(second, [delivery('available-handler')])._unsafeUnwrap();
+
+    const claim = deliveries
+      .claimNext({ leaseMs: 100, excludedHandlerIds: ['busy-handler'] })
+      ._unsafeUnwrap();
+
+    expect(claim?.delivery.handler_id).toBe('available-handler');
+    expect(deliveries.findByKey(first.eventId, 'busy-handler')._unsafeUnwrap()).toMatchObject({
+      status: 'pending',
+      attempts: 0,
+    });
+  });
+
+  it('accepts bounded exclusions beyond 256 so a healthy delivery is not stalled', () => {
+    const blocked = event();
+    const healthy = event();
+    events.insertWithDeliveries(blocked, [delivery('busy-handler')])._unsafeUnwrap();
+    events.insertWithDeliveries(healthy, [delivery('available-handler')])._unsafeUnwrap();
+    const excluded = [
+      'busy-handler',
+      ...Array.from({ length: 257 }, (_, index) => `other-handler-${index}`),
+    ];
+
+    const claim = deliveries
+      .claimNext({ leaseMs: 100, excludedHandlerIds: excluded })
+      ._unsafeUnwrap();
+
+    expect(claim?.delivery.handler_id).toBe('available-handler');
+    expect(deliveries.findByKey(blocked.eventId, 'busy-handler')._unsafeUnwrap()).toMatchObject({
+      status: 'pending',
+      attempts: 0,
+    });
   });
 
   it('does not let a public claim timestamp expire another active lease', () => {
@@ -754,6 +817,85 @@ describe('lifecycle event persistence', () => {
     expect(deliveries.findByEventId(input.eventId)._unsafeUnwrap()).toHaveLength(1);
   });
 
+  it('moves a non-retryable failure directly to dead letter under its current lease', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const input = event();
+    events.insertWithDeliveries(input, [{ ...delivery(), maxAttempts: 3 }])._unsafeUnwrap();
+    const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+
+    const terminalResult = deliveries.fail(
+      input.eventId,
+      'run-projector',
+      claim.delivery.claim_token!,
+      { code: 'permanent-failure' },
+      now + 500,
+      false,
+    );
+    expect(terminalResult.isOk()).toBe(true);
+    const terminal = terminalResult._unsafeUnwrap();
+
+    expect(terminal).toMatchObject({
+      status: 'dead_letter',
+      attempts: 1,
+      max_attempts: 3,
+      next_retry_at: null,
+      claim_token: null,
+      last_error: '{"code":"permanent-failure"}',
+    });
+  });
+
+  it('upgrades a committed v14 database before terminally dead-lettering a non-retryable lease', () => {
+    const dbPath = join(mkdtempSync(join(tmpdir(), 'talon-lifecycle-v14-db-')), 'talon.sqlite');
+    const legacyDb = new Database(dbPath);
+    legacyDb.pragma('foreign_keys = ON');
+    let upgradeLeaseNow = 1_800_000_000_000;
+    try {
+      expect(runMigrations(legacyDb, committedV14Migrations())._unsafeUnwrap()).toBe(15);
+      expect(legacyDb.pragma('user_version', { simple: true })).toBe(14);
+      const legacyEvents = new LifecycleEventRepository(legacyDb);
+      const legacyDeliveries = new LifecycleDeliveryRepository(legacyDb, () => upgradeLeaseNow);
+      const input = event();
+      legacyEvents.insertWithDeliveries(input, [{ ...delivery(), maxAttempts: 3 }])._unsafeUnwrap();
+      const lease = legacyDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+
+      const currentMigrations = join(
+        import.meta.dirname,
+        '../../../../../src/core/database/migrations',
+      );
+      expect(runMigrations(legacyDb, currentMigrations)._unsafeUnwrap()).toBe(1);
+      expect(legacyDb.pragma('user_version', { simple: true })).toBe(15);
+      const upgradedDeliveries = new LifecycleDeliveryRepository(legacyDb, () => upgradeLeaseNow);
+      const terminal = upgradedDeliveries
+        .fail(
+          input.eventId,
+          'run-projector',
+          lease.delivery.claim_token!,
+          { code: 'permanent-failure' },
+          upgradeLeaseNow + 500,
+          false,
+        )
+        ._unsafeUnwrap();
+
+      expect(terminal).toMatchObject({
+        status: 'dead_letter',
+        attempts: 1,
+        max_attempts: 3,
+        claim_token: null,
+        claim_expires_at: null,
+        next_retry_at: null,
+      });
+      expect(
+        upgradedDeliveries.reopen(input.eventId, 'run-projector')._unsafeUnwrap(),
+      ).toMatchObject({
+        status: 'pending',
+        attempts: 0,
+      });
+    } finally {
+      legacyDb.close();
+    }
+  });
+
   it('returns Result errors for invalid and hostile public inputs without throwing', () => {
     const hostile = new Proxy(
       {},
@@ -973,7 +1115,7 @@ describe('lifecycle event persistence', () => {
       },
       {
         status: 'dead_letter',
-        attempts: 1,
+        attempts: 0,
         nextRetryAt: null,
         claimToken: null,
         claimExpiresAt: null,

--- a/tests/unit/lifecycle/lifecycle-dispatcher.test.ts
+++ b/tests/unit/lifecycle/lifecycle-dispatcher.test.ts
@@ -1,0 +1,784 @@
+import { describe, expect, it, vi } from 'vitest';
+import { err, ok, type Result } from 'neverthrow';
+import { LifecycleError } from '../../../src/core/errors/index.js';
+import type {
+  ClaimedLifecycleDelivery,
+  LifecycleDeliveryRow,
+} from '../../../src/core/database/repositories/lifecycle-delivery-repository.js';
+import {
+  CapturedLifecycleHandlerExecutor,
+  type LifecycleHandlerExecutor,
+} from '../../../src/lifecycle/handler-executor.js';
+import { LifecycleDispatcher } from '../../../src/lifecycle/lifecycle-dispatcher.js';
+import { createLifecycleDispatcherPolicy } from '../../../src/lifecycle/dispatcher-policy.js';
+
+function claim(
+  handlerId = 'projector',
+  eventId = `event-${handlerId}`,
+  overrides: Partial<LifecycleDeliveryRow> = {},
+): ClaimedLifecycleDelivery {
+  return {
+    delivery: {
+      event_id: eventId,
+      handler_id: handlerId,
+      persona: 'assistant',
+      priority: 0,
+      handler_identity: JSON.stringify({
+        version: 'v1',
+        handlerId,
+        runtimeKind: 'native',
+        implementationRef: handlerId,
+        implementationVersion: '1.0.0',
+        mode: 'event',
+        inputContract: 'talon.lifecycle.event.envelope.v1',
+        outputContract: 'talon.lifecycle.signal.envelopes.v1',
+      }),
+      failure_policy: JSON.stringify({ version: 'v1', mode: 'dead_letter' }),
+      status: 'claimed',
+      attempts: 0,
+      max_attempts: 3,
+      next_retry_at: null,
+      claim_token: `claim-${eventId}`,
+      claim_expires_at: 100_000,
+      last_error: null,
+      completed_at: null,
+      created_at: 1,
+      updated_at: 1,
+      ...overrides,
+    },
+    event: {
+      event_sequence: 1,
+      event_id: eventId,
+      version: 'v1',
+      type: 'message.persisted.v1',
+      aggregate_type: 'thread',
+      aggregate_id: 'thread-1',
+      correlation_id: 'correlation-1',
+      causation_id: null,
+      recursion_depth: 0,
+      recursion_max_depth: 4,
+      provenance: JSON.stringify({ source: 'test' }),
+      payload: JSON.stringify({ references: [], metadata: {} }),
+      occurred_at: '2026-07-16T12:00:00.000Z',
+      created_at: 1,
+    },
+  };
+}
+
+function success() {
+  return ok({
+    outcome: 'success' as const,
+    outputContract: 'talon.lifecycle.signal.envelopes.v1' as const,
+    signals: [],
+  });
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+class FakeDeliveries {
+  readonly complete = vi.fn(() => ok({} as LifecycleDeliveryRow));
+  readonly fail = vi.fn(() => ok({} as LifecycleDeliveryRow));
+  readonly claimNext = vi.fn();
+}
+
+class FakeSignals {
+  readonly handoff = vi.fn(async () => ok(undefined));
+}
+
+function dispatcher(
+  deliveries: FakeDeliveries,
+  executor: LifecycleHandlerExecutor,
+  overrides: ConstructorParameters<typeof LifecycleDispatcher>[0]['policy'] = {},
+  signals = new FakeSignals(),
+) {
+  return LifecycleDispatcher.create({
+    deliveries,
+    executor,
+    signalRouter: signals,
+    clock: { now: () => 1_000 },
+    policy: { pollIntervalMs: 86_400_000, ...overrides },
+  })._unsafeUnwrap();
+}
+
+describe('LifecycleDispatcher', () => {
+  it('executes the immutable delivery identity and completes its matching lease once', async () => {
+    const deliveries = new FakeDeliveries();
+    const signals = new FakeSignals();
+    deliveries.claimNext.mockReturnValueOnce(ok(claim()));
+    const executor: LifecycleHandlerExecutor = {
+      execute: vi.fn(async (execution) => {
+        expect(execution.idempotencyKey).toBe('event-projector:projector');
+        expect(execution.identity.implementationVersion).toBe('1.0.0');
+        expect('claim' in execution).toBe(false);
+        expect(Object.isFrozen(execution.event)).toBe(true);
+        return success();
+      }),
+    };
+    const subject = dispatcher(deliveries, executor, {}, signals);
+
+    await expect(subject.dispatchOnce()).resolves.toMatchObject({ value: true });
+    await subject.stop();
+
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+    expect(deliveries.complete).toHaveBeenCalledWith(
+      'event-projector',
+      'projector',
+      'claim-event-projector',
+    );
+    expect(deliveries.complete.mock.invocationCallOrder[0]).toBeGreaterThan(
+      signals.handoff.mock.invocationCallOrder[0]!,
+    );
+    expect(deliveries.fail).not.toHaveBeenCalled();
+  });
+
+  it('enforces global and per-handler backpressure before claiming another delivery', async () => {
+    const first = deferred<Result<ReturnType<typeof success>['value'], LifecycleError>>();
+    const deliveries = new FakeDeliveries();
+    deliveries.claimNext.mockImplementation(
+      ({ excludedHandlerIds }: { excludedHandlerIds?: string[] }) => {
+        if (!excludedHandlerIds?.includes('projector')) return ok(claim('projector', 'event-one'));
+        return ok(claim('other-projector', 'event-two'));
+      },
+    );
+    const executor: LifecycleHandlerExecutor = {
+      execute: vi.fn(async (execution) => {
+        if (execution.identity.handlerId === 'projector') return first.promise;
+        return success();
+      }),
+    };
+    const subject = dispatcher(deliveries, executor, {
+      maxConcurrency: 2,
+      maxConcurrencyPerHandler: 1,
+    });
+
+    await subject.dispatchOnce();
+    await subject.dispatchOnce();
+    expect(deliveries.claimNext.mock.calls[1]?.[0]).toMatchObject({
+      excludedHandlerIds: ['projector'],
+    });
+    expect(subject.snapshot().inFlight).toBe(2);
+
+    first.resolve(success());
+    await Promise.resolve();
+    await Promise.resolve();
+    await subject.stop();
+    expect(deliveries.complete).toHaveBeenCalledTimes(2);
+  });
+
+  it('records bounded retry diagnostics and opens a circuit after consecutive failures', async () => {
+    const deliveries = new FakeDeliveries();
+    deliveries.claimNext.mockReturnValueOnce(ok(claim())).mockReturnValueOnce(ok(claim('other')));
+    const executor: LifecycleHandlerExecutor = {
+      execute: vi.fn(async () => err(new LifecycleError('handler failed'))),
+    };
+    const subject = dispatcher(deliveries, executor, { circuitFailureThreshold: 1 });
+
+    await subject.dispatchOnce();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await subject.stop();
+
+    expect(deliveries.fail).toHaveBeenCalledWith(
+      'event-projector',
+      'projector',
+      'claim-event-projector',
+      { code: 'handler-execution-failed' },
+      2_000,
+      true,
+    );
+    expect(subject.snapshot().handlers).toEqual([
+      expect.objectContaining({ handlerId: 'projector', circuit: 'open' }),
+    ]);
+  });
+
+  it('does not overwrite a delivery when its lease completion was lost', async () => {
+    const deliveries = new FakeDeliveries();
+    deliveries.claimNext.mockReturnValueOnce(ok(claim()));
+    deliveries.complete.mockReturnValueOnce(err(new LifecycleError('lease lost')));
+    const subject = dispatcher(deliveries, { execute: async () => success() });
+
+    await subject.dispatchOnce();
+    await subject.stop();
+
+    expect(deliveries.complete).toHaveBeenCalledTimes(1);
+    expect(deliveries.fail).not.toHaveBeenCalled();
+  });
+
+  it('keeps one captured repository authority from claim through completion', async () => {
+    const repositoryA = new FakeDeliveries();
+    const repositoryB = new FakeDeliveries();
+    const signalsA = new FakeSignals();
+    const signalsB = new FakeSignals();
+    const running = deferred<Result<ReturnType<typeof success>['value'], LifecycleError>>();
+    repositoryA.claimNext.mockReturnValueOnce(ok(claim()));
+    const options = {
+      deliveries: repositoryA,
+      executor: { execute: async () => running.promise },
+      signalRouter: signalsA,
+      clock: { now: () => 1_000 },
+      policy: { pollIntervalMs: 86_400_000 },
+    };
+    const subject = LifecycleDispatcher.create(options)._unsafeUnwrap();
+
+    await subject.dispatchOnce();
+    options.deliveries = repositoryB;
+    options.executor = { execute: async () => success() };
+    options.signalRouter = signalsB;
+    running.resolve(success());
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await subject.stop();
+
+    expect(repositoryA.complete).toHaveBeenCalledWith(
+      'event-projector',
+      'projector',
+      'claim-event-projector',
+    );
+    expect(repositoryA.fail).not.toHaveBeenCalled();
+    expect(repositoryB.complete).not.toHaveBeenCalled();
+    expect(repositoryB.fail).not.toHaveBeenCalled();
+    expect(signalsA.handoff).toHaveBeenCalledTimes(1);
+    expect(signalsB.handoff).not.toHaveBeenCalled();
+  });
+
+  it('hands a reclaimed success to the durable signal boundary with the same idempotency key before each completion attempt', async () => {
+    const deliveries = new FakeDeliveries();
+    const signals = new FakeSignals();
+    deliveries.claimNext
+      .mockReturnValueOnce(ok(claim()))
+      .mockReturnValueOnce(
+        ok(claim('projector', 'event-projector', { claim_token: 'replacement-lease' })),
+      );
+    deliveries.complete.mockReturnValueOnce(err(new LifecycleError('crash after handoff')));
+    const subject = dispatcher(deliveries, { execute: async () => success() }, {}, signals);
+
+    await subject.dispatchOnce();
+    await subject.stop();
+    await subject.dispatchOnce();
+    await subject.stop();
+
+    expect(signals.handoff).toHaveBeenCalledTimes(2);
+    expect(signals.handoff.mock.calls.map(([value]) => value.idempotencyKey)).toEqual([
+      'event-projector:projector',
+      'event-projector:projector',
+    ]);
+    expect(deliveries.complete).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors non-retryable errors and preserve-session terminal completion', async () => {
+    const deliveries = new FakeDeliveries();
+    deliveries.claimNext.mockReturnValueOnce(
+      ok(
+        claim('projector', 'event-projector', {
+          failure_policy: JSON.stringify({ version: 'v1', mode: 'preserve_session' }),
+        }),
+      ),
+    );
+    const subject = dispatcher(deliveries, {
+      execute: async () =>
+        ok({ outcome: 'error', code: 'invalid-input', message: 'invalid', retryable: false }),
+    });
+
+    await subject.dispatchOnce();
+    await subject.stop();
+
+    expect(deliveries.complete).toHaveBeenCalledWith(
+      'event-projector',
+      'projector',
+      'claim-event-projector',
+    );
+    expect(deliveries.fail).not.toHaveBeenCalled();
+  });
+
+  it('dead-letters a non-retryable error through the lease-guarded repository transition', async () => {
+    const deliveries = new FakeDeliveries();
+    deliveries.claimNext.mockReturnValueOnce(ok(claim()));
+    const subject = dispatcher(deliveries, {
+      execute: async () =>
+        ok({ outcome: 'error', code: 'invalid-input', message: 'invalid', retryable: false }),
+    });
+
+    await subject.dispatchOnce();
+    await subject.stop();
+
+    expect(deliveries.fail).toHaveBeenCalledWith(
+      'event-projector',
+      'projector',
+      'claim-event-projector',
+      { code: 'handler-reported-error' },
+      2_000,
+      false,
+    );
+  });
+
+  it('enforces global concurrency on direct public dispatch calls', async () => {
+    const running = deferred<Result<ReturnType<typeof success>['value'], LifecycleError>>();
+    const deliveries = new FakeDeliveries();
+    deliveries.claimNext.mockReturnValue(ok(claim()));
+    const subject = dispatcher(
+      deliveries,
+      { execute: async () => running.promise },
+      { maxConcurrency: 1 },
+    );
+
+    await subject.dispatchOnce();
+    await expect(subject.dispatchOnce()).resolves.toMatchObject({ value: false });
+    expect(deliveries.claimNext).toHaveBeenCalledTimes(1);
+    running.resolve(success());
+    await subject.stop();
+  });
+
+  it('cancels a hung handler before lease expiry and bounds shutdown', async () => {
+    vi.useFakeTimers();
+    const deliveries = new FakeDeliveries();
+    deliveries.claimNext.mockReturnValueOnce(ok(claim()));
+    const observed = vi.fn();
+    const subject = dispatcher(
+      deliveries,
+      {
+        execute: async (execution) =>
+          new Promise((resolve) => {
+            execution.signal.addEventListener('abort', () => {
+              observed(execution.signal.aborted);
+              resolve(err(new LifecycleError('cancelled')));
+            });
+          }),
+      },
+      { leaseMs: 100, handlerTimeoutMs: 50, shutdownTimeoutMs: 75 },
+    );
+
+    await subject.dispatchOnce();
+    await vi.advanceTimersByTimeAsync(50);
+    await subject.stop();
+
+    expect(observed).toHaveBeenCalledWith(true);
+    expect(deliveries.fail).toHaveBeenCalledWith(
+      'event-projector',
+      'projector',
+      'claim-event-projector',
+      { code: 'handler-timeout' },
+      2_000,
+      true,
+    );
+    vi.useRealTimers();
+  });
+
+  it('retains timed-out abort-ignoring executions in global and handler capacity until they settle', async () => {
+    vi.useFakeTimers();
+    try {
+      const late = deferred<Result<ReturnType<typeof success>['value'], LifecycleError>>();
+      const retry = deferred<Result<ReturnType<typeof success>['value'], LifecycleError>>();
+      const deliveries = new FakeDeliveries();
+      deliveries.claimNext
+        .mockReturnValueOnce(ok(claim('projector', 'event-first')))
+        .mockReturnValueOnce(ok(claim('projector', 'event-retry')));
+      const executor: LifecycleHandlerExecutor = {
+        execute: vi
+          .fn()
+          .mockImplementationOnce(async () => late.promise)
+          .mockImplementationOnce(async () => retry.promise),
+      };
+      const subject = dispatcher(deliveries, executor, {
+        maxConcurrency: 1,
+        maxConcurrencyPerHandler: 1,
+        leaseMs: 100,
+        handlerTimeoutMs: 50,
+        shutdownTimeoutMs: 75,
+      });
+
+      await subject.dispatchOnce();
+      await vi.advanceTimersByTimeAsync(50);
+      expect(subject.snapshot()).toMatchObject({ inFlight: 1 });
+      expect(subject.snapshot().handlers).toEqual([
+        expect.objectContaining({ handlerId: 'projector', inFlight: 1 }),
+      ]);
+      expect(deliveries.fail).toHaveBeenCalledTimes(1);
+
+      await expect(subject.dispatchOnce()).resolves.toMatchObject({ value: false });
+      expect(deliveries.claimNext).toHaveBeenCalledTimes(1);
+
+      const stopped = subject.stop();
+      await vi.advanceTimersByTimeAsync(75);
+      await stopped;
+      expect(subject.snapshot()).toMatchObject({ running: false, inFlight: 1 });
+
+      subject.start();
+      await Promise.resolve();
+      await expect(subject.dispatchOnce()).resolves.toMatchObject({ value: false });
+      expect(deliveries.claimNext).toHaveBeenCalledTimes(1);
+
+      late.resolve(success());
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(executor.execute).toHaveBeenCalledTimes(2);
+      expect(deliveries.claimNext).toHaveBeenCalledTimes(2);
+      expect(subject.snapshot()).toMatchObject({ inFlight: 1 });
+
+      retry.resolve(success());
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(deliveries.complete).toHaveBeenCalledTimes(1);
+      await subject.stop();
+      expect(deliveries.fail).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels active work during shutdown instead of waiting past its lease fence', async () => {
+    const running = deferred<Result<ReturnType<typeof success>['value'], LifecycleError>>();
+    const deliveries = new FakeDeliveries();
+    deliveries.claimNext.mockReturnValueOnce(ok(claim()));
+    const subject = dispatcher(deliveries, { execute: async () => running.promise });
+
+    await subject.dispatchOnce();
+    const stopped = subject.stop();
+    running.resolve(success());
+    await stopped;
+
+    expect(deliveries.complete).not.toHaveBeenCalled();
+    expect(deliveries.fail).toHaveBeenCalledWith(
+      'event-projector',
+      'projector',
+      'claim-event-projector',
+      { code: 'handler-timeout' },
+      2_000,
+      true,
+    );
+    expect(subject.snapshot()).toMatchObject({ running: false, stopping: false, inFlight: 0 });
+  });
+
+  it('clears the losing shutdown timeout when stop settles immediately', async () => {
+    vi.useFakeTimers();
+    try {
+      const subject = dispatcher(
+        new FakeDeliveries(),
+        { execute: async () => success() },
+        {
+          shutdownTimeoutMs: 5_000,
+        },
+      );
+
+      await subject.stop();
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects hostile dispatcher construction and non-callable dependencies without traps', () => {
+    const traps = { get: vi.fn(), ownKeys: vi.fn(), getPrototypeOf: vi.fn() };
+    const hostile = new Proxy({}, traps);
+    const accessorOptions = Object.defineProperty({}, 'policy', {
+      enumerable: true,
+      get() {
+        throw new Error('must not read options policy');
+      },
+    });
+
+    expect(LifecycleDispatcher.create(hostile as never).isErr()).toBe(true);
+    expect(traps.get).not.toHaveBeenCalled();
+    expect(traps.ownKeys).not.toHaveBeenCalled();
+    expect(traps.getPrototypeOf).not.toHaveBeenCalled();
+    expect(() => LifecycleDispatcher.create(accessorOptions as never)).not.toThrow();
+    expect(LifecycleDispatcher.create(accessorOptions as never).isErr()).toBe(true);
+    expect(
+      LifecycleDispatcher.create({
+        deliveries: { claimNext: true, complete: true, fail: true },
+        executor: { execute: true },
+        signalRouter: { handoff: true },
+      } as never).isErr(),
+    ).toBe(true);
+  });
+
+  it('contains throwing and malformed claim results at the public Result boundary', async () => {
+    const throwing = new FakeDeliveries();
+    throwing.claimNext.mockImplementation(() => {
+      throw new Error('claim failed');
+    });
+    const malformed = new FakeDeliveries();
+    malformed.claimNext.mockReturnValue({ isErr: () => false, isOk: () => true, value: 1 });
+    const throwingSubject = dispatcher(throwing, { execute: async () => success() });
+    const malformedSubject = dispatcher(malformed, { execute: async () => success() });
+
+    expect((await throwingSubject.dispatchOnce()).isErr()).toBe(true);
+    expect((await malformedSubject.dispatchOnce()).isErr()).toBe(true);
+
+    throwingSubject.start();
+    malformedSubject.start();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await throwingSubject.stop();
+    await malformedSubject.stop();
+  });
+
+  it('rejects accessor and proxy claim results without evaluating their traps', async () => {
+    const accessorReads = vi.fn();
+    const accessorResult = Object.defineProperties(
+      {},
+      {
+        isErr: { enumerable: true, value: () => false },
+        isOk: { enumerable: true, value: () => true },
+        value: {
+          enumerable: true,
+          get() {
+            accessorReads();
+            throw new Error('must not read claim result');
+          },
+        },
+      },
+    );
+    const proxyTraps = { get: vi.fn(), ownKeys: vi.fn(), getPrototypeOf: vi.fn() };
+    const proxyResult = new Proxy({}, proxyTraps);
+    const accessor = new FakeDeliveries();
+    const proxied = new FakeDeliveries();
+    accessor.claimNext.mockReturnValue(accessorResult);
+    proxied.claimNext.mockReturnValue(proxyResult);
+
+    expect(
+      (await dispatcher(accessor, { execute: async () => success() }).dispatchOnce()).isErr(),
+    ).toBe(true);
+    expect(
+      (await dispatcher(proxied, { execute: async () => success() }).dispatchOnce()).isErr(),
+    ).toBe(true);
+    expect(accessorReads).not.toHaveBeenCalled();
+    expect(proxyTraps.get).not.toHaveBeenCalled();
+    expect(proxyTraps.ownKeys).not.toHaveBeenCalled();
+  });
+});
+
+describe('CapturedLifecycleHandlerExecutor', () => {
+  it('rejects a handler result that does not match the captured contract', async () => {
+    const executor = CapturedLifecycleHandlerExecutor.create({
+      nativeCatalog: [
+        {
+          identity: JSON.parse(claim().delivery.handler_identity) as never,
+          handler: async () =>
+            ok({ outcome: 'success', outputContract: 'wrong.v1', signals: [] } as never),
+        },
+      ],
+    })._unsafeUnwrap();
+    const invalid = await executor.execute({
+      event: {
+        version: 'v1',
+        type: 'message.persisted.v1',
+        eventId: 'event-projector',
+        occurredAt: '2026-07-16T12:00:00.000Z',
+        context: {
+          aggregate: { type: 'thread', id: 'thread-1' },
+          correlationId: 'correlation-1',
+          recursion: { depth: 0, maxDepth: 4 },
+          provenance: { source: 'test' },
+        },
+        payload: { references: [], metadata: {} },
+      },
+      identity: JSON.parse(claim().delivery.handler_identity) as never,
+      persona: 'assistant',
+      idempotencyKey: 'event-projector:projector',
+      signal: new AbortController().signal,
+    });
+
+    expect(invalid.isErr()).toBe(true);
+  });
+
+  it('matches the complete immutable identity tuple, not only implementation ref', async () => {
+    const handler = vi.fn(async () => success());
+    const executor = CapturedLifecycleHandlerExecutor.create({
+      nativeCatalog: [
+        {
+          identity: JSON.parse(claim().delivery.handler_identity) as never,
+          handler,
+        },
+      ],
+    })._unsafeUnwrap();
+    const identity = {
+      ...(JSON.parse(claim().delivery.handler_identity) as Record<string, unknown>),
+      implementationVersion: '2.0.0',
+    };
+
+    const result = await executor.execute({
+      event: {
+        version: 'v1',
+        type: 'message.persisted.v1',
+        eventId: 'event-projector',
+        occurredAt: '2026-07-16T12:00:00.000Z',
+        context: {
+          aggregate: { type: 'thread', id: 'thread-1' },
+          correlationId: 'correlation-1',
+          recursion: { depth: 0, maxDepth: 4 },
+          provenance: { source: 'test' },
+        },
+        payload: { references: [], metadata: {} },
+      },
+      identity: identity as never,
+      persona: 'assistant',
+      idempotencyKey: 'event-projector:projector',
+      signal: new AbortController().signal,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('allows one subagent identity for distinct explicit persona attachments', async () => {
+    const identity = {
+      ...(JSON.parse(claim().delivery.handler_identity) as Record<string, unknown>),
+      runtimeKind: 'subagent',
+      implementationRef: 'triage-agent',
+    } as never;
+    const alice = vi.fn(async () => success());
+    const bob = vi.fn(async () => success());
+    const executor = CapturedLifecycleHandlerExecutor.create({
+      subagentCatalog: [
+        {
+          identity,
+          handler: alice,
+          subagentScope: { persona: 'alice', capabilities: { allow: [] } },
+        },
+        {
+          identity,
+          handler: bob,
+          subagentScope: { persona: 'bob', capabilities: { allow: [] } },
+        },
+      ],
+    })._unsafeUnwrap();
+    const event = {
+      version: 'v1' as const,
+      type: 'message.persisted.v1' as const,
+      eventId: 'event-projector',
+      occurredAt: '2026-07-16T12:00:00.000Z',
+      context: {
+        aggregate: { type: 'thread', id: 'thread-1' },
+        correlationId: 'correlation-1',
+        recursion: { depth: 0, maxDepth: 4 },
+        provenance: { source: 'test' },
+      },
+      payload: { references: [], metadata: {} },
+    };
+
+    await executor.execute({
+      event,
+      identity,
+      persona: 'alice',
+      idempotencyKey: 'event-projector:projector',
+      signal: new AbortController().signal,
+    });
+    await executor.execute({
+      event,
+      identity,
+      persona: 'bob',
+      idempotencyKey: 'event-projector:projector',
+      signal: new AbortController().signal,
+    });
+
+    expect(alice).toHaveBeenCalledTimes(1);
+    expect(bob).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects duplicate subagent identity/persona authority and cross-persona use', async () => {
+    const identity = {
+      ...(JSON.parse(claim().delivery.handler_identity) as Record<string, unknown>),
+      runtimeKind: 'subagent',
+      implementationRef: 'triage-agent',
+    } as never;
+    const handler = vi.fn(async () => success());
+    const duplicate = CapturedLifecycleHandlerExecutor.create({
+      subagentCatalog: [
+        { identity, handler, subagentScope: { persona: 'alice', capabilities: { allow: [] } } },
+        { identity, handler, subagentScope: { persona: 'alice', capabilities: { allow: [] } } },
+      ],
+    });
+    const onlyAlice = CapturedLifecycleHandlerExecutor.create({
+      subagentCatalog: [
+        { identity, handler, subagentScope: { persona: 'alice', capabilities: { allow: [] } } },
+      ],
+    })._unsafeUnwrap();
+
+    const crossPersona = await onlyAlice.execute({
+      event: {
+        version: 'v1',
+        type: 'message.persisted.v1',
+        eventId: 'event-projector',
+        occurredAt: '2026-07-16T12:00:00.000Z',
+        context: {
+          aggregate: { type: 'thread', id: 'thread-1' },
+          correlationId: 'correlation-1',
+          recursion: { depth: 0, maxDepth: 4 },
+          provenance: { source: 'test' },
+        },
+        payload: { references: [], metadata: {} },
+      },
+      identity,
+      persona: 'bob',
+      idempotencyKey: 'event-projector:projector',
+      signal: new AbortController().signal,
+    });
+
+    expect(duplicate.isErr()).toBe(true);
+    expect(crossPersona.isErr()).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('rejects hostile accessor and proxy policy/catalog inputs without throwing', () => {
+    const policy = {
+      get leaseMs(): number {
+        throw new Error('read');
+      },
+    };
+    expect(() => createLifecycleDispatcherPolicy(policy)).not.toThrow();
+    expect(createLifecycleDispatcherPolicy(policy).isErr()).toBe(true);
+    expect(
+      CapturedLifecycleHandlerExecutor.create({ nativeCatalog: new Proxy([], {}) }).isErr(),
+    ).toBe(true);
+  });
+
+  it('bounds catalog options, entries, identities, and scopes before descriptor evaluation', () => {
+    const identity = JSON.parse(claim().delivery.handler_identity) as Record<string, unknown>;
+    const accessed = vi.fn();
+    const oversized = (base: Record<string, unknown> = {}): Record<string, unknown> => {
+      const value = { ...base };
+      while (Reflect.ownKeys(value).length < 64) {
+        value[`extra-${Reflect.ownKeys(value).length}`] = true;
+      }
+      Object.defineProperty(value, 'overflow', {
+        enumerable: true,
+        get() {
+          accessed();
+          throw new Error('must not evaluate oversized input');
+        },
+      });
+      return value;
+    };
+    const handler = async () => success();
+
+    expect(CapturedLifecycleHandlerExecutor.create(oversized() as never).isErr()).toBe(true);
+    expect(
+      CapturedLifecycleHandlerExecutor.create({
+        nativeCatalog: [oversized({ identity, handler }) as never],
+      }).isErr(),
+    ).toBe(true);
+    expect(
+      CapturedLifecycleHandlerExecutor.create({
+        nativeCatalog: [{ identity: oversized(identity), handler } as never],
+      }).isErr(),
+    ).toBe(true);
+    expect(
+      CapturedLifecycleHandlerExecutor.create({
+        subagentCatalog: [
+          {
+            identity: { ...identity, runtimeKind: 'subagent' },
+            handler,
+            subagentScope: oversized({ persona: 'assistant', capabilities: {} }),
+          } as never,
+        ],
+      }).isErr(),
+    ).toBe(true);
+    expect(accessed).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a durable lifecycle dispatcher with lease-safe completion, bounded global/per-handler concurrency, retry/dead-letter behavior, circuit state, and restart-safe shutdown
- add immutable native/subagent handler execution authority and typed hostile-input boundaries
- add the v15 non-retryable delivery migration and upgrade coverage while preserving migration 014 byte-for-byte
- extend delivery claiming for bounded dispatcher exclusions

## Verification
- pinned Node 24 focused tests: 80/80 passed
- npm run build
- scoped source ESLint
- Prettier
- git diff --check
- migration 014 byte identity and exact eight-file SHA-256 integrity
- Node 24 shutdown probe: no active Timeout resources; 0.05s exit with shutdownTimeoutMs=5000
- fresh gpt-5.6-sol/high review: 0 Critical, 0 High, 0 Medium, 1 known non-blocking Low

## Notes
- targets the lifecycle epic branch
- full npm test suite was not run, per repository policy
- known Low: the v14 upgrade test fixture depends on historical git commit fbe4f08; intentionally left untouched