### PR TITLE
feat(lifecycle): wire daemon queue and scheduler events

### DIFF
--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/TICKET-003-core-boundary-integration/in-progress/TASK-007-daemon-message-queue-schedule-events.md
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/TICKET-003-core-boundary-integration/in-progress/TASK-007-daemon-message-queue-schedule-events.md
@@ -22,12 +22,12 @@ current_review_model: gpt-5.5
 current_review_reasoning_effort: xhigh
 branch: task/TASK-007-daemon-message-queue-schedule-events
 worker_worktree: /Users/ivo.toby/workspace/talon/.worktrees/WAVE-004-daemon-message-queue-schedule-events
-worktree_status: conflict_free_uncommitted_exact_refresh_merge_active
+worktree_status: pr_open_reviewed_remediations_ready_for_commit_push_pending_wdd_marker_review
 worker_thread_id: 019f6a80-eb6a-7051-9e84-f448be2c2a17
-review_thread_id: 019f6b0f-f3c8-7160-bb2a-81329c61d473
-pr: null
-current_gate: exact_refresh_merge_active_gpt55_xhigh_full_review_required
-branch_freshness: conflict_free_uncommitted_exact_refresh_merge_from_fdf0e77_source_commit_8a994e_unchanged
+review_thread_id: 019f6b85-a9ac-74f3-9fcd-b10c566acdb8
+pr: https://github.com/ivo-toby/talon/pull/263
+current_gate: reviewed_remediation_ready_for_commit_push_pending_fresh_wdd_marker_review
+branch_freshness: reviewed_refresh_merge_commit_f695bf4717ae024283479763d77684de9730f6b5_pushed_pr_open_against_epic
 verification:
   - "npx vitest run tests/unit/daemon/daemon-bootstrap.test.ts tests/unit/pipeline/message-pipeline.test.ts tests/unit/queue/queue-processor.test.ts tests/unit/scheduler/scheduler.test.ts"
   - "npx vitest run tests/unit/lifecycle/lifecycle-event-bus.test.ts tests/unit/lifecycle/lifecycle-dispatcher.test.ts tests/unit/core/database/migrations/runner.test.ts"
@@ -117,15 +117,13 @@ task/TASK-007-daemon-message-queue-schedule-events
 
 ## Worker Worktree
 
-Created clean at `/Users/ivo.toby/workspace/talon/.worktrees/WAVE-004-daemon-message-queue-schedule-events` from reviewed and pushed activation-sync commit `923623b`, then fast-forwarded through readiness checkpoint `a6d48f7` to reviewed/pushed dispatch checkpoint `c682625`. TASK-007 completed exactly six bounded Terra/high remediation passes. Final controller verification passed 12 focused files / 385 tests under exact Node v24.15.0 ABI 137, plus build, latest-source lint, targeted formatting, and diff checks. Fresh complete-diff Sol/high source review `019f6b0f-f3c8-7160-bb2a-81329c61d473` passed 0C/0H/0M/0L on fingerprint `0333fdfbe0fd25403b59a5acbd9e7cb3028cefddfd7af1ec6fc61fe73d2ed3a0`. Reviewed task commit `8a994eac930b18ce5ec1e3fe78999c2a021e4308` is clean, pushed, and aligned with the local remote-tracking ref. The amended WDD/model-policy checkpoint passed GPT-5.5/xhigh review and is pushed at `d104ba4`. Final marker review `019f6b4b-dc25-7331-9d26-b5f5595ff21b` passed GPT-5.5/xhigh 0C/0H/0M/0L on fingerprint `0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131`; marker commit `fdf0e775a411959739a577071788eabe4133e3f2` is pushed. The worktree is in a conflict-free uncommitted exact refresh merge from `fdf0e77`; `HEAD` and upstream remain reviewed source commit `8a994eac930b18ce5ec1e3fe78999c2a021e4308`, and `MERGE_HEAD` is `fdf0e775a411959739a577071788eabe4133e3f2`. A fresh full GPT-5.5/xhigh refresh review is required before the merge commit. PR checks/review/freshness/merge/cleanup/reconciliation remain.
+Created clean at `/Users/ivo.toby/workspace/talon/.worktrees/WAVE-004-daemon-message-queue-schedule-events` from reviewed and pushed activation-sync commit `923623b`, then fast-forwarded through readiness checkpoint `a6d48f7` to reviewed/pushed dispatch checkpoint `c682625`. TASK-007 completed exactly six bounded Terra/high remediation passes. Final controller verification passed 12 focused files / 385 tests under exact Node v24.15.0 ABI 137, plus build, latest-source lint, targeted formatting, and diff checks. Fresh complete-diff Sol/high source review `019f6b0f-f3c8-7160-bb2a-81329c61d473` passed 0C/0H/0M/0L on fingerprint `0333fdfbe0fd25403b59a5acbd9e7cb3028cefddfd7af1ec6fc61fe73d2ed3a0`. Reviewed task commit `8a994eac930b18ce5ec1e3fe78999c2a021e4308` is clean, pushed, and aligned with the local remote-tracking ref. The amended WDD/model-policy checkpoint passed GPT-5.5/xhigh review and is pushed at `d104ba4`. Final marker review `019f6b4b-dc25-7331-9d26-b5f5595ff21b` passed GPT-5.5/xhigh 0C/0H/0M/0L on fingerprint `0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131`; marker commit `fdf0e775a411959739a577071788eabe4133e3f2` is pushed. Full GPT-5.5/xhigh refresh review `019f6b54-ded2-7201-8ef8-cbfdf63c35cd` passed 0C/0H/0M/0L on fingerprint `e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1`. The reviewed exact refresh merge was committed and pushed as `f695bf4717ae024283479763d77684de9730f6b5`, and PR #263 (`https://github.com/ivo-toby/talon/pull/263`) is open against `epic/durable-lifecycle-pipeline`. The selected migration-test failure and lifecycle hot-reload Medium are remediated with focused verification. Complete GPT-5.5/xhigh review `019f6b7d-fd1b-78c3-ba7f-7cade5ca636b` reviewed the unchanged 37-path union and found 0C/0H/0M/0L substantive findings; its sole initial block was the controller's non-canonical newline-stripped fingerprint. Independent GPT-5.5/xhigh integrity adjudication `019f6b85-a9ac-74f3-9fcd-b10c566acdb8` reproduced 37 paths, exactly six modified files, canonical newline-preserving fingerprint `0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`, `git diff --check`, and JSON parse, and issued Amended PASS carrying forward 0C/0H/0M/0L. Remediation is reviewed and ready for commit/push after a fresh GPT-5.5/xhigh review of this state-only WDD marker. The old Verify PR run remains failed pending push. PR freshness/merge/cleanup/reconciliation remain.
 
 ## PR / Patch Reference
 
-Reviewed source commit `8a994eac930b18ce5ec1e3fe78999c2a021e4308` is pushed.
-The task worktree is in a conflict-free uncommitted exact refresh merge from marker
-commit `fdf0e775a411959739a577071788eabe4133e3f2`. The task PR will target
-`epic/durable-lifecycle-pipeline` after the fresh full GPT-5.5/xhigh refresh
-review passes and the merge commit is created and pushed.
+Reviewed refresh merge commit `f695bf4717ae024283479763d77684de9730f6b5` is
+pushed. PR #263 targets `epic/durable-lifecycle-pipeline`:
+`https://github.com/ivo-toby/talon/pull/263`.
 
 ## Current Canonical State
 
@@ -142,12 +140,45 @@ checkpoint passed GPT-5.5/xhigh review 0C/0H/0M/2L on fingerprint
 pushed at `d104ba4`. Final marker review
 `019f6b4b-dc25-7331-9d26-b5f5595ff21b` passed GPT-5.5/xhigh 0C/0H/0M/0L on
 fingerprint `0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131`,
-and marker commit `fdf0e775a411959739a577071788eabe4133e3f2` is pushed. TASK-007
-is now in a conflict-free uncommitted exact refresh merge from `fdf0e77`; source commit
-`8a994eac930b18ce5ec1e3fe78999c2a021e4308` is unchanged and a fresh full
-GPT-5.5/xhigh review is required before the merge commit. PR, merge, cleanup,
-and reconciliation remain. Historical GPT-5.6 worker/reviewer references in this
-task remain provenance only; no new GPT-5.6 activity is permitted.
+and marker commit `fdf0e775a411959739a577071788eabe4133e3f2` is pushed. Full
+GPT-5.5/xhigh refresh review `019f6b54-ded2-7201-8ef8-cbfdf63c35cd` passed
+0C/0H/0M/0L on fingerprint
+`e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1`. The
+reviewed exact refresh merge was committed and pushed as
+`f695bf4717ae024283479763d77684de9730f6b5`, and PR #263
+(`https://github.com/ivo-toby/talon/pull/263`) is open against
+`epic/durable-lifecycle-pipeline`. GitHub Verify PR run `29507211058` failed one
+selected test because the committed-v14 migration test expected 1 applied
+migration and `user_version` 15, but migrations 016 and 017 make the correct
+current totals 3 and 17. GPT-5.5/high implementation session
+`019f6b5c-57e9-74e2-9cf4-d59582276884` completed the focused remediation by
+changing only `tests/unit/core/database/repositories/lifecycle-event-repository.test.ts`
+lines 866-867, updating expected applied migration count 1 to 3 and
+`user_version` 15 to 17. Node 24.15.0 focused verification passed 30/30 in that
+file; no install, rebuild, or full suite ran. PR Agent run `29507211075` passed;
+its failed-suggestions issue comment is non-actionable, with no review threads.
+GitHub Verify PR run `29507211058` remains failed until a reviewed fix is pushed.
+The migration-test blocker was accepted by complete GPT-5.5/xhigh review
+`019f6b67-c08a-7e13-a1e4-579fbac1e114`, which found 0C/0H/1M/0L: lifecycle
+hot reload could retain stale bootstrap-owned runtime and persona authority.
+GPT-5.5/high remediation added the pre-mutation restart-required guard in
+`src/daemon/daemon.ts` plus focused coverage in
+`tests/unit/daemon/reload.test.ts`, preserving the migration fix. Focused reload
+tests passed 26/26; build, source lint, source formatting, and diff check passed.
+Focused GPT-5.5/high sanity review `019f6b75-52f0-73a1-9016-41922cb35236`
+passed 0C/0H/0M. Complete GPT-5.5/xhigh review
+`019f6b7d-fd1b-78c3-ba7f-7cade5ca636b` found 0C/0H/0M/0L substantive
+findings on the unchanged 37-path union and initially blocked only on a
+non-canonical newline-stripped fingerprint. Independent GPT-5.5/xhigh integrity
+adjudication `019f6b85-a9ac-74f3-9fcd-b10c566acdb8` reproduced 37 paths,
+exactly six modified files, canonical newline-preserving fingerprint
+`0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`, diff
+check, and JSON parse, and issued Amended PASS carrying forward 0C/0H/0M/0L.
+Fresh GPT-5.5/xhigh review of this state-only WDD marker is required before
+commit.
+PR review/freshness/merge/cleanup/reconciliation remain.
+Historical GPT-5.6 worker/reviewer references in this task remain
+provenance only; no new GPT-5.6 activity is permitted.
 
 ## RED-GREEN TDD Plan
 
@@ -242,6 +273,43 @@ Refactor only the new/touched boundary after green; do not broaden scope or chan
   ESLint, targeted Prettier, and `git diff --check`. No full suite, dependency
   mutation, commit, push, WDD worker edit, `.minispec` edit, or Low/P3 edit
   occurred.
+- Full GPT-5.5/xhigh refresh review `019f6b54-ded2-7201-8ef8-cbfdf63c35cd`
+  passed 0C/0H/0M/0L on fingerprint
+  `e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1`; the
+  reviewed merge was committed and pushed as
+  `f695bf4717ae024283479763d77684de9730f6b5` and PR #263 opened against the
+  epic branch. GitHub Verify PR run `29507211058` failed one selected migration
+  test because the committed-v14 fixture expected 1 applied migration and
+  `user_version` 15, while migrations 016 and 017 make the correct current
+  totals 3 and 17. GPT-5.5/high implementation session
+  `019f6b5c-57e9-74e2-9cf4-d59582276884` completed the focused remediation by
+  changing only `tests/unit/core/database/repositories/lifecycle-event-repository.test.ts`
+  lines 866-867, updating expected applied migration count 1 to 3 and
+  `user_version` 15 to 17. Node 24.15.0 focused verification passed 30/30 in
+  that file; no install, rebuild, or full suite ran. PR Agent run
+  `29507211075` passed; its failed-suggestions issue comment is non-actionable,
+  with no review threads. GitHub Verify PR run `29507211058` remains failed
+  until a reviewed fix is pushed. The Medium CI blocker is
+  remediation_completed_awaiting_fresh_full_gpt55_xhigh_review, not resolved.
+- Complete GPT-5.5/xhigh review `019f6b67-c08a-7e13-a1e4-579fbac1e114`
+  found 0C/0H/1M/0L after the migration fix: successful hot reload could leave
+  lifecycle runtime and lifecycle-attached persona authority stale. GPT-5.5/high
+  remediation changed only `src/daemon/daemon.ts` and
+  `tests/unit/daemon/reload.test.ts`, preserved the migration-test fix, and
+  passed 26/26 focused reload tests, build, source lint, source formatting, and
+  diff check. Focused GPT-5.5/high sanity review
+  `019f6b75-52f0-73a1-9016-41922cb35236` passed 0C/0H/0M. These source/test
+  edits invalidate the prior complete review, so fresh GPT-5.5/xhigh review is
+  required before commit.
+- Final complete GPT-5.5/xhigh review `019f6b7d-fd1b-78c3-ba7f-7cade5ca636b`
+  found 0C/0H/0M/0L substantive findings on the unchanged 37-path union and
+  initially blocked only on a non-canonical newline-stripped fingerprint.
+  Integrity adjudication `019f6b85-a9ac-74f3-9fcd-b10c566acdb8` reproduced 37
+  paths, exactly six modified files, canonical fingerprint
+  `0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`, diff
+  check, and JSON parse, and issued Amended PASS carrying forward 0C/0H/0M/0L.
+  Remediation is reviewed and ready for commit/push after fresh GPT-5.5/xhigh
+  review of this state-only marker.
 
 ## Review Feedback
 
@@ -373,6 +441,29 @@ Refactor only the new/touched boundary after green; do not broaden scope or chan
   GPT-5.5/xhigh 0C/0H/0M/0L on fingerprint
   `0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131`. Marker
   commit `fdf0e775a411959739a577071788eabe4133e3f2` is pushed. This task is now
-  in a conflict-free uncommitted exact refresh merge from that marker with source commit
-  `8a994eac930b18ce5ec1e3fe78999c2a021e4308` unchanged; fresh full GPT-5.5/xhigh
-  review is required before merge commit.
+  through reviewed refresh merge commit
+  `f695bf4717ae024283479763d77684de9730f6b5`, which is pushed and open as PR
+  #263 against the epic branch. GitHub Verify PR run `29507211058` failed one
+  selected committed-v14 migration assertion; GPT-5.5/high implementation
+  session `019f6b5c-57e9-74e2-9cf4-d59582276884` completed the focused
+  remediation by changing only the selected migration-test expectations on
+  lines 866-867. Node 24.15.0 focused verification passed 30/30 in that file;
+  no install, rebuild, or full suite ran. PR Agent run `29507211075` passed with
+  no review threads, and its failed-suggestions issue comment is non-actionable.
+  GitHub Verify PR run `29507211058` remains failed until a reviewed fix is
+  pushed. The Medium CI blocker is
+  remediation_completed_awaiting_fresh_full_gpt55_xhigh_review, not resolved.
+- Superseding current gate: complete GPT-5.5/xhigh review
+  `019f6b67-c08a-7e13-a1e4-579fbac1e114` found 0C/0H/1M/0L on lifecycle
+  hot-reload staleness. GPT-5.5/high remediation and 26/26 focused reload tests,
+  build, source lint, source formatting, and diff check completed; focused
+  sanity review `019f6b75-52f0-73a1-9016-41922cb35236` passed 0C/0H/0M. Fresh
+  complete GPT-5.5/xhigh review is required before commit.
+- Amended final review gate passed: complete GPT-5.5/xhigh session
+  `019f6b7d-fd1b-78c3-ba7f-7cade5ca636b` carries 0C/0H/0M/0L substantive
+  findings, and independent integrity adjudication
+  `019f6b85-a9ac-74f3-9fcd-b10c566acdb8` reproduced the unchanged 37-path
+  union, exactly six modified files, canonical fingerprint
+  `0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`, diff
+  check, and JSON parse. Fresh GPT-5.5/xhigh marker review is required before
+  commit/push.

--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/controller-state.md
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/controller-state.md
@@ -56,6 +56,11 @@ Every task advances independently as soon as its gates clear.
   fingerprint `0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131`,
   committed, and pushed at `fdf0e77`; TASK-007 is now in a conflict-free uncommitted
   exact refresh merge from that marker with source commit `8a994ea` unchanged
+- WAVE-004 TASK-007 refresh merge: GPT-5.5/xhigh reviewed 0C/0H/0M/0L in
+  session `019f6b54-ded2-7201-8ef8-cbfdf63c35cd` on fingerprint
+  `e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1`,
+  committed, and pushed at `f695bf4`; PR #263 is open against
+  `epic/durable-lifecycle-pipeline`
 
 ## Pending Waves
 
@@ -88,28 +93,55 @@ policy checkpoint passed GPT-5.5/xhigh review and is pushed at `d104ba4`. The
 durable controller-state marker passed GPT-5.5/xhigh review
 `019f6b4b-dc25-7331-9d26-b5f5595ff21b` 0C/0H/0M/0L on fingerprint
 `0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131` and was
-pushed at `fdf0e775a411959739a577071788eabe4133e3f2`. TASK-007 is now in a
-conflict-free uncommitted exact refresh merge from that marker; `HEAD` and upstream
-remain the reviewed source commit `8a994eac930b18ce5ec1e3fe78999c2a021e4308`,
-and `MERGE_HEAD` is `fdf0e775a411959739a577071788eabe4133e3f2`. A fresh full
-GPT-5.5/xhigh refresh review is required before the merge commit. PR
-checks/review/freshness/merge/cleanup/reconciliation remain. Historical Sol/high
-and Terra/high references below are provenance only and do not authorize new
-GPT-5.6 activity.
+pushed at `fdf0e775a411959739a577071788eabe4133e3f2`. Full GPT-5.5/xhigh
+refresh review `019f6b54-ded2-7201-8ef8-cbfdf63c35cd` passed 0C/0H/0M/0L on
+fingerprint `e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1`.
+The reviewed refresh merge was committed and pushed as
+`f695bf4717ae024283479763d77684de9730f6b5`, and PR #263
+(`https://github.com/ivo-toby/talon/pull/263`) is open against
+`epic/durable-lifecycle-pipeline`. GitHub Verify PR run `29507211058` failed one
+selected test because the committed-v14 migration test expected 1 applied
+migration and `user_version` 15, but migrations 016 and 017 make the correct
+current totals 3 and 17. GPT-5.5/high implementation session
+`019f6b5c-57e9-74e2-9cf4-d59582276884` completed the focused remediation by
+changing only `tests/unit/core/database/repositories/lifecycle-event-repository.test.ts`
+lines 866-867, updating expected applied migration count 1 to 3 and
+`user_version` 15 to 17. Node 24.15.0 focused verification passed 30/30 in that
+file; no install, rebuild, or full suite ran. PR Agent run `29507211075` passed;
+its failed-suggestions issue comment is non-actionable, with no review threads.
+GitHub Verify PR run `29507211058` remains failed until a reviewed fix is pushed.
+The Medium CI blocker is remediation_completed_awaiting_fresh_full_gpt55_xhigh_review,
+not resolved. PR review/freshness/merge/cleanup/reconciliation remain.
+Historical Sol/high and Terra/high references below are provenance only
+and do not authorize new GPT-5.6 activity.
+
+Superseding current gate: complete GPT-5.5/xhigh review
+`019f6b7d-fd1b-78c3-ba7f-7cade5ca636b` reviewed the unchanged 37-path union and
+found 0C/0H/0M/0L substantive findings. Its sole initial block was the
+controller's non-canonical newline-stripped fingerprint. Independent GPT-5.5/
+xhigh integrity adjudication `019f6b85-a9ac-74f3-9fcd-b10c566acdb8`
+reproduced 37 paths, exactly six modified files, canonical newline-preserving
+fingerprint `0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`,
+`git diff --check`, and JSON parse, and issued Amended PASS carrying forward
+0C/0H/0M/0L. Remediation is reviewed and ready for commit/push after a fresh
+GPT-5.5/xhigh review of this state-only WDD marker. PR #263 remains open; old
+Verify PR run `29507211058` remains failed pending push. WAVE-005 is inactive,
+`pauseAfterWave` remains WAVE-004, and next-wave activation is false.
 
 ## Monitoring
 
 - Mode: Codex thread heartbeat
 - Cadence: adaptive; next controller check in 5 minutes
-- Status: exact refresh merge active; fresh full GPT-5.5/xhigh review required before merge commit
+- Status: PR open; amended full review passed 0C/0H/0M/0L; reviewed remediation ready for commit/push pending fresh GPT-5.5/xhigh WDD marker review
 - Scheduler: `talon-issue-256-wdd-wave-4-monitor`
-- Last checked: 2026-07-16T16:23:58+02:00
-- Next check due: 2026-07-16T16:28:58+02:00
+- Last checked: 2026-07-16T17:24:23+02:00
+- Next check due: 2026-07-16T17:29:23+02:00
 - Stop condition: WAVE-004 is fully reconciled, its reviewed reconciliation checkpoint is pushed, the monitor is deactivated, and epic work pauses before WAVE-005.
 - Automation state: the WAVE-003 heartbeat was deleted after reconciliation
   push. Self-contained WAVE-004 heartbeat
-  `talon-issue-256-wdd-wave-4-monitor` is active for exact-refresh review,
-  merge commit, PR, merge, cleanup, and WAVE-004 reconciliation only. It must
+  `talon-issue-256-wdd-wave-4-monitor` is active for fresh GPT-5.5/xhigh
+  review, PR checks after a reviewed fix is pushed, merge, cleanup, and WAVE-004
+  reconciliation only. It must
   not activate WAVE-005.
 
 ## Current Task Gates
@@ -205,11 +237,41 @@ GPT-5.6 activity.
   pushed, and aligned with the local remote-tracking ref. Final GPT-5.5/xhigh
   marker review `019f6b4b-dc25-7331-9d26-b5f5595ff21b` passed 0C/0H/0M/0L on
   fingerprint `0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131`;
-  marker commit `fdf0e775a411959739a577071788eabe4133e3f2` is pushed. TASK-007
-  is in a conflict-free uncommitted exact refresh merge from `fdf0e77`; source commit
-  `8a994eac930b18ce5ec1e3fe78999c2a021e4308` is unchanged and a fresh full
-  GPT-5.5/xhigh refresh review is required before the merge commit. Historical
-  controller verification
+  marker commit `fdf0e775a411959739a577071788eabe4133e3f2` is pushed. Full
+  GPT-5.5/xhigh refresh review `019f6b54-ded2-7201-8ef8-cbfdf63c35cd` passed
+  0C/0H/0M/0L on fingerprint
+  `e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1`. The
+  reviewed refresh merge was committed and pushed as
+  `f695bf4717ae024283479763d77684de9730f6b5`, and PR #263
+  (`https://github.com/ivo-toby/talon/pull/263`) is open against
+  `epic/durable-lifecycle-pipeline`. GitHub Verify PR run `29507211058` failed
+  one selected committed-v14 migration test because it expected 1 applied
+  migration and `user_version` 15, while migrations 016 and 017 make the correct
+  current totals 3 and 17. GPT-5.5/high implementation session
+  `019f6b5c-57e9-74e2-9cf4-d59582276884` completed the focused remediation by
+  changing only `tests/unit/core/database/repositories/lifecycle-event-repository.test.ts`
+  lines 866-867, updating expected applied migration count 1 to 3 and
+  `user_version` 15 to 17. Node 24.15.0 focused verification passed 30/30 in
+  that file; no install, rebuild, or full suite ran. PR Agent run
+  `29507211075` passed; its failed-suggestions issue comment is non-actionable,
+  with no review threads. GitHub Verify PR run `29507211058` remains failed
+  until a reviewed fix is pushed. The Medium CI blocker is
+  remediation_completed_awaiting_fresh_full_gpt55_xhigh_review, not resolved.
+  Superseding review/remediation state: GPT-5.5/xhigh session
+  `019f6b67-c08a-7e13-a1e4-579fbac1e114` found 0C/0H/1M/0L on stale
+  lifecycle hot-reload authority. GPT-5.5/high remediation changed daemon and
+  reload-test files while preserving the migration fix; 26/26 focused reload
+  tests, build, source lint, source formatting, and diff check passed. Focused
+  sanity review `019f6b75-52f0-73a1-9016-41922cb35236` passed 0C/0H/0M. Fresh
+  complete GPT-5.5/xhigh review is required before commit.
+  Superseding gate: complete GPT-5.5/xhigh review
+  `019f6b7d-fd1b-78c3-ba7f-7cade5ca636b` found 0C/0H/0M/0L substantive
+  findings. Integrity adjudication `019f6b85-a9ac-74f3-9fcd-b10c566acdb8`
+  reproduced the unchanged 37-path union, exactly six modified files, canonical
+  fingerprint `0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`,
+  diff check, and JSON parse, and issued Amended PASS. Fresh GPT-5.5/xhigh WDD
+  marker review is required before commit/push.
+  Historical controller verification
   passed 179 focused tests, build, scoped lint, and diff checks. Sol/high review
   `019f6a8f-2e78-7712-b6d8-ff006b8d1507` blocked 0C/2H/5M/0L after reproducing
   219 focused test passes. It found missing runtime capability/executor wiring,
@@ -261,14 +323,33 @@ GPT-5.6 activity.
 - WAVE-003 / TASK-006: merged branch `task/TASK-006-durable-event-dispatcher`;
   clean worktree removed and pruned after PR #262 merged. The Low remains
   untouched.
-- WAVE-004 / TASK-007: clean local/remote branch
-  `task/TASK-007-daemon-message-queue-schedule-events` and clean worktree
+- WAVE-004 / TASK-007: local/remote branch
+  `task/TASK-007-daemon-message-queue-schedule-events` and assigned worktree
   `/Users/ivo.toby/workspace/talon/.worktrees/WAVE-004-daemon-message-queue-schedule-events`
-  have an active conflict-free uncommitted exact refresh merge. `HEAD` and upstream are
-  the reviewed, pushed, local-remote-tracking-aligned source commit
-  `8a994eac930b18ce5ec1e3fe78999c2a021e4308`; `MERGE_HEAD` is pushed marker
-  commit `fdf0e775a411959739a577071788eabe4133e3f2`. A fresh full GPT-5.5/xhigh
-  refresh review is required before the merge commit.
+  are at reviewed, pushed refresh merge commit
+  `f695bf4717ae024283479763d77684de9730f6b5`, with PR #263 open against
+  `epic/durable-lifecycle-pipeline`. GitHub Verify PR run `29507211058` failed
+  one selected committed-v14 migration test. GPT-5.5/high implementation session
+  `019f6b5c-57e9-74e2-9cf4-d59582276884` completed the focused remediation by
+  changing only test lines 866-867, with 30/30 focused Node 24.15.0 verification
+  passing and no install, rebuild, or full suite. Fresh full GPT-5.5/xhigh
+  review is required before any remediation commit. PR Agent run `29507211075`
+  passed with no review threads; its failed-suggestions issue comment is
+  non-actionable. GitHub Verify PR remains failed until a reviewed fix is
+  pushed. Complete GPT-5.5/xhigh review
+  `019f6b67-c08a-7e13-a1e4-579fbac1e114` found 0C/0H/1M/0L on lifecycle
+  hot-reload staleness. GPT-5.5/high remediation of `src/daemon/daemon.ts` and
+  `tests/unit/daemon/reload.test.ts` preserved the migration fix and passed
+  26/26 focused reload tests plus build/static gates. Focused GPT-5.5/high
+  sanity review `019f6b75-52f0-73a1-9016-41922cb35236` passed 0C/0H/0M; fresh
+  complete GPT-5.5/xhigh review is required before commit.
+  Complete GPT-5.5/xhigh review `019f6b7d-fd1b-78c3-ba7f-7cade5ca636b` now
+  carries 0C/0H/0M/0L substantive findings after integrity adjudication
+  `019f6b85-a9ac-74f3-9fcd-b10c566acdb8` reproduced the unchanged 37-path
+  union, exactly six modified files, canonical fingerprint
+  `0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`, diff
+  check, and JSON parse. Reviewed remediation is ready for commit/push pending
+  fresh GPT-5.5/xhigh review of this WDD marker.
 
 ## Gate Definitions
 
@@ -312,10 +393,27 @@ and clean worktree were fast-forwarded to that exact commit before dispatch.
 The model-policy checkpoint was reviewed and pushed at
 `d104ba468dbe3241691f8940e90238953b82ebeb`. The final controller-state marker
 passed GPT-5.5/xhigh review and was pushed at
-`fdf0e775a411959739a577071788eabe4133e3f2`. TASK-007 now has a clean
-uncommitted exact refresh merge from that marker; `HEAD` and upstream remain
-reviewed source commit `8a994eac930b18ce5ec1e3fe78999c2a021e4308`, and a fresh
-full GPT-5.5/xhigh refresh review is required before the merge commit.
+`fdf0e775a411959739a577071788eabe4133e3f2`. TASK-007's exact refresh merge
+passed full GPT-5.5/xhigh review `019f6b54-ded2-7201-8ef8-cbfdf63c35cd`
+0C/0H/0M/0L on fingerprint
+`e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1`. The
+reviewed merge commit `f695bf4717ae024283479763d77684de9730f6b5` is pushed and
+open as PR #263 against the epic branch. GitHub Verify PR run `29507211058`
+failed one selected committed-v14 migration assertion; GPT-5.5/high remediation
+completed that fix with 30/30 focused tests. Complete GPT-5.5/xhigh review
+`019f6b67-c08a-7e13-a1e4-579fbac1e114` then found 0C/0H/1M/0L on stale
+lifecycle runtime/authority after hot reload. GPT-5.5/high remediation changed
+only daemon source and reload tests, preserved the migration fix, passed 26/26
+focused reload tests and build/static gates, and focused sanity review
+`019f6b75-52f0-73a1-9016-41922cb35236` passed 0C/0H/0M. A fresh complete
+GPT-5.5/xhigh review is required before commit. Complete GPT-5.5/xhigh review
+`019f6b7d-fd1b-78c3-ba7f-7cade5ca636b` subsequently found 0C/0H/0M/0L
+substantive findings; integrity adjudication
+`019f6b85-a9ac-74f3-9fcd-b10c566acdb8` reproduced the unchanged 37-path union,
+exactly six modified files, canonical fingerprint
+`0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`, diff
+check, and JSON parse and issued Amended PASS. Only fresh GPT-5.5/xhigh review
+of this WDD marker remains before commit/push.
 
 ## Open P1/P2 Feedback
 
@@ -333,6 +431,14 @@ full GPT-5.5/xhigh refresh review is required before the merge commit.
 - WAVE-004 activation-sync review passed after the stale-summary Medium was
   corrected. The two known Low follow-ups remain untouched; readiness review
   also passed 0C/0H/0M/2L and both Lows remain untouched.
+- TASK-007 has one active gate: fresh GPT-5.5/xhigh review of this state-only
+  WDD marker before commit/push. Complete review
+  `019f6b7d-fd1b-78c3-ba7f-7cade5ca636b` has 0C/0H/0M/0L substantive findings;
+  integrity adjudication `019f6b85-a9ac-74f3-9fcd-b10c566acdb8` reproduced the
+  unchanged 37-path union, exactly six modified files, canonical fingerprint
+  `0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`, diff
+  check, and JSON parse, and issued Amended PASS. Old Verify PR run
+  `29507211058` remains failed pending the reviewed push.
 
 ## Verification Status
 
@@ -384,8 +490,30 @@ full GPT-5.5/xhigh refresh review is required before the merge commit.
   untouched. Final marker review `019f6b4b-dc25-7331-9d26-b5f5595ff21b` passed
   GPT-5.5/xhigh 0C/0H/0M/0L on fingerprint
   `0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131` and was
-  pushed at `fdf0e77`. TASK-007 exact refresh is an active clean no-commit merge
-  and requires a fresh full GPT-5.5/xhigh review before merge commit.
+  pushed at `fdf0e77`. TASK-007 exact refresh review
+  `019f6b54-ded2-7201-8ef8-cbfdf63c35cd` passed GPT-5.5/xhigh 0C/0H/0M/0L on
+  fingerprint `e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1`;
+  reviewed merge commit `f695bf4717ae024283479763d77684de9730f6b5` is pushed
+  and PR #263 is open against the epic branch. GitHub Verify PR run
+  `29507211058` failed one selected committed-v14 migration test. GPT-5.5/high
+  implementation session `019f6b5c-57e9-74e2-9cf4-d59582276884` completed the
+  focused remediation with 30/30 focused Node 24.15.0 verification, and PR Agent
+  run `29507211075` passed with no review threads. GitHub Verify PR remains
+  failed until a reviewed fix is pushed; the Medium CI blocker is
+  remediation_completed_awaiting_fresh_full_gpt55_xhigh_review, not resolved.
+- Superseding verification: complete GPT-5.5/xhigh review
+  `019f6b67-c08a-7e13-a1e4-579fbac1e114` found 0C/0H/1M/0L on lifecycle
+  hot-reload staleness after accepting the migration fix. GPT-5.5/high
+  remediation passed 26/26 focused reload tests, build, source lint, source
+  formatting, and diff check. Focused GPT-5.5/high sanity review
+  `019f6b75-52f0-73a1-9016-41922cb35236` passed 0C/0H/0M. Fresh complete
+  GPT-5.5/xhigh review is now required.
+- Final substantive verification passed: complete GPT-5.5/xhigh review
+  `019f6b7d-fd1b-78c3-ba7f-7cade5ca636b` carries 0C/0H/0M/0L, and independent
+  integrity adjudication `019f6b85-a9ac-74f3-9fcd-b10c566acdb8` reproduced the
+  unchanged 37-path union, exactly six modified files, canonical fingerprint
+  `0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9`, diff
+  check, and JSON parse. Only marker review remains.
 
 ## Shared Context Reconciliation
 
@@ -790,13 +918,34 @@ full GPT-5.5/xhigh refresh review is required before the merge commit.
   reviewed source commit `8a994eac930b18ce5ec1e3fe78999c2a021e4308`, and
   `MERGE_HEAD` is `fdf0e775a411959739a577071788eabe4133e3f2`. A fresh full
   GPT-5.5/xhigh refresh review is required before the merge commit.
+- 2026-07-16: Full GPT-5.5/xhigh refresh review
+  `019f6b54-ded2-7201-8ef8-cbfdf63c35cd` passed 0C/0H/0M/0L on fingerprint
+  `e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1`. The
+  reviewed refresh merge was committed and pushed as
+  `f695bf4717ae024283479763d77684de9730f6b5`, and PR #263
+  `https://github.com/ivo-toby/talon/pull/263` opened against
+  `epic/durable-lifecycle-pipeline`.
+- 2026-07-16: GitHub Verify PR run `29507211058` failed one selected
+  committed-v14 migration test because it expected 1 applied migration and
+  `user_version` 15, while migrations 016 and 017 make the correct current
+  totals 3 and 17. GPT-5.5/high implementation session
+  `019f6b5c-57e9-74e2-9cf4-d59582276884` completed the focused remediation by
+  changing only `tests/unit/core/database/repositories/lifecycle-event-repository.test.ts`
+  lines 866-867, updating expected applied migration count 1 to 3 and
+  `user_version` 15 to 17. Node 24.15.0 focused verification passed 30/30 in
+  that file; no install, rebuild, or full suite ran. PR Agent run
+  `29507211075` passed; its failed-suggestions issue comment is non-actionable,
+  with no review threads. GitHub Verify PR run `29507211058` remains failed
+  until a reviewed fix is pushed. The Medium CI blocker is
+  remediation_completed_awaiting_fresh_full_gpt55_xhigh_review, not resolved.
 
 ## Next Action
 
-Run a fresh full GPT-5.5/xhigh review over the active exact TASK-007 refresh
-merge, then create and push the merge commit only if it passes 0C/0H/0M. Open
-the PR targeting the epic, and continue through checks, review, freshness, merge,
-cleanup, and WAVE-004 reconciliation. Then deactivate monitoring and pause; do
-not activate WAVE-005. Remediate only Critical/High/Medium WDD, refresh, or PR
-blockers; leave Low/P3 and `.minispec` untouched, and do not run full `npm test`
-without approval.
+Run a fresh GPT-5.5/xhigh review of this state-only WDD marker before any
+commit. After a clean marker review, commit and push the already substantively
+reviewed fixes so GitHub Verify PR run `29507211058`
+can be superseded by a fresh passing run, then continue PR #263 through
+freshness, merge, cleanup, and WAVE-004 reconciliation. Then deactivate
+monitoring and pause; do not activate WAVE-005. Remediate only Critical/High/
+Medium WDD, refresh, CI, or PR blockers; leave Low/P3 and `.minispec` untouched,
+and do not run full `npm test` without approval.

--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/orchestration.json
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/orchestration.json
@@ -791,14 +791,14 @@
           "reasoningEffort": "high",
           "reviewModel": "reviewGate",
           "workerThreadId": "019f6a80-eb6a-7051-9e84-f448be2c2a17",
-      "reviewThreadId": "019f6b0f-f3c8-7160-bb2a-81329c61d473",
+          "reviewThreadId": "019f6b85-a9ac-74f3-9fcd-b10c566acdb8",
           "branch": "task/TASK-007-daemon-message-queue-schedule-events",
           "workerWorktree": "/Users/ivo.toby/workspace/talon/.worktrees/WAVE-004-daemon-message-queue-schedule-events",
-      "worktreeStatus": "conflict_free_uncommitted_exact_refresh_merge_active",
+          "worktreeStatus": "pr_open_reviewed_remediations_ready_for_commit_push_pending_wdd_marker_review",
           "cleanup": null,
-          "pr": null,
-          "latestCommit": "8a994eac930b18ce5ec1e3fe78999c2a021e4308",
-      "branchFreshness": "conflict_free_uncommitted_exact_refresh_merge_from_fdf0e77_source_commit_8a994e_unchanged",
+          "pr": "https://github.com/ivo-toby/talon/pull/263",
+          "latestCommit": "f695bf4717ae024283479763d77684de9730f6b5",
+          "branchFreshness": "reviewed_refresh_merge_commit_f695bf4717ae024283479763d77684de9730f6b5_pushed_pr_open_against_epic",
           "blockingFeedback": [
             {
               "severity": "High",
@@ -904,10 +904,20 @@
           "severity": "Medium",
           "summary": "IPC shutdown discards the newly fallible stop promise, so a rejected or timed-out drain can become an unhandled rejection and interrupt deferred teardown gating.",
           "status": "resolved_by_review"
+        },
+        {
+          "severity": "Medium",
+          "summary": "GitHub Verify PR run 29507211058 failed one selected committed-v14 migration test because it expected 1 applied migration and user_version 15, while migrations 016 and 017 make the correct current totals 3 and 17.",
+          "status": "resolved_by_full_review_019f6b67_c08a_7e13_a1e4_579fbac1e114"
+        },
+        {
+          "severity": "Medium",
+          "summary": "Successful daemon hot reload can leave the bootstrap-owned lifecycle runtime, subscriptions, sub-agent assignments, and capability authority stale when lifecycle configuration or lifecycle-attached persona authority changes.",
+          "status": "resolved_by_amended_full_gpt55_xhigh_review"
         }
       ],
       "verification": {
-        "status": "exact_refresh_merge_active_review_required",
+        "status": "reviewed_remediations_ready_for_commit_push_pending_fresh_wdd_marker_review",
         "boundedTerraHighRemediationPasses": 6,
         "focusedTests": "12 focused files / 385 tests passed under exact Node v24.15.0 ABI 137",
         "finalControllerVerification": "passed 12 focused files / 385 tests under exact Node v24.15.0 ABI 137, plus build, latest-source lint, targeted formatting, and diff checks",
@@ -922,13 +932,28 @@
         "remoteTrackingRefAlignment": "clean, pushed, and aligned with the local remote-tracking ref",
         "finalMarkerReview": "passed GPT-5.5/xhigh 0C/0H/0M/0L on fingerprint 0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131; session 019f6b4b-dc25-7331-9d26-b5f5595ff21b",
         "markerCommit": "fdf0e775a411959739a577071788eabe4133e3f2",
-        "exactRefreshMerge": "active conflict-free uncommitted no-commit merge from marker fdf0e775a411959739a577071788eabe4133e3f2; HEAD/upstream source commit 8a994eac930b18ce5ec1e3fe78999c2a021e4308 unchanged; fresh full GPT-5.5/xhigh review required before merge commit",
-        "currentStateSummary": "TASK-007 completed exactly six bounded Terra/high remediation passes; final controller verification passed 12 focused files / 385 tests under exact Node v24.15.0 ABI 137, plus build, latest-source lint, targeted formatting, and diff checks; fresh complete-diff Sol/high source review 019f6b0f-f3c8-7160-bb2a-81329c61d473 passed 0C/0H/0M/0L on fingerprint 0333fdfbe0fd25403b59a5acbd9e7cb3028cefddfd7af1ec6fc61fe73d2ed3a0; reviewed task commit 8a994eac930b18ce5ec1e3fe78999c2a021e4308 is clean, pushed, and aligned with the local remote-tracking ref; the model-policy/WDD checkpoint passed GPT-5.5/xhigh 0C/0H/0M/2L on fingerprint 9242e2c0b7bfcd138aae37abe4402a6e8020b3b4290d4e24c372beedb63dfdfd and was committed/pushed at d104ba468dbe3241691f8940e90238953b82ebeb; final marker review 019f6b4b-dc25-7331-9d26-b5f5595ff21b passed GPT-5.5/xhigh 0C/0H/0M/0L on fingerprint 0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131 and marker commit fdf0e775a411959739a577071788eabe4133e3f2 is pushed; TASK-007 is in a conflict-free uncommitted exact refresh merge from fdf0e77 with source commit 8a994eac930b18ce5ec1e3fe78999c2a021e4308 unchanged; fresh full GPT-5.5/xhigh refresh review is required before the merge commit; PR checks/review/freshness/merge/cleanup/reconciliation remain."
+        "exactRefreshReview": "passed GPT-5.5/xhigh 0C/0H/0M/0L on fingerprint e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1; session 019f6b54-ded2-7201-8ef8-cbfdf63c35cd",
+        "reviewedRefreshMergeCommit": "f695bf4717ae024283479763d77684de9730f6b5",
+        "pr": "https://github.com/ivo-toby/talon/pull/263",
+        "githubVerifyPr": "failed selected migration test; run 29507211058; committed-v14 migration test expected 1 applied migration and user_version 15, but migrations 016 and 017 make the correct current totals 3 and 17",
+        "blockingRemediation": "migration-test remediation completed by GPT-5.5/high implementation session 019f6b5c-57e9-74e2-9cf4-d59582276884; changed only tests/unit/core/database/repositories/lifecycle-event-repository.test.ts lines 866-867, updating expected applied migration count 1 to 3 and user_version 15 to 17",
+        "blockingRemediationVerification": "Node 24.15.0 focused verification passed 30/30 in tests/unit/core/database/repositories/lifecycle-event-repository.test.ts; no install, rebuild, or full suite",
+        "fullReviewAfterMigrationRemediation": "GPT-5.5/xhigh session 019f6b67-c08a-7e13-a1e4-579fbac1e114 reviewed the complete snapshot and found 0C/0H/1M/0L; the migration-test fix was accepted and the sole Medium was stale lifecycle runtime/authority after successful hot reload",
+        "lifecycleReloadRemediation": "GPT-5.5/high remediation changed src/daemon/daemon.ts and tests/unit/daemon/reload.test.ts only, adding a pre-mutation restart-required guard for lifecycle configuration and lifecycle-attached persona subscription, sub-agent assignment, and capability-authority changes while preserving the migration-test fix",
+        "lifecycleReloadRemediationVerification": "focused reload tests passed 26/26 under Node 24; build, source lint, source formatting, and git diff --check passed; no install, rebuild, or full suite",
+        "focusedHighSanityReview": "passed GPT-5.5/high 0C/0H/0M in session 019f6b75-52f0-73a1-9016-41922cb35236",
+        "freshFullXhighReview": "complete GPT-5.5/xhigh session 019f6b7d-fd1b-78c3-ba7f-7cade5ca636b reviewed the unchanged 37-path union with 0C/0H/0M/0L substantive findings; its only initial block was the controller's non-canonical newline-stripped fingerprint",
+        "canonicalReviewFingerprint": "0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9 using newline-preserving path plus sha256 records",
+        "integrityAdjudication": "independent GPT-5.5/xhigh session 019f6b85-a9ac-74f3-9fcd-b10c566acdb8 reproduced the unchanged 37 paths, exactly six modified files, canonical fingerprint 0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9, git diff --check, and JSON parse; Amended PASS carries forward 0C/0H/0M/0L",
+        "wddMarkerReview": "fresh GPT-5.5/xhigh review required after this state-only update before commit",
+        "prAgent": "passed; run 29507211075; failed-suggestions issue comment non-actionable; no review threads",
+        "githubVerifyPrCurrent": "run 29507211058 remains failed until a reviewed fix is pushed",
+        "currentStateSummary": "TASK-007 source commit 8a994eac930b18ce5ec1e3fe78999c2a021e4308 and refresh merge f695bf4717ae024283479763d77684de9730f6b5 are pushed; PR #263 is open against epic/durable-lifecycle-pipeline and old GitHub Verify PR run 29507211058 remains failed pending a reviewed push. Migration and lifecycle hot-reload remediations passed focused verification. Complete GPT-5.5/xhigh review 019f6b7d-fd1b-78c3-ba7f-7cade5ca636b reviewed the unchanged 37-path union with 0C/0H/0M/0L substantive findings and initially blocked only on a non-canonical newline-stripped fingerprint. Independent GPT-5.5/xhigh integrity adjudication 019f6b85-a9ac-74f3-9fcd-b10c566acdb8 reproduced 37 paths, exactly six modified files, canonical newline-preserving fingerprint 0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9, git diff --check, and JSON parse, and issued Amended PASS carrying forward 0C/0H/0M/0L. Remediation is reviewed and ready for commit/push after a fresh GPT-5.5/xhigh review of this state-only WDD marker. PR Agent run 29507211075 passed with no review threads. WAVE-005 remains planned and inactive; pauseAfterWave is WAVE-004 and nextWaveActivationAllowed is false."
       },
-      "currentGate": "exact_refresh_merge_active_gpt55_xhigh_full_review_required"
-        }
-      ]
-    },
+      "currentGate": "reviewed_remediation_ready_for_commit_push_pending_fresh_wdd_marker_review"
+    }
+  ]
+},
     {
       "id": "WAVE-005",
       "status": "planned",
@@ -1574,24 +1599,72 @@
       "lowFindingDisposition": "none"
     },
     "exactTaskRefresh": {
-      "status": "conflict_free_uncommitted_merge_active_review_required",
+      "status": "reviewed_committed_pushed_pr_open",
       "sourceCommit": "8a994eac930b18ce5ec1e3fe78999c2a021e4308",
-      "headAndUpstreamCommit": "8a994eac930b18ce5ec1e3fe78999c2a021e4308",
+      "headAndUpstreamCommit": "f695bf4717ae024283479763d77684de9730f6b5",
       "mergeHead": "fdf0e775a411959739a577071788eabe4133e3f2",
       "mergeHeadSource": "final_controller_state_marker",
-      "freshFullReviewRequiredBeforeMergeCommit": true,
+      "freshFullReviewRequiredBeforeMergeCommit": false,
       "reviewModel": "gpt-5.5",
-      "reviewReasoningEffort": "xhigh"
+      "reviewReasoningEffort": "xhigh",
+      "reviewThreadId": "019f6b54-ded2-7201-8ef8-cbfdf63c35cd",
+      "reviewCounts": "0C/0H/0M/0L",
+      "reviewFingerprint": "e1f9ccba66738480acc9d143d454e122413878b8d8edd5885c89f6ec500748d1",
+      "reviewedMergeCommit": "f695bf4717ae024283479763d77684de9730f6b5",
+      "reviewedMergeCommitStatus": "pushed",
+      "pr": "https://github.com/ivo-toby/talon/pull/263"
+    },
+    "pullRequest": {
+      "number": 263,
+      "url": "https://github.com/ivo-toby/talon/pull/263",
+      "targetBranch": "epic/durable-lifecycle-pipeline",
+      "status": "open",
+      "githubVerifyPr": {
+        "runId": "29507211058",
+        "status": "failed",
+        "failure": "one selected committed-v14 migration test expected 1 applied migration and user_version 15, but migrations 016 and 017 make the correct current totals 3 and 17"
+      },
+      "prAgent": {
+        "status": "passed",
+        "runId": "29507211075",
+        "failedSuggestionsIssueComment": "non_actionable",
+        "reviewThreads": "none"
+      },
+      "blockingRemediation": {
+        "status": "reviewed_remediation_ready_for_commit_push_pending_fresh_wdd_marker_review",
+        "sessionId": "019f6b5c-57e9-74e2-9cf4-d59582276884",
+        "model": "gpt-5.5",
+        "reasoningEffort": "high",
+        "changedOnly": "tests/unit/core/database/repositories/lifecycle-event-repository.test.ts lines 866-867; expected applied migration count 1 to 3 and user_version 15 to 17",
+        "verification": "Node 24.15.0 focused verification passed 30/30 in tests/unit/core/database/repositories/lifecycle-event-repository.test.ts; no install, rebuild, or full suite",
+        "fullReviewThreadId": "019f6b67-c08a-7e13-a1e4-579fbac1e114",
+        "fullReviewCounts": "0C/0H/1M/0L",
+        "fullReviewFinding": "successful hot reload could retain stale bootstrap-owned lifecycle runtime, subscriptions, sub-agent assignment, and capability authority",
+        "lifecycleRemediationChangedOnly": "src/daemon/daemon.ts and tests/unit/daemon/reload.test.ts; prior migration-test remediation preserved",
+        "lifecycleRemediationVerification": "focused reload tests 26/26, build, source lint, source formatting, and git diff --check passed",
+        "focusedSanityReviewThreadId": "019f6b75-52f0-73a1-9016-41922cb35236",
+        "focusedSanityReviewCounts": "0C/0H/0M",
+        "freshFullReviewThreadId": "019f6b7d-fd1b-78c3-ba7f-7cade5ca636b",
+        "freshFullReviewCounts": "0C/0H/0M/0L substantive findings",
+        "freshFullReviewInitialDisposition": "blocked only on controller non-canonical newline-stripped fingerprint",
+        "canonicalFingerprint": "0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9",
+        "integrityAdjudicationThreadId": "019f6b85-a9ac-74f3-9fcd-b10c566acdb8",
+        "integrityAdjudication": "Amended PASS; reproduced unchanged 37-path union, exactly six modified files, canonical fingerprint, git diff --check, and JSON parse; carries forward 0C/0H/0M/0L",
+        "freshFullReviewRequiredBeforeCommit": false,
+        "freshWddMarkerReviewRequiredBeforeCommit": true,
+        "reviewModel": "gpt-5.5",
+        "reviewReasoningEffort": "xhigh"
+      }
     }
   },
   "monitoring": {
     "mode": "codex_thread_heartbeat",
     "cadence": "adaptive",
-    "status": "exact_refresh_merge_active_gpt55_xhigh_full_review_required",
-    "lastCheckedAt": "2026-07-16T16:23:58+02:00",
-    "nextCheckDueAt": "2026-07-16T16:28:58+02:00",
+    "status": "pr_open_reviewed_remediations_ready_for_commit_push_pending_fresh_wdd_marker_review",
+    "lastCheckedAt": "2026-07-16T17:24:23+02:00",
+    "nextCheckDueAt": "2026-07-16T17:29:23+02:00",
     "schedulerRef": "talon-issue-256-wdd-wave-4-monitor",
-    "fallbackPrompt": "WAVE-004 post-source-commit controller workflow only. Never use GPT-5.6. Use GPT-5.5/xhigh for every review and at most GPT-5.5/high for implementation or blocking remediation. The model-policy/WDD checkpoint passed GPT-5.5/xhigh 0C/0H/0M/2L and is pushed at d104ba468dbe3241691f8940e90238953b82ebeb. Final controller-state marker review 019f6b4b-dc25-7331-9d26-b5f5595ff21b passed GPT-5.5/xhigh 0C/0H/0M/0L on fingerprint 0b1cb83c04c8987483ecbed102aace37f8681ddc4397c35681c93b7a07b4c131 and marker commit fdf0e775a411959739a577071788eabe4133e3f2 is pushed. TASK-007 is in a conflict-free uncommitted exact refresh merge from fdf0e77; HEAD and upstream remain reviewed source commit 8a994eac930b18ce5ec1e3fe78999c2a021e4308 and MERGE_HEAD is fdf0e775a411959739a577071788eabe4133e3f2. Run a fresh full GPT-5.5/xhigh refresh review before any merge commit, then commit and push the refresh only if it passes 0C/0H/0M, open the PR targeting the epic, and monitor checks, review, freshness, merge, cleanup, and WAVE-004 reconciliation. Do not authorize, start, resume, or redispatch TASK-007 source implementation or source remediation. Remediate only Critical/High/Medium WDD, refresh, or PR blockers; never auto-edit Low/P3 findings, leave .minispec and validation-checklist.md untouched, and do not run the full npm test suite without approval. After the reviewed WAVE-004 reconciliation checkpoint is pushed, deactivate monitoring and pause all epic work; do not activate WAVE-005.",
+    "fallbackPrompt": "WAVE-004 PR controller workflow only. Never use GPT-5.6. Use GPT-5.5/xhigh for every review and at most GPT-5.5/high for implementation or blocking remediation. PR #263 is open against epic/durable-lifecycle-pipeline at pushed refresh merge f695bf4717ae024283479763d77684de9730f6b5; old GitHub Verify PR run 29507211058 remains failed pending a reviewed push. Complete GPT-5.5/xhigh review 019f6b7d-fd1b-78c3-ba7f-7cade5ca636b reviewed the unchanged 37-path union with 0C/0H/0M/0L substantive findings and initially blocked only on the controller's non-canonical newline-stripped fingerprint. Canonical newline-preserving fingerprint is 0ac9b08bf02d5591109710f74b5ec95b0fbb040fbb0daf1e75f6cc2a3be3e0d9. Independent GPT-5.5/xhigh integrity adjudication 019f6b85-a9ac-74f3-9fcd-b10c566acdb8 reproduced 37 paths, exactly six modified files, that fingerprint, git diff --check, and JSON parse, and issued Amended PASS carrying forward 0C/0H/0M/0L. Remediation is reviewed and ready for commit/push after a fresh GPT-5.5/xhigh review of this state-only WDD marker. Remediate only Critical/High/Medium findings; never auto-edit Low/P3 findings. Leave source/tests, .minispec, validation-checklist.md, wave-plan, shared context, and other tasks untouched during the marker update; do not run full npm test without approval. After the reviewed WAVE-004 reconciliation checkpoint is pushed, deactivate monitoring and pause all epic work; do not activate WAVE-005.",
     "stopCondition": "WAVE-004 is fully reconciled, its reviewed reconciliation checkpoint is pushed, monitoring is deactivated, and epic work is paused before WAVE-005.",
     "stopReason": null
   }

--- a/src/core/database/migrations/016-lifecycle-signal-outbox.sql
+++ b/src/core/database/migrations/016-lifecycle-signal-outbox.sql
@@ -1,0 +1,28 @@
+-- Migration 016: durable handoff boundary for handler-emitted lifecycle signals.
+--
+-- Signals are not lifecycle events: they retain their typed signal contract and
+-- are consumed by signal handlers/projectors through this append-only outbox.
+
+CREATE TABLE lifecycle_signal_handoffs (
+  idempotency_key TEXT PRIMARY KEY CHECK (typeof(idempotency_key) = 'text' AND lifecycle_runtime_id_valid(idempotency_key)),
+  event_id        TEXT NOT NULL REFERENCES lifecycle_events(event_id) ON DELETE CASCADE,
+  handler_id      TEXT NOT NULL CHECK (typeof(handler_id) = 'text' AND lifecycle_identifier_valid(handler_id)),
+  persona         TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  created_at      INTEGER NOT NULL CHECK (typeof(created_at) = 'integer' AND created_at BETWEEN -9007199254740991 AND 9007199254740991),
+  UNIQUE (event_id, handler_id, idempotency_key)
+);
+
+CREATE TABLE lifecycle_signals (
+  signal_id       TEXT PRIMARY KEY CHECK (typeof(signal_id) = 'text' AND lifecycle_runtime_id_valid(signal_id)),
+  handoff_key     TEXT NOT NULL REFERENCES lifecycle_signal_handoffs(idempotency_key) ON DELETE CASCADE,
+  persona         TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  version         TEXT NOT NULL CHECK (version = 'v1'),
+  type            TEXT NOT NULL CHECK (typeof(type) = 'text' AND lifecycle_identifier_valid(type)),
+  context         TEXT NOT NULL CHECK (typeof(context) = 'text' AND json_valid(context)),
+  payload         TEXT NOT NULL CHECK (typeof(payload) = 'text' AND lifecycle_json_valid_payload(payload)),
+  occurred_at     TEXT NOT NULL CHECK (typeof(occurred_at) = 'text' AND occurred_at GLOB '????-??-??T??:??:??.???Z' AND strftime('%Y-%m-%dT%H:%M:%fZ', occurred_at) IS occurred_at),
+  created_at      INTEGER NOT NULL CHECK (typeof(created_at) = 'integer' AND created_at BETWEEN -9007199254740991 AND 9007199254740991)
+);
+
+CREATE INDEX idx_lifecycle_signals_persona_created ON lifecycle_signals(persona, created_at);
+CREATE INDEX idx_lifecycle_signals_type_created ON lifecycle_signals(type, created_at);

--- a/src/core/database/migrations/017-queue-lifecycle-scope.sql
+++ b/src/core/database/migrations/017-queue-lifecycle-scope.sql
@@ -1,0 +1,13 @@
+-- Migration 017: lifecycle publication scope is manager-owned queue metadata,
+-- never part of a caller-supplied work payload.
+
+ALTER TABLE queue_items ADD COLUMN lifecycle_persona TEXT
+  CHECK (lifecycle_persona IS NULL OR (typeof(lifecycle_persona) = 'text' AND lifecycle_persona_valid(lifecycle_persona)));
+ALTER TABLE queue_items ADD COLUMN lifecycle_item_type TEXT
+  CHECK (
+    (lifecycle_persona IS NULL AND lifecycle_item_type IS NULL)
+    OR (typeof(lifecycle_persona) = 'text' AND lifecycle_item_type IN ('message', 'schedule'))
+  );
+
+CREATE INDEX idx_queue_items_lifecycle_scope ON queue_items(lifecycle_persona, lifecycle_item_type)
+  WHERE lifecycle_persona IS NOT NULL;

--- a/src/core/database/repositories/index.ts
+++ b/src/core/database/repositories/index.ts
@@ -20,7 +20,7 @@ export { BindingRepository } from './binding-repository.js';
 export type { ThreadRow, InsertThreadInput, UpdateThreadInput } from './thread-repository.js';
 export { ThreadRepository } from './thread-repository.js';
 
-export type { MessageRow, InsertMessageInput } from './message-repository.js';
+export type { MessageRow, InsertMessageInput, InsertMessageOutcome } from './message-repository.js';
 export { MessageRepository } from './message-repository.js';
 
 export type { QueueItemRow, QueueStatus, QueueType, EnqueueInput } from './queue-repository.js';
@@ -86,3 +86,6 @@ export type {
   LifecycleFailureDiagnostic,
 } from './lifecycle-delivery-repository.js';
 export { LifecycleDeliveryRepository } from './lifecycle-delivery-repository.js';
+
+export type { LifecycleSignalHandoffInput, LifecycleSignalRow } from './lifecycle-signal-repository.js';
+export { LifecycleSignalRepository } from './lifecycle-signal-repository.js';

--- a/src/core/database/repositories/lifecycle-signal-repository.ts
+++ b/src/core/database/repositories/lifecycle-signal-repository.ts
@@ -1,0 +1,132 @@
+/** Durable, idempotent handoff storage for validated lifecycle signals. */
+
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+
+import { DbError } from '../../errors/index.js';
+import {
+  LifecycleSignalEnvelopeSchema,
+  type LifecycleSignalEnvelope,
+} from '../../../lifecycle/contracts/index.js';
+import { BaseRepository } from './base-repository.js';
+
+export interface LifecycleSignalHandoffInput {
+  readonly eventId: string;
+  readonly handlerId: string;
+  readonly persona: string;
+  readonly idempotencyKey: string;
+  readonly signals: readonly unknown[];
+}
+
+export interface LifecycleSignalRow {
+  signal_id: string;
+  handoff_key: string;
+  persona: string;
+  version: 'v1';
+  type: string;
+  context: string;
+  payload: string;
+  occurred_at: string;
+  created_at: number;
+}
+
+function sameHandoff(
+  row: { event_id: string; handler_id: string; persona: string },
+  input: LifecycleSignalHandoffInput,
+): boolean {
+  return (
+    row.event_id === input.eventId &&
+    row.handler_id === input.handlerId &&
+    row.persona === input.persona
+  );
+}
+
+/** Signals are committed atomically before the originating delivery completes. */
+export class LifecycleSignalRepository extends BaseRepository {
+  private readonly findHandoffStmt: Database.Statement;
+  private readonly insertHandoffStmt: Database.Statement;
+  private readonly insertSignalStmt: Database.Statement;
+  private readonly countSignalsStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    super(db);
+    this.findHandoffStmt = db.prepare(`
+      SELECT event_id, handler_id, persona FROM lifecycle_signal_handoffs WHERE idempotency_key = ?
+    `);
+    this.insertHandoffStmt = db.prepare(`
+      INSERT INTO lifecycle_signal_handoffs (idempotency_key, event_id, handler_id, persona, created_at)
+      VALUES (@idempotency_key, @event_id, @handler_id, @persona, @created_at)
+    `);
+    this.insertSignalStmt = db.prepare(`
+      INSERT INTO lifecycle_signals
+        (signal_id, handoff_key, persona, version, type, context, payload, occurred_at, created_at)
+      VALUES
+        (@signal_id, @handoff_key, @persona, @version, @type, @context, @payload, @occurred_at, @created_at)
+    `);
+    this.countSignalsStmt = db.prepare(`
+      SELECT COUNT(*) AS count FROM lifecycle_signals WHERE handoff_key = ?
+    `);
+  }
+
+  handoff(input: LifecycleSignalHandoffInput): Result<void, DbError> {
+    const signals = this.parseSignals(input.signals);
+    if (!signals || input.persona.length === 0) {
+      return err(new DbError('Failed to persist lifecycle signal handoff: invalid signal handoff'));
+    }
+    try {
+      const write = this.db.transaction(() => {
+        const existing = this.findHandoffStmt.get(input.idempotencyKey) as
+          | { event_id: string; handler_id: string; persona: string }
+          | undefined;
+        if (existing) {
+          if (!sameHandoff(existing, input)) {
+            throw new Error('lifecycle signal handoff idempotency key collision');
+          }
+          const count = this.countSignalsStmt.get(input.idempotencyKey) as { count: number };
+          if (count.count !== signals.length) {
+            throw new Error('lifecycle signal handoff is incomplete');
+          }
+          return;
+        }
+        const createdAt = this.now();
+        this.insertHandoffStmt.run({
+          idempotency_key: input.idempotencyKey,
+          event_id: input.eventId,
+          handler_id: input.handlerId,
+          persona: input.persona,
+          created_at: createdAt,
+        });
+        for (const signal of signals) {
+          this.insertSignalStmt.run({
+            signal_id: signal.signalId,
+            handoff_key: input.idempotencyKey,
+            persona: input.persona,
+            version: signal.version,
+            type: signal.type,
+            context: JSON.stringify(signal.context),
+            payload: JSON.stringify(signal.payload),
+            occurred_at: signal.occurredAt,
+            created_at: createdAt,
+          });
+        }
+      });
+      write();
+      return ok(undefined);
+    } catch {
+      return err(new DbError('Failed to persist lifecycle signal handoff'));
+    }
+  }
+
+  private parseSignals(signals: readonly unknown[]): LifecycleSignalEnvelope[] | undefined {
+    if (signals.length > 32) return undefined;
+    const parsed: LifecycleSignalEnvelope[] = [];
+    const ids = new Set<string>();
+    for (const signal of signals) {
+      const candidate = LifecycleSignalEnvelopeSchema.safeParse(signal);
+      if (!candidate.success || ids.has(candidate.data.signalId)) return undefined;
+      ids.add(candidate.data.signalId);
+      parsed.push(candidate.data);
+    }
+    return parsed;
+  }
+}

--- a/src/core/database/repositories/message-repository.ts
+++ b/src/core/database/repositories/message-repository.ts
@@ -26,6 +26,12 @@ export interface MessageRow {
 /** Fields accepted when inserting a new message. `created_at` is set automatically. */
 export type InsertMessageInput = Omit<MessageRow, 'created_at'>;
 
+/** The authoritative outcome of INSERT OR IGNORE. */
+export interface InsertMessageOutcome {
+  readonly message: MessageRow;
+  readonly inserted: boolean;
+}
+
 /** Repository for reading and writing message records. */
 export class MessageRepository extends BaseRepository {
   private readonly insertStmt: Database.Statement;
@@ -86,12 +92,21 @@ export class MessageRepository extends BaseRepository {
    * succeeds but returns the existing row unchanged.
    */
   insert(input: InsertMessageInput): Result<MessageRow, DbError> {
+    return this.insertIfAbsent(input).map(({ message }) => message);
+  }
+
+  /**
+   * Inserts a message or returns the existing idempotent row while preserving
+   * whether this invocation actually created durable state. Callers that
+   * attach follow-up work must use this instead of inferring from the row.
+   */
+  insertIfAbsent(input: InsertMessageInput): Result<InsertMessageOutcome, DbError> {
     try {
       const row: MessageRow = { ...input, created_at: this.now() };
-      this.insertStmt.run(row);
+      const result = this.insertStmt.run(row);
       // Re-fetch so we always return the authoritative persisted row.
       const persisted = this.findByIdempotencyKeyStmt.get(input.idempotency_key) as MessageRow;
-      return ok(persisted);
+      return ok({ message: persisted, inserted: result.changes === 1 });
     } catch (cause) {
       return err(
         new DbError(

--- a/src/core/database/repositories/queue-repository.ts
+++ b/src/core/database/repositories/queue-repository.ts
@@ -29,6 +29,8 @@ export interface QueueItemRow {
   next_retry_at: number | null;
   error: string | null;
   payload: string;
+  lifecycle_persona: string | null;
+  lifecycle_item_type: 'message' | 'schedule' | null;
   claimed_at: number | null;
   created_at: number;
   updated_at: number;
@@ -37,15 +39,24 @@ export interface QueueItemRow {
 /** Fields accepted when enqueueing a new item. */
 export type EnqueueInput = Pick<
   QueueItemRow,
-  'id' | 'thread_id' | 'message_id' | 'type' | 'payload' | 'max_attempts'
->;
+  | 'id'
+  | 'thread_id'
+  | 'message_id'
+  | 'type'
+  | 'payload'
+  | 'max_attempts'
+> &
+  Partial<Pick<QueueItemRow, 'lifecycle_persona' | 'lifecycle_item_type'>>;
 
 /** Repository for durable queue operations. */
 export class QueueRepository extends BaseRepository {
   private readonly enqueueStmt: Database.Statement;
   private readonly claimNextStmt: Database.Statement;
   private readonly completeStmt: Database.Statement;
+  private readonly completeClaimedStmt: Database.Statement;
   private readonly markDeadLetterStmt: Database.Statement;
+  private readonly failClaimedStmt: Database.Statement;
+  private readonly deadLetterClaimedStmt: Database.Statement;
   private readonly findByIdStmt: Database.Statement;
   private readonly findPendingStmt: Database.Statement;
   private readonly findDeadLetterStmt: Database.Statement;
@@ -59,10 +70,12 @@ export class QueueRepository extends BaseRepository {
     this.enqueueStmt = db.prepare(`
       INSERT INTO queue_items
         (id, thread_id, message_id, type, status, attempts, max_attempts,
-         next_retry_at, error, payload, claimed_at, created_at, updated_at)
+         next_retry_at, error, payload, lifecycle_persona, lifecycle_item_type,
+         claimed_at, created_at, updated_at)
       VALUES
         (@id, @thread_id, @message_id, @type, 'pending', 0, @max_attempts,
-         NULL, NULL, @payload, NULL, @created_at, @updated_at)
+         NULL, NULL, @payload, @lifecycle_persona, @lifecycle_item_type,
+         NULL, @created_at, @updated_at)
     `);
 
     // Atomically claim the oldest pending/retryable item for a given thread.
@@ -106,10 +119,29 @@ export class QueueRepository extends BaseRepository {
       WHERE id = @id
     `);
 
+    this.completeClaimedStmt = db.prepare(`
+      UPDATE queue_items
+      SET status = 'completed', updated_at = @now
+      WHERE id = @id AND status = 'claimed'
+    `);
+
     this.markDeadLetterStmt = db.prepare(`
       UPDATE queue_items
       SET status = 'dead_letter', error = @error, updated_at = @now
       WHERE id = @id
+    `);
+
+    this.failClaimedStmt = db.prepare(`
+      UPDATE queue_items
+      SET status = 'failed', attempts = attempts + 1, next_retry_at = @next_retry_at,
+          error = @error, updated_at = @now
+      WHERE id = @id AND status = 'claimed' AND attempts + 1 < max_attempts
+    `);
+    this.deadLetterClaimedStmt = db.prepare(`
+      UPDATE queue_items
+      SET status = 'dead_letter', attempts = attempts + 1, next_retry_at = NULL,
+          error = @error, updated_at = @now
+      WHERE id = @id AND status = 'claimed' AND attempts + 1 >= max_attempts
     `);
 
     this.findByIdStmt = db.prepare(`SELECT * FROM queue_items WHERE id = ?`);
@@ -143,7 +175,13 @@ export class QueueRepository extends BaseRepository {
   enqueue(input: EnqueueInput): Result<QueueItemRow, DbError> {
     try {
       const ts = this.now();
-      this.enqueueStmt.run({ ...input, created_at: ts, updated_at: ts });
+      this.enqueueStmt.run({
+        ...input,
+        lifecycle_persona: input.lifecycle_persona ?? null,
+        lifecycle_item_type: input.lifecycle_item_type ?? null,
+        created_at: ts,
+        updated_at: ts,
+      });
       const row = this.findByIdStmt.get(input.id) as QueueItemRow;
       return ok(row);
     } catch (cause) {
@@ -191,6 +229,55 @@ export class QueueRepository extends BaseRepository {
       return ok(undefined);
     } catch (cause) {
       return err(new DbError(`Failed to complete queue item: ${String(cause)}`, cause instanceof Error ? cause : undefined));
+    }
+  }
+
+  /** Completes exactly one currently claimed item. */
+  completeClaimed(id: string): Result<boolean, DbError> {
+    try {
+      return ok(this.completeClaimedStmt.run({ id, now: this.now() }).changes === 1);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to complete claimed queue item: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
+  }
+
+  /**
+   * Applies one terminal failure transition only while the item remains
+   * claimed. A stale/conflicting call returns null and must not publish.
+   */
+  transitionClaimedFailure(
+    id: string,
+    errorMessage: string,
+    nextRetryAt: number,
+  ): Result<'failed' | 'dead_letter' | null, DbError> {
+    try {
+      const now = this.now();
+      if (this.deadLetterClaimedStmt.run({ id, error: errorMessage, now }).changes === 1) {
+        return ok('dead_letter');
+      }
+      if (
+        this.failClaimedStmt.run({
+          id,
+          error: errorMessage,
+          next_retry_at: nextRetryAt,
+          now,
+        }).changes === 1
+      ) {
+        return ok('failed');
+      }
+      return ok(null);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to transition claimed queue item: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
     }
   }
 

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -1165,6 +1165,7 @@ export class AgentRunner {
                         'message',
                         { personaId, content: 'continue' },
                         continueMessageId,
+                        { persona: personaName, itemType: 'message' },
                       );
                       if (enqueueResult.isOk()) {
                         this.ctx.logger.info(

--- a/src/daemon/daemon-bootstrap.ts
+++ b/src/daemon/daemon-bootstrap.ts
@@ -33,6 +33,9 @@ import {
   BindingRepository,
   MemoryRepository,
   A2ATaskRepository,
+  LifecycleEventRepository,
+  LifecycleDeliveryRepository,
+  LifecycleSignalRepository,
 } from '../core/database/repositories/index.js';
 import { buildAgentCardRegistry, A2ATaskMapper, A2AServer } from '../a2a/index.js';
 
@@ -43,7 +46,7 @@ import { MessagePipeline } from '../pipeline/message-pipeline.js';
 import { QueueManager } from '../queue/queue-manager.js';
 import { Scheduler } from '../scheduler/scheduler.js';
 import { migrateLegacySchedules } from '../scheduler/legacy-schedule-migration.js';
-import { DaemonError, SubAgentError } from '../core/errors/error-types.js';
+import { DaemonError, LifecycleError, SubAgentError } from '../core/errors/error-types.js';
 import { AuditLogger } from '../core/logging/audit-logger.js';
 import { RepositoryAuditStore } from '../core/database/repositories/audit-repository.js';
 import { PersonaLoader } from '../personas/persona-loader.js';
@@ -74,6 +77,36 @@ import { NoopObservabilityService } from '../observability/langfuse/noop-observa
 import type { ObservabilityService } from '../observability/langfuse/observability-types.js';
 import { wrapProviderOptions } from '../subagents/provider-options.js';
 import { OAuthTokenStore } from '../auth/oauth-token-store.js';
+import { LifecycleEventBus } from '../lifecycle/lifecycle-event-bus.js';
+import { LifecycleDispatcher } from '../lifecycle/lifecycle-dispatcher.js';
+import { CapturedLifecycleHandlerExecutor } from '../lifecycle/handler-executor.js';
+import type { LifecycleRuntimeCapability } from '../lifecycle/handler-executor.js';
+import { LifecycleInterceptorEngine } from '../lifecycle/interceptors/interceptor-engine.js';
+import { nativeAllowInterceptor } from '../lifecycle/interceptors/native-example-handlers.js';
+import { SubAgentLifecycleAdapter } from '../lifecycle/adapters/subagent-lifecycle-adapter.js';
+import { createLifecycleHandlerRegistry } from '../lifecycle/handler-registry.js';
+import { LifecycleRuntime } from '../lifecycle/lifecycle-runtime.js';
+import {
+  LIFECYCLE_ENFORCING_INTERCEPTOR_OUTPUT_CONTRACT,
+  LIFECYCLE_EVENT_INPUT_CONTRACT,
+  LIFECYCLE_INTERCEPTOR_INPUT_CONTRACT,
+  LIFECYCLE_SIGNAL_ENVELOPES_OUTPUT_CONTRACT,
+} from '../lifecycle/contracts/index.js';
+
+/** Lifecycle attachment requires both a loaded capability and persona opt-in. */
+export function hasExplicitLifecycleSubagentAuthority(
+  subagents: readonly string[] | undefined,
+  implementationRef: string,
+): boolean {
+  return subagents?.includes(implementationRef) ?? false;
+}
+
+export function supportsLifecycleBootstrapHandler(
+  runtimeKind: 'native' | 'subagent',
+  mode: 'event' | 'signal' | 'interceptor',
+): boolean {
+  return runtimeKind === 'native' || mode !== 'interceptor';
+}
 
 // ---------------------------------------------------------------------------
 // Bootstrap
@@ -164,6 +197,9 @@ export async function bootstrap(
     binding: new BindingRepository(db),
     memory: new MemoryRepository(db),
     a2aTask: new A2ATaskRepository(db),
+    lifecycleEvent: new LifecycleEventRepository(db),
+    lifecycleDelivery: new LifecycleDeliveryRepository(db),
+    lifecycleSignal: new LifecycleSignalRepository(db),
   };
 
   // 5. Audit logger
@@ -204,6 +240,7 @@ export async function bootstrap(
       ),
     );
   }
+  const loadedPersonaList = personaLoadResult.value;
 
   // 8. Load skills
   const skillLoader = new SkillLoader(logger);
@@ -616,7 +653,225 @@ export async function bootstrap(
   const channelRegistry = new ChannelRegistry(logger);
 
   // 12. Queue manager
-  const queueManager = new QueueManager(repos.queue, repos.thread, config.queue, logger);
+  // Lifecycle services are intentionally constructed only when enabled. This
+  // keeps an omitted/disabled lifecycle configuration on the exact legacy
+  // execution path, while the durable dispatcher remains an independent
+  // workload when enabled.
+  let lifecycleRuntime: LifecycleRuntime | null = null;
+  if (config.lifecycle?.enabled) {
+    const nativeImplementations = {
+      'native-noop-event': () =>
+        Promise.resolve(
+          ok({
+            outcome: 'success' as const,
+            outputContract:
+              LIFECYCLE_SIGNAL_ENVELOPES_OUTPUT_CONTRACT as typeof LIFECYCLE_SIGNAL_ENVELOPES_OUTPUT_CONTRACT,
+            signals: [],
+          }),
+        ),
+      // Interceptors execute synchronously through LifecycleInterceptorEngine;
+      // retaining this identity in the captured executor prevents a divergent
+      // authority catalog from ever selecting a different implementation.
+      'native-allow-interceptor': () =>
+        Promise.resolve(err(new LifecycleError('Lifecycle interceptors are not dispatcher jobs'))),
+    };
+    const nativeImplementationCatalog = [
+      {
+        ref: 'native-noop-event',
+        implementationVersion: '1.0.0',
+        mode: 'event' as const,
+        inputContract: LIFECYCLE_EVENT_INPUT_CONTRACT,
+        outputContract: LIFECYCLE_SIGNAL_ENVELOPES_OUTPUT_CONTRACT,
+      },
+      {
+        ref: 'native-allow-interceptor',
+        implementationVersion: '1.0.0',
+        mode: 'interceptor' as const,
+        inputContract: LIFECYCLE_INTERCEPTOR_INPUT_CONTRACT,
+        outputContract: LIFECYCLE_ENFORCING_INTERCEPTOR_OUTPUT_CONTRACT,
+        interceptorSafety: 'enforcing' as const,
+      },
+    ];
+    const loadedSubagentCatalog = [...mergedAgentMap.values()].flatMap((agent) =>
+      (agent.lifecycleCapabilities ?? []).map((capability) => ({
+        ref: agent.manifest.name,
+        implementationVersion: agent.manifest.version,
+        mode: capability.mode,
+        inputContract: capability.inputContract,
+        outputContract: capability.outputContract,
+        ...(capability.interceptorSafety
+          ? { interceptorSafety: capability.interceptorSafety }
+          : {}),
+      })),
+    );
+    const registryResult = createLifecycleHandlerRegistry({
+      lifecycle: config.lifecycle,
+      channels: config.channels.map(({ name }) => ({ name })),
+      personas: config.personas.map(({ name, lifecycle }) => ({ name, lifecycle })),
+      nativeImplementationCatalog,
+      loadedSubagentCatalog,
+    });
+    if (registryResult.isErr()) {
+      await cleanupBootstrapFailure(db, observability, logger);
+      return err(
+        new DaemonError(`Failed to construct lifecycle registry: ${registryResult.error.message}`),
+      );
+    }
+    const resolvedHandlers = config.personas.flatMap((persona) =>
+      registryResult.value.listPersonaHandlers(persona.name),
+    );
+    const nativeCatalogByIdentity = new Map<string, LifecycleRuntimeCapability>();
+    const subagentCatalog: LifecycleRuntimeCapability[] = [];
+    const subagentAdapter = subAgentRunner ? new SubAgentLifecycleAdapter(subAgentRunner) : null;
+    for (const handler of resolvedHandlers) {
+      if (handler.identity.runtimeKind === 'native') {
+        const implementation =
+          nativeImplementations[
+            handler.identity.implementationRef as keyof typeof nativeImplementations
+          ];
+        if (implementation) {
+          // Native handlers have no persona authority. Capture each immutable
+          // identity once even when configuration attaches it to many personas.
+          const identityKey = JSON.stringify([
+            handler.identity.version,
+            handler.identity.handlerId,
+            handler.identity.runtimeKind,
+            handler.identity.implementationRef,
+            handler.identity.implementationVersion,
+            handler.identity.mode,
+            handler.identity.inputContract,
+            handler.identity.outputContract,
+            handler.identity.interceptorSafety ?? null,
+          ]);
+          if (!nativeCatalogByIdentity.has(identityKey)) {
+            nativeCatalogByIdentity.set(identityKey, {
+              identity: handler.identity,
+              handler: implementation,
+            });
+          }
+        }
+        continue;
+      }
+      if (!supportsLifecycleBootstrapHandler(handler.identity.runtimeKind, handler.identity.mode)) {
+        await cleanupBootstrapFailure(db, observability, logger);
+        return err(
+          new DaemonError(
+            `Lifecycle sub-agent interceptors are unsupported: ${handler.identity.handlerId}`,
+          ),
+        );
+      }
+      const loadedPersona = loadedPersonaList.find(
+        (persona) => persona.config.name === handler.persona,
+      );
+      const personaRow = repos.persona.findByName(handler.persona);
+      const agent = mergedAgentMap.get(handler.identity.implementationRef);
+      if (
+        !subagentAdapter ||
+        !loadedPersona ||
+        personaRow.isErr() ||
+        !personaRow.value ||
+        !agent?.lifecycleRun ||
+        !hasExplicitLifecycleSubagentAuthority(
+          loadedPersona.config.subagents,
+          handler.identity.implementationRef,
+        )
+      ) {
+        await cleanupBootstrapFailure(db, observability, logger);
+        return err(
+          new DaemonError(
+            `Failed to construct lifecycle sub-agent capability for ${handler.identity.handlerId}`,
+          ),
+        );
+      }
+      const capturedHandler = handler;
+      const capturedPersona = loadedPersona;
+      const capturedPersonaId = personaRow.value.id;
+      subagentCatalog.push({
+        identity: handler.identity,
+        subagentScope: {
+          persona: handler.persona,
+          capabilities: {
+            allow: [...capturedPersona.resolvedCapabilities.allow],
+            requireApproval: [...capturedPersona.resolvedCapabilities.requireApproval],
+          },
+        },
+        handler: (execution) =>
+          subagentAdapter.invoke({
+            handler: capturedHandler,
+            scope: {
+              threadId:
+                execution.event.payload.references.find((reference) => reference.type === 'thread')
+                  ?.id ?? execution.event.context.aggregate.id,
+              aggregate: execution.event.context.aggregate,
+              persona: {
+                id: capturedPersonaId,
+                name: capturedHandler.persona,
+                subagents: capturedPersona.config.subagents,
+                capabilities: capturedPersona.resolvedCapabilities,
+              },
+            },
+            input: execution.event,
+          }),
+      });
+    }
+    const executorResult = CapturedLifecycleHandlerExecutor.create({
+      nativeCatalog: [...nativeCatalogByIdentity.values()],
+      subagentCatalog,
+    });
+    if (executorResult.isErr()) {
+      await cleanupBootstrapFailure(db, observability, logger);
+      return err(
+        new DaemonError(`Failed to construct lifecycle executor: ${executorResult.error.message}`),
+      );
+    }
+    const interceptorEngine = new LifecycleInterceptorEngine({
+      resolveHandlers: (
+        query,
+      ): ReturnType<typeof registryResult.value.resolveInterceptorHandlers> =>
+        registryResult.value.resolveInterceptorHandlers(query),
+      implementations: { 'native-allow-interceptor': nativeAllowInterceptor },
+      auditLogger,
+    });
+    const dispatcherResult = LifecycleDispatcher.create({
+      deliveries: repos.lifecycleDelivery,
+      executor: executorResult.value,
+      signalRouter: {
+        handoff: (handoff) => {
+          if (handoff.signals.length === 0) return Promise.resolve(ok(undefined));
+          const persisted = repos.lifecycleSignal.handoff(handoff);
+          return Promise.resolve(
+            persisted.isErr()
+              ? err(
+                  new LifecycleError(
+                    `Failed to persist lifecycle signals: ${persisted.error.message}`,
+                  ),
+                )
+              : ok(undefined),
+          );
+        },
+      },
+    });
+    if (dispatcherResult.isErr()) {
+      await cleanupBootstrapFailure(db, observability, logger);
+      return err(
+        new DaemonError(
+          `Failed to construct lifecycle dispatcher: ${dispatcherResult.error.message}`,
+        ),
+      );
+    }
+    const dispatcher = dispatcherResult.value;
+    const eventBus = new LifecycleEventBus(repos.lifecycleEvent, registryResult.value, () => {
+      dispatcher.wake();
+    });
+    lifecycleRuntime = new LifecycleRuntime(eventBus, interceptorEngine, dispatcher);
+  }
+  const queueManager = new QueueManager(
+    repos.queue,
+    repos.thread,
+    config.queue,
+    logger,
+    lifecycleRuntime ?? undefined,
+  );
 
   let executionEnvManager: ExecutionEnvManager | null = null;
   if (config.sprites.enabled) {
@@ -646,6 +901,13 @@ export async function bootstrap(
       providerRegistry: backgroundProviderRegistry,
       executionEnvManager,
       hostToolsSocketPath: resolve(join(dataDir, 'host-tools.sock')),
+      resolveLifecyclePersonaName: lifecycleRuntime
+        ? (personaId: string): string | undefined =>
+            personaLoader
+              .getById(personaId)
+              .map((persona) => persona?.config.name)
+              .unwrapOr(undefined)
+        : undefined,
       // Share the same token store the foreground path uses so an
       // `talonctl auth-mcp` run unlocks Glean (etc.) for both run
       // types — without this, background runs receive raw
@@ -674,6 +936,7 @@ export async function bootstrap(
     personaLoader,
     config.scheduler,
     logger,
+    lifecycleRuntime ?? undefined,
   );
 
   // 15. Message pipeline and channel registration
@@ -686,6 +949,8 @@ export async function bootstrap(
     router,
     auditLogger,
     logger,
+    lifecycleRuntime ?? undefined,
+    (personaId) => personaLoader.getById(personaId).map((persona) => persona?.config.name),
   );
 
   registerChannels(config, channelRegistry, {
@@ -697,7 +962,6 @@ export async function bootstrap(
   });
 
   // 16. A2A server (internal-only, no port binding in M1)
-  const loadedPersonaList = personaLoadResult.value;
   const a2aCardRegistry = buildAgentCardRegistry(loadedPersonaList);
   const a2aTaskMapper = new A2ATaskMapper(
     repos.a2aTask,
@@ -742,6 +1006,7 @@ export async function bootstrap(
     contextAssembler,
     oauthTokenStore,
     logger,
+    lifecycleRuntime,
     a2aServer,
     a2aTaskMapper,
   } as Omit<DaemonContext, 'hostToolsBridge'> & { hostToolsBridge?: HostToolsBridge };

--- a/src/daemon/daemon-context.ts
+++ b/src/daemon/daemon-context.ts
@@ -27,6 +27,9 @@ import type {
   BindingRepository,
   MemoryRepository,
   A2ATaskRepository,
+  LifecycleEventRepository,
+  LifecycleDeliveryRepository,
+  LifecycleSignalRepository,
 } from '../core/database/repositories/index.js';
 import type { ChannelRegistry } from '../channels/channel-registry.js';
 import type { QueueManager } from '../queue/queue-manager.js';
@@ -49,6 +52,7 @@ import type { ObservabilityService } from '../observability/langfuse/observabili
 import type { A2AServer } from '../a2a/a2a-server.js';
 import type { A2ATaskMapper } from '../a2a/a2a-task-mapper.js';
 import type { OAuthTokenStore } from '../auth/oauth-token-store.js';
+import type { LifecycleRuntime } from '../lifecycle/lifecycle-runtime.js';
 
 // ---------------------------------------------------------------------------
 // Repository bundle
@@ -70,6 +74,9 @@ export interface DaemonRepos {
   readonly binding: BindingRepository;
   readonly memory: MemoryRepository;
   readonly a2aTask: A2ATaskRepository;
+  readonly lifecycleEvent: LifecycleEventRepository;
+  readonly lifecycleDelivery: LifecycleDeliveryRepository;
+  readonly lifecycleSignal: LifecycleSignalRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,4 +123,6 @@ export interface DaemonContext {
   readonly toolInstructions: Map<string, string>;
   readonly a2aServer: A2AServer | null;
   readonly a2aTaskMapper: A2ATaskMapper | null;
+  /** Null when lifecycle is absent or explicitly disabled, preserving legacy behaviour. */
+  readonly lifecycleRuntime: LifecycleRuntime | null;
 }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -45,6 +45,7 @@ export class TalondDaemon {
   private ipcServer: DaemonIpcServer | null = null;
   private watchdog: WatchdogNotifier | null = null;
   private mcpRegistry: McpRegistry | null = null;
+  private deferredTeardown: Promise<void> | null = null;
 
   constructor(private readonly logger: pino.Logger) {}
 
@@ -74,88 +75,205 @@ export class TalondDaemon {
     }
     this.ctx = ctxResult.value;
 
-    if (this.logger.level !== this.ctx.config.logLevel) {
-      this.logger.level = this.ctx.config.logLevel;
-    }
+    try {
+      if (this.logger.level !== this.ctx.config.logLevel) {
+        this.logger.level = this.ctx.config.logLevel;
+      }
 
-    // 2. Register and start MCP servers from loaded skills.
-    this.mcpRegistry = new McpRegistry(this.logger);
-    for (const skill of this.ctx.loadedSkills) {
-      for (const server of skill.resolvedMcpServers) {
-        try {
-          this.mcpRegistry.register(server.name, server.config);
-        } catch (cause) {
-          this.logger.warn(
-            { mcpServer: server.name, cause: String(cause) },
-            'daemon: failed to register MCP server definition',
-          );
+      // 2. Register and start MCP servers from loaded skills.
+      this.mcpRegistry = new McpRegistry(this.logger);
+      for (const skill of this.ctx.loadedSkills) {
+        for (const server of skill.resolvedMcpServers) {
+          try {
+            this.mcpRegistry.register(server.name, server.config);
+          } catch (cause) {
+            this.logger.warn(
+              { mcpServer: server.name, cause: String(cause) },
+              'daemon: failed to register MCP server definition',
+            );
+          }
         }
       }
-    }
-    await this.mcpRegistry.startAll();
+      await this.mcpRegistry.startAll();
 
-    // 3. Create the agent runner and start the host-tools bridge.
-    this.agentRunner = new AgentRunner(this.ctx);
-    this.ctx.hostToolsBridge.start();
+      // 3. Create the agent runner and start the host-tools bridge.
+      this.agentRunner = new AgentRunner(this.ctx);
+      this.ctx.hostToolsBridge.start();
 
-    // 4. Start channel connectors (non-fatal).
-    try {
-      await this.ctx.channelRegistry.startAll();
-      this.logger.info('daemon: all channel connectors started');
+      // 4. Start channel connectors (non-fatal).
+      try {
+        await this.ctx.channelRegistry.startAll();
+        this.logger.info('daemon: all channel connectors started');
+      } catch (cause) {
+        this.logger.error(
+          { cause },
+          'daemon: one or more channel connectors failed to start — continuing without them',
+        );
+      }
+
+      // Inject sibling bot IDs for multi-connector self-filtering.
+      injectSiblingBotIds(this.ctx.channelRegistry, this.logger);
+
+      // 5. Start queue processing.
+      this.ctx.queueManager.startProcessing((item) => this.agentRunner!.run(item));
+
+      // Lifecycle delivery is deliberately independent from the user queue: a
+      // slow or failing handler may retry in its own durable workload but never
+      // consumes queue capacity or changes an originating queue item result.
+      this.ctx.lifecycleRuntime?.start();
+
+      // 6. Start scheduler.
+      this.ctx.scheduler.start();
+
+      // 7. Write PID file (non-fatal).
+      try {
+        writePidFile(this.ctx.dataDir);
+      } catch (cause) {
+        this.logger.warn({ cause }, 'daemon: failed to write PID file');
+      }
+
+      // 8. Start IPC server.
+      const ipcBase = join(this.ctx.dataDir, 'ipc/daemon');
+      await Promise.all([
+        ensureOwnerOnlyDir(join(ipcBase, 'input')),
+        ensureOwnerOnlyDir(join(ipcBase, 'output')),
+        ensureOwnerOnlyDir(join(ipcBase, 'errors')),
+      ]);
+      this.ipcServer = new DaemonIpcServer({
+        inputDir: join(ipcBase, 'input'),
+        outputDir: join(ipcBase, 'output'),
+        errorsDir: join(ipcBase, 'errors'),
+        logger: this.logger,
+        commandHandler: (cmd: DaemonCommand): Promise<DaemonResponse> => this.handleIpcCommand(cmd),
+      });
+      this.ipcServer.start();
+      this.logger.info('daemon: IPC server started');
+
+      // 9. Mark running + start watchdog.
+      this._state = 'running';
+      this.startedAt = Date.now();
+      this.logger.info('daemon: running');
+
+      this.watchdog = new WatchdogNotifier({
+        intervalMs: 10_000,
+        logger: this.logger,
+        dataDir: this.ctx.dataDir,
+      });
+      this.watchdog.start();
+      this.watchdog.notifyReady();
+
+      return ok(undefined);
     } catch (cause) {
-      this.logger.error(
-        { cause },
-        'daemon: one or more channel connectors failed to start — continuing without them',
+      const message = cause instanceof Error ? cause.message : String(cause);
+      this.logger.error({ cause }, 'daemon: startup failed after bootstrap');
+      const cleaned = await this.cleanupFailedStart();
+      if (!cleaned) {
+        this.beginDeferredTeardown();
+        return err(
+          new DaemonError(`Failed to start daemon: ${message}; workloads are still draining`),
+        );
+      }
+      this._state = 'stopped';
+      return err(
+        new DaemonError(
+          `Failed to start daemon: ${message}`,
+          cause instanceof Error ? cause : undefined,
+        ),
       );
     }
+  }
 
-    // Inject sibling bot IDs for multi-connector self-filtering.
-    injectSiblingBotIds(this.ctx.channelRegistry, this.logger);
-
-    // 5. Start queue processing.
-    this.ctx.queueManager.startProcessing((item) => this.agentRunner!.run(item));
-
-    // 6. Start scheduler.
-    this.ctx.scheduler.start();
-
-    // 7. Write PID file (non-fatal).
+  /** Best-effort reverse-order cleanup for a startup that never reached running. */
+  private async cleanupFailedStart(): Promise<boolean> {
+    this.watchdog?.stop();
+    this.watchdog = null;
+    this.ipcServer?.stop();
+    this.ipcServer = null;
+    const ctx = this.ctx;
+    if (!ctx) return true;
     try {
-      writePidFile(this.ctx.dataDir);
+      removePidFile(ctx.dataDir);
     } catch (cause) {
-      this.logger.warn({ cause }, 'daemon: failed to write PID file');
+      this.logStartupCleanupFailure('remove PID file', cause);
     }
+    let schedulerDrained = false;
+    try {
+      schedulerDrained = (await ctx.scheduler.stop())?.status !== 'timed_out';
+    } catch (cause) {
+      this.logStartupCleanupFailure('stop scheduler', cause);
+    }
+    let lifecycleDrained = false;
+    try {
+      lifecycleDrained = (await ctx.lifecycleRuntime?.stop()) ?? true;
+    } catch (cause) {
+      this.logStartupCleanupFailure('stop lifecycle dispatcher', cause);
+    }
+    let queueDrained = false;
+    try {
+      queueDrained = (await ctx.queueManager.stopProcessing())?.status !== 'timed_out';
+    } catch (cause) {
+      this.logStartupCleanupFailure('stop queue processing', cause);
+    }
+    if (!schedulerDrained || !lifecycleDrained || !queueDrained) return false;
+    try {
+      await ctx.channelRegistry.stopAll();
+    } catch (cause) {
+      this.logStartupCleanupFailure('stop channel connectors', cause);
+    }
+    try {
+      ctx.hostToolsBridge.stop();
+    } catch (cause) {
+      this.logStartupCleanupFailure('stop host tools bridge', cause);
+    }
+    try {
+      await this.mcpRegistry?.stopAll();
+    } catch (cause) {
+      this.logStartupCleanupFailure('stop MCP registry', cause);
+    }
+    this.mcpRegistry = null;
+    try {
+      await ctx.backgroundAgentManager?.shutdown();
+    } catch (cause) {
+      this.logStartupCleanupFailure('shutdown background agents', cause);
+    }
+    try {
+      await ctx.observability.shutdown();
+    } catch (cause) {
+      this.logStartupCleanupFailure('shutdown observability', cause);
+    }
+    try {
+      ctx.db.close();
+    } catch (cause) {
+      this.logStartupCleanupFailure('close database', cause);
+    }
+    this.ctx = null;
+    this.agentRunner = null;
+    this.startedAt = null;
+    return true;
+  }
 
-    // 8. Start IPC server.
-    const ipcBase = join(this.ctx.dataDir, 'ipc/daemon');
-    await Promise.all([
-      ensureOwnerOnlyDir(join(ipcBase, 'input')),
-      ensureOwnerOnlyDir(join(ipcBase, 'output')),
-      ensureOwnerOnlyDir(join(ipcBase, 'errors')),
-    ]);
-    this.ipcServer = new DaemonIpcServer({
-      inputDir: join(ipcBase, 'input'),
-      outputDir: join(ipcBase, 'output'),
-      errorsDir: join(ipcBase, 'errors'),
-      logger: this.logger,
-      commandHandler: (cmd: DaemonCommand): Promise<DaemonResponse> => this.handleIpcCommand(cmd),
-    });
-    this.ipcServer.start();
-    this.logger.info('daemon: IPC server started');
+  private beginDeferredTeardown(): void {
+    if (this.deferredTeardown || !this.ctx) return;
+    const ctx = this.ctx;
+    this.deferredTeardown = Promise.all([
+      ctx.scheduler.waitForDrain(),
+      ctx.queueManager.waitForDrain(),
+      ctx.lifecycleRuntime?.waitForDrain() ?? Promise.resolve(),
+    ])
+      .then(() => this.cleanupFailedStart())
+      .then((cleaned) => {
+        if (cleaned) this._state = 'stopped';
+      })
+      .catch((cause) => {
+        this.logStartupCleanupFailure('deferred workload drain', cause);
+      })
+      .finally(() => {
+        this.deferredTeardown = null;
+      });
+  }
 
-    // 9. Mark running + start watchdog.
-    this._state = 'running';
-    this.startedAt = Date.now();
-    this.logger.info('daemon: running');
-
-    this.watchdog = new WatchdogNotifier({
-      intervalMs: 10_000,
-      logger: this.logger,
-      dataDir: this.ctx.dataDir,
-    });
-    this.watchdog.start();
-    this.watchdog.notifyReady();
-
-    return ok(undefined);
+  private logStartupCleanupFailure(step: string, cause: unknown): void {
+    this.logger.debug({ cause, step }, 'daemon: startup cleanup step failed');
   }
 
   // ---------------------------------------------------------------------------
@@ -163,7 +281,14 @@ export class TalondDaemon {
   // ---------------------------------------------------------------------------
 
   async stop(): Promise<void> {
-    if (this._state === 'stopped' || this._state === 'stopping') {
+    if (this._state === 'stopped') {
+      return;
+    }
+    if (this._state === 'stopping') {
+      // A previous bounded drain reported an unknown outcome. A later stop
+      // call is the explicit recovery path: it retries only deferred joining,
+      // never tears down dependencies beneath unconfirmed work.
+      this.beginDeferredTeardown();
       return;
     }
 
@@ -177,21 +302,44 @@ export class TalondDaemon {
     }
 
     if (this.ctx !== null) {
+      let schedulerDrained = false;
+      let lifecycleDrained = false;
+      let queueDrained = false;
+      try {
+        schedulerDrained = (await this.ctx.scheduler.stop())?.status !== 'timed_out';
+      } catch (cause) {
+        this.logStartupCleanupFailure('stop scheduler', cause);
+      }
+      try {
+        lifecycleDrained = (await this.ctx.lifecycleRuntime?.stop()) ?? true;
+      } catch (cause) {
+        this.logStartupCleanupFailure('stop lifecycle dispatcher', cause);
+      }
+
+      // Join user work while its MCP and host-tool dependencies are still
+      // available; closing either first can strand a claimed queue item.
+      this.ctx.sessionTracker.clearAll();
+      try {
+        queueDrained = (await this.ctx.queueManager.stopProcessing())?.status !== 'timed_out';
+      } catch (cause) {
+        this.logStartupCleanupFailure('stop queue processing', cause);
+      }
+      if (!schedulerDrained || !lifecycleDrained || !queueDrained) {
+        this.beginDeferredTeardown();
+        throw new DaemonError('Daemon workloads are still draining; resource teardown is deferred');
+      }
+
       try {
         await this.ctx.channelRegistry.stopAll();
       } catch (cause) {
         this.logger.error({ cause }, 'daemon: error stopping channel connectors');
       }
 
-      this.ctx.scheduler.stop();
-
       if (this.mcpRegistry !== null) {
         await this.mcpRegistry.stopAll();
         this.mcpRegistry = null;
       }
 
-      this.ctx.sessionTracker.clearAll();
-      this.ctx.queueManager.stopProcessing();
       this.ctx.hostToolsBridge.stop();
       await this.ctx.backgroundAgentManager?.shutdown();
       try {
@@ -327,9 +475,7 @@ export class TalondDaemon {
       this.ctx.dataDir,
     );
     if (loadedSkillsResult.isErr()) {
-      return err(
-        new DaemonError(`Failed to reload skills: ${loadedSkillsResult.error.message}`),
-      );
+      return err(new DaemonError(`Failed to reload skills: ${loadedSkillsResult.error.message}`));
     }
     // Update loadedSkills in-place on the context (mutable field for reload).
     (this.ctx as unknown as { loadedSkills: DaemonContext['loadedSkills'] }).loadedSkills =
@@ -459,7 +605,13 @@ export class TalondDaemon {
 
       case 'shutdown': {
         setImmediate(() => {
-          void this.stop();
+          void this.stop().catch((cause) => {
+            // A bounded drain deliberately rejects to preserve dependent
+            // resources for deferred teardown. IPC shutdown is fire-and-forget,
+            // so contain that expected Result boundary rather than leaking an
+            // unhandled rejection into the process.
+            this.logger.error({ cause }, 'daemon: IPC shutdown deferred after drain failure');
+          });
         });
         return {
           id: responseId,
@@ -481,7 +633,14 @@ export class TalondDaemon {
 
         // Default: purge pending, failed, and completed. Accept override via payload.
         type QS = 'pending' | 'claimed' | 'processing' | 'completed' | 'failed' | 'dead_letter';
-        const validStatuses: readonly QS[] = ['pending', 'claimed', 'processing', 'completed', 'failed', 'dead_letter'];
+        const validStatuses: readonly QS[] = [
+          'pending',
+          'claimed',
+          'processing',
+          'completed',
+          'failed',
+          'dead_letter',
+        ];
         const requestedStatuses: QS[] = Array.isArray(command.payload?.statuses)
           ? (command.payload.statuses as string[]).filter((s): s is QS =>
               (validStatuses as readonly string[]).includes(s),

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -429,6 +429,14 @@ export class TalondDaemon {
     const newConfig = configResult.value;
     const oldConfig = this.ctx.config;
 
+    if (lifecycleConfigurationChanged(oldConfig, newConfig)) {
+      return err(
+        new DaemonError(
+          'Cannot hot-reload lifecycle configuration or lifecycle-attached persona subscriptions/authority; restart required to apply these changes',
+        ),
+      );
+    }
+
     this.logger.info({ configPath: effectivePath }, 'daemon: applying hot-reload');
 
     // Log level — apply immediately.
@@ -717,4 +725,25 @@ export class TalondDaemon {
     if (changed.length > 0)
       this.logger.info({ changed: changed }, 'daemon: reload — personas changed');
   }
+}
+
+function lifecycleConfigurationChanged(oldConfig: TalondConfig, newConfig: TalondConfig): boolean {
+  if (JSON.stringify(oldConfig.lifecycle ?? null) !== JSON.stringify(newConfig.lifecycle ?? null)) {
+    return true;
+  }
+
+  const personaLifecycleConfiguration = (config: TalondConfig): string =>
+    JSON.stringify(
+      config.personas
+        .filter((persona) => persona.lifecycle !== undefined)
+        .map((persona) => ({
+          name: persona.name,
+          lifecycle: persona.lifecycle,
+          subagents: persona.subagents,
+          capabilities: persona.capabilities,
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name)),
+    );
+
+  return personaLifecycleConfiguration(oldConfig) !== personaLifecycleConfiguration(newConfig);
 }

--- a/src/lifecycle/adapters/subagent-lifecycle-adapter.ts
+++ b/src/lifecycle/adapters/subagent-lifecycle-adapter.ts
@@ -31,6 +31,8 @@ export const LIFECYCLE_SUBAGENT_RESULT_KEY = 'lifecycleResult';
 
 export interface LifecycleSubagentPersonaScope {
   readonly id: string;
+  /** Configured lifecycle owner name; distinct from durable persona id. */
+  readonly name?: string;
   readonly subagents: readonly string[];
   readonly capabilities: ResolvedCapabilities;
 }
@@ -73,7 +75,7 @@ const RESOLVED_HANDLER_KEYS = new Set([
   'failurePolicy',
 ]);
 const SCOPE_KEYS = new Set(['threadId', 'persona', 'approvedCapabilities', 'aggregate']);
-const PERSONA_KEYS = new Set(['id', 'subagents', 'capabilities']);
+const PERSONA_KEYS = new Set(['id', 'name', 'subagents', 'capabilities']);
 const CAPABILITIES_KEYS = new Set(['allow', 'requireApproval']);
 
 /**
@@ -115,7 +117,12 @@ export class SubAgentLifecycleAdapter {
           new LifecycleError('lifecycle subagent aggregate is not owned by the dispatch thread'),
         );
       }
-      if (this.hasMismatchedPayloadPersona(parsedInput.data, snapshot.scope.persona.id)) {
+      if (
+        this.hasMismatchedPayloadPersona(
+          parsedInput.data,
+          snapshot.scope.persona.name ?? snapshot.scope.persona.id,
+        )
+      ) {
         return err(
           new LifecycleError('lifecycle subagent payload persona does not match dispatch scope'),
         );
@@ -192,7 +199,7 @@ export class SubAgentLifecycleAdapter {
     if (definition.runtime.kind !== 'subagent' || identity.runtimeKind !== 'subagent') {
       return new LifecycleError('lifecycle handler is not a subagent implementation');
     }
-    if (handler.persona !== persona.id) {
+    if (handler.persona !== (persona.name ?? persona.id)) {
       return new LifecycleError('lifecycle handler may only run for its attached persona');
     }
     if (!persona.subagents.includes(identity.implementationRef)) {
@@ -405,8 +412,17 @@ export class SubAgentLifecycleAdapter {
     const id = LifecycleFilterOwnerNameSchema.safeParse(this.ownDataProperty(source, 'id'));
     const subagents = this.materializeStringArray(this.ownDataProperty(source, 'subagents'));
     const capabilities = this.materializeCapabilities(this.ownDataProperty(source, 'capabilities'));
-    if (!id.success || !subagents || !capabilities) return undefined;
-    return Object.freeze({ id: id.data, subagents, capabilities });
+    const nameValue = this.ownDataProperty(source, 'name');
+    const name =
+      nameValue === undefined ? undefined : LifecycleFilterOwnerNameSchema.safeParse(nameValue);
+    if (!id.success || !subagents || !capabilities || (name !== undefined && !name.success))
+      return undefined;
+    return Object.freeze({
+      id: id.data,
+      ...(name?.success ? { name: name.data } : {}),
+      subagents,
+      capabilities,
+    });
   }
 
   private materializeCapabilities(value: unknown): ResolvedCapabilities | undefined {

--- a/src/lifecycle/handler-executor.ts
+++ b/src/lifecycle/handler-executor.ts
@@ -2,6 +2,7 @@
 
 import { err, ok, type Result } from 'neverthrow';
 import { types } from 'node:util';
+import { createHash } from 'node:crypto';
 import {
   LifecycleEventEnvelopeSchema,
   LifecycleHandlerIdentityContractSchema,
@@ -38,6 +39,21 @@ export interface LifecycleHandlerExecutor {
   execute(
     execution: LifecycleHandlerExecution,
   ): Promise<Result<LifecycleHandlerResult, LifecycleError>>;
+}
+
+/**
+ * Stable, bounded idempotency key for one signal handoff. The length-delimited
+ * encoding prevents tuple ambiguity before hashing and keeps valid maximum
+ * event/handler identities inside LifecycleRuntimeId's persistence bound.
+ */
+export function lifecycleSignalHandoffKey(eventId: string, handlerId: string): string {
+  const encode = (value: string): string => `${Buffer.byteLength(value, 'utf8')}:${value}`;
+  return `lsh.v1.${createHash('sha256')
+    .update('talon.lifecycle.signal-handoff.v1\0', 'utf8')
+    .update(encode(eventId), 'utf8')
+    .update('\0', 'utf8')
+    .update(encode(handlerId), 'utf8')
+    .digest('base64url')}`;
 }
 
 export interface LifecycleRuntimeCapability {
@@ -407,7 +423,10 @@ export function materializeLifecycleHandlerExecution(
         event: deepFreeze(structuredClone(event.data)),
         identity: deepFreeze(structuredClone(identity.data)),
         persona: claim.delivery.persona,
-        idempotencyKey: `${claim.delivery.event_id}:${claim.delivery.handler_id}`,
+        idempotencyKey: lifecycleSignalHandoffKey(
+          claim.delivery.event_id,
+          claim.delivery.handler_id,
+        ),
         signal,
       }),
     );

--- a/src/lifecycle/lifecycle-dispatcher.ts
+++ b/src/lifecycle/lifecycle-dispatcher.ts
@@ -30,6 +30,8 @@ export interface LifecycleDispatcherClock {
 export interface LifecycleSignalHandoff {
   readonly eventId: string;
   readonly handlerId: string;
+  /** Persisted delivery ownership; signals must never escape this persona scope. */
+  readonly persona: string;
   /** Stable key lets the durable projection boundary de-duplicate crash recovery. */
   readonly idempotencyKey: string;
   readonly signals: readonly unknown[];
@@ -487,6 +489,7 @@ export class LifecycleDispatcher {
       const handoff = await this.authority.handoff({
         eventId: lease.eventId,
         handlerId: lease.handlerId,
+        persona: claim.delivery.persona,
         idempotencyKey: execution.value.idempotencyKey,
         signals: resultSignals(result.value),
       });

--- a/src/lifecycle/lifecycle-event-bus.ts
+++ b/src/lifecycle/lifecycle-event-bus.ts
@@ -356,6 +356,18 @@ export class LifecycleEventBus {
     }
   }
 
+  /** Validates a caller-held context before it performs an authoritative write. */
+  assertTransaction(transaction: TransactionContext): Result<void, LifecycleError> {
+    try {
+      return this.#connection.inTransaction &&
+        getOpenOwnedTransactionContext(transaction, this.#transactionOwner, this.#connection)
+        ? ok(undefined)
+        : err(new LifecycleError('Cannot use a transaction outside this lifecycle event bus'));
+    } catch {
+      return err(new LifecycleError('Cannot validate lifecycle transaction authority'));
+    }
+  }
+
   /**
    * Validates a supplied derived event against its parent before publication.
    * Derived events retain aggregate, correlation and max depth, use the parent

--- a/src/lifecycle/lifecycle-runtime.ts
+++ b/src/lifecycle/lifecycle-runtime.ts
@@ -1,0 +1,68 @@
+/**
+ * Daemon-owned lifecycle runtime facade.
+ *
+ * It deliberately exposes the event bus transaction boundary instead of the
+ * underlying repositories, so domain publishers cannot accidentally wake a
+ * dispatcher before the authoritative SQLite commit.
+ */
+
+import { type Result } from 'neverthrow';
+
+import type { DbError, LifecycleError } from '../core/errors/index.js';
+import type { LifecycleEventFanoutResult } from '../core/database/repositories/index.js';
+import type { LifecycleInterceptorEnvelope } from './contracts/index.js';
+import type { LifecycleDispatcher } from './lifecycle-dispatcher.js';
+import { LifecycleEventBus, type LifecycleEventPublishInput } from './lifecycle-event-bus.js';
+import {
+  LifecycleInterceptorEngine,
+  type LifecycleInterceptorExecution,
+  type LifecycleInterceptorInvocation,
+} from './interceptors/interceptor-engine.js';
+import type { TransactionContext } from './transaction-context.js';
+
+export class LifecycleRuntime {
+  constructor(
+    private readonly eventBus: LifecycleEventBus,
+    private readonly interceptorEngine: LifecycleInterceptorEngine,
+    readonly dispatcher: LifecycleDispatcher,
+  ) {}
+
+  transaction<T, E>(
+    callback: (transaction: TransactionContext) => Result<T, E>,
+  ): Result<T, E | DbError | LifecycleError> {
+    return this.eventBus.transaction(callback);
+  }
+
+  publish(
+    input: LifecycleEventPublishInput,
+    transaction?: TransactionContext,
+  ): Result<LifecycleEventFanoutResult, DbError | LifecycleError> {
+    return this.eventBus.publish(input, transaction);
+  }
+
+  assertTransaction(transaction: TransactionContext): Result<void, LifecycleError> {
+    return this.eventBus.assertTransaction(transaction);
+  }
+
+  intercept(
+    invocation: LifecycleInterceptorInvocation,
+    input: LifecycleInterceptorEnvelope,
+  ): Result<LifecycleInterceptorExecution, LifecycleError> {
+    return this.interceptorEngine.intercept(invocation, input);
+  }
+
+  start(): void {
+    this.dispatcher.start();
+  }
+
+  async stop(): Promise<boolean> {
+    await this.dispatcher.stop();
+    return this.dispatcher.snapshot().inFlight === 0;
+  }
+
+  async waitForDrain(): Promise<void> {
+    while (this.dispatcher.snapshot().inFlight > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}

--- a/src/pipeline/message-pipeline.ts
+++ b/src/pipeline/message-pipeline.ts
@@ -22,6 +22,8 @@ import type { AuditLogger } from '../core/logging/audit-logger.js';
 import type { InboundEvent } from '../channels/channel-types.js';
 import { MessageNormalizer } from './message-normalizer.js';
 import type { PipelineResult, PipelineStats } from './pipeline-types.js';
+import type { LifecycleRuntime } from '../lifecycle/lifecycle-runtime.js';
+import type { LifecycleEventEnvelope } from '../lifecycle/contracts/index.js';
 
 /**
  * Orchestrates the full inbound message lifecycle from raw InboundEvent
@@ -48,6 +50,8 @@ export class MessagePipeline {
     private readonly router: ChannelRouter,
     private readonly auditLogger: AuditLogger,
     private readonly logger: pino.Logger,
+    private readonly lifecycleRuntime?: LifecycleRuntime,
+    private readonly resolvePersonaName?: (personaId: string) => Result<string | undefined, Error>,
   ) {}
 
   /**
@@ -151,15 +155,166 @@ export class MessagePipeline {
         return ok('duplicate');
       }
 
-      const insertResult = this.messageRepo.insert({
+      // Lifecycle interception needs the configured persona name, while the
+      // queue continues to use the persisted persona ID. Resolve it before
+      // persistence only when the optional runtime is enabled; the legacy path
+      // retains its original lookup order and behaviour.
+      let routedPersonaId: string | null | undefined;
+      let personaName: string | undefined;
+      let content = normalized.content;
+      if (this.lifecycleRuntime) {
+        const personaResult = this.router.resolvePersona(channelId, threadId);
+        if (personaResult.isErr()) {
+          this.statsCounters.errors++;
+          return err(
+            new PipelineError(
+              `Failed to resolve persona for channel ${channelId}, thread ${threadId}: ${personaResult.error.message}`,
+              personaResult.error,
+            ),
+          );
+        }
+        routedPersonaId = personaResult.value;
+        if (routedPersonaId !== null) {
+          const personaNameResult = this.resolvePersonaName?.(routedPersonaId);
+          if (!personaNameResult || personaNameResult.isErr() || !personaNameResult.value) {
+            this.statsCounters.errors++;
+            return err(
+              new PipelineError(`Failed to resolve lifecycle persona for ${routedPersonaId}`),
+            );
+          }
+          personaName = personaNameResult.value;
+          const interception = this.lifecycleRuntime.intercept(
+            {
+              persona: personaName,
+              hook: 'message.before_persist',
+              itemOrigin: 'channel',
+              itemType: 'message',
+              channel: event.channelName,
+              messageSource: 'inbound',
+            },
+            {
+              version: 'v1',
+              interceptionId: uuidv4(),
+              hook: 'message.before_persist',
+              context: this.lifecycleContext('message', normalized.id, normalized.id, 'channel'),
+              input: {
+                messageId: normalized.id,
+                content,
+                source: 'inbound',
+                channel: event.channelName,
+                persona: personaName,
+              },
+            },
+          );
+          if (interception.isErr()) {
+            this.statsCounters.errors++;
+            return err(
+              new PipelineError(`Lifecycle interception failed: ${interception.error.message}`),
+            );
+          }
+          if (interception.value.outcome !== 'allow') {
+            this.logger.info(
+              { messageId: normalized.id, threadId, reason: interception.value.reason },
+              'pipeline: inbound message denied by lifecycle policy',
+            );
+            return ok('denied');
+          }
+          content = (interception.value.input.input as { content: string }).content;
+        }
+      }
+
+      const messageInput = {
         id: normalized.id,
         thread_id: normalized.threadId,
         direction: 'inbound',
-        content: normalized.content,
+        content,
         idempotency_key: scopedIdempotencyKey,
         provider_id: normalized.senderId,
         run_id: null,
-      });
+      } as const;
+      if (this.lifecycleRuntime && personaName && routedPersonaId) {
+        const atomicResult = this.lifecycleRuntime.transaction<PipelineResult, PipelineError>(
+          (transaction) => {
+            const inserted = this.messageRepo.insertIfAbsent(messageInput);
+            if (inserted.isErr()) {
+              return err(
+                new PipelineError(
+                  `Failed to persist message with idempotency key '${scopedIdempotencyKey}': ${inserted.error.message}`,
+                  inserted.error,
+                ),
+              );
+            }
+            if (!inserted.value.inserted) return ok('duplicate' as const);
+
+            const persisted = this.publishMessageEvent(
+              'message.persisted.v1',
+              normalized.id,
+              threadId,
+              personaName,
+              event.channelName,
+              transaction,
+            );
+            if (persisted.isErr()) return err(persisted.error);
+
+            const routed = this.publishMessageEvent(
+              'message.routed.v1',
+              normalized.id,
+              threadId,
+              personaName,
+              event.channelName,
+              transaction,
+              routedPersonaId,
+            );
+            if (routed.isErr()) return err(routed.error);
+
+            const enqueued = this.queueManager.enqueueInLifecycleTransaction(
+              threadId,
+              'message',
+              {
+                messageId: normalized.id,
+                channelId,
+                channelName: event.channelName,
+                senderId: normalized.senderId,
+                content,
+                timestamp: normalized.timestamp,
+                personaId: routedPersonaId,
+              },
+              { persona: personaName, itemType: 'message' },
+              transaction,
+              normalized.id,
+            );
+            if (enqueued.isErr()) {
+              return err(
+                new PipelineError(
+                  `Failed to enqueue message ${normalized.id} for thread ${threadId}: ${enqueued.error.message}`,
+                  enqueued.error,
+                ),
+              );
+            }
+            return ok('enqueued' as const);
+          },
+        );
+        if (atomicResult.isErr()) {
+          this.statsCounters.errors++;
+          return err(
+            new PipelineError(
+              `Failed to atomically process message ${normalized.id}: ${atomicResult.error.message}`,
+              atomicResult.error,
+            ),
+          );
+        }
+        if (atomicResult.value === 'duplicate') {
+          this.statsCounters.duplicates++;
+          return ok('duplicate');
+        }
+        this.logger.info(
+          { messageId: normalized.id, threadId, channelId, personaId: routedPersonaId },
+          'pipeline: message enqueued',
+        );
+        return ok('enqueued');
+      }
+
+      const insertResult = this.messageRepo.insert(messageInput);
       if (insertResult.isErr()) {
         this.statsCounters.errors++;
         return err(
@@ -173,7 +328,10 @@ export class MessagePipeline {
       // ------------------------------------------------------------------
       // Step 5: Resolve persona via ChannelRouter.
       // ------------------------------------------------------------------
-      const personaResult = this.router.resolvePersona(channelId, threadId);
+      const personaResult =
+        routedPersonaId === undefined
+          ? this.router.resolvePersona(channelId, threadId)
+          : ok(routedPersonaId);
       if (personaResult.isErr()) {
         this.statsCounters.errors++;
         return err(
@@ -217,7 +375,7 @@ export class MessagePipeline {
           channelId,
           channelName: event.channelName,
           senderId: normalized.senderId,
-          content: normalized.content,
+          content,
           timestamp: normalized.timestamp,
           personaId,
         },
@@ -268,5 +426,70 @@ export class MessagePipeline {
    */
   stats(): PipelineStats {
     return { ...this.statsCounters };
+  }
+
+  private lifecycleContext(
+    aggregateType: string,
+    aggregateId: string,
+    correlationId: string,
+    source: string,
+  ): LifecycleEventEnvelope['context'] {
+    return {
+      aggregate: { type: aggregateType, id: aggregateId },
+      correlationId,
+      recursion: { depth: 0, maxDepth: 8 },
+      provenance: { source, sourceEventIds: [], sourceReferences: [] },
+    };
+  }
+
+  private lifecycleEvent(
+    type: LifecycleEventEnvelope['type'],
+    aggregateId: string,
+    correlationId: string,
+    source: string,
+    references: LifecycleEventEnvelope['payload']['references'],
+    metadata: LifecycleEventEnvelope['payload']['metadata'],
+  ): LifecycleEventEnvelope {
+    return {
+      version: 'v1',
+      type,
+      eventId: uuidv4(),
+      occurredAt: new Date().toISOString(),
+      context: this.lifecycleContext('message', aggregateId, correlationId, source),
+      payload: { references, metadata },
+    };
+  }
+
+  private publishMessageEvent(
+    type: 'message.persisted.v1' | 'message.routed.v1',
+    messageId: string,
+    threadId: string,
+    personaName: string,
+    channelName: string,
+    transaction: import('../lifecycle/transaction-context.js').TransactionContext,
+    personaId?: string,
+  ): Result<void, PipelineError> {
+    const references: LifecycleEventEnvelope['payload']['references'] = [
+      { type: 'message', id: messageId },
+      { type: 'thread', id: threadId },
+      ...(personaId ? [{ type: 'persona', id: personaId }] : []),
+    ];
+    const publication = this.lifecycleRuntime!.publish(
+      {
+        event: this.lifecycleEvent(type, messageId, messageId, 'channel', references, {
+          direction: 'inbound',
+          source: 'channel',
+        }),
+        persona: personaName,
+        itemOrigin: 'channel',
+        itemType: 'message',
+        channel: channelName,
+        messageSource: 'inbound',
+      },
+      transaction,
+    );
+    return publication.isErr()
+      ? err(new PipelineError(`Failed to publish ${type}: ${publication.error.message}`))
+      : ok(undefined);
   }
 }

--- a/src/pipeline/pipeline-types.ts
+++ b/src/pipeline/pipeline-types.ts
@@ -48,9 +48,10 @@ export interface NormalizedMessage {
  * - `'enqueued'`   — message was persisted and a queue item was created.
  * - `'duplicate'`  — message was already present (idempotency_key matched).
  * - `'no_persona'` — no persona binding found for the channel+thread pair.
+ * - `'denied'`     — an enabled native lifecycle policy rejected the inbound message.
  * - `'error'`      — an unexpected error occurred (details in the Err wrapper).
  */
-export type PipelineResult = 'enqueued' | 'duplicate' | 'no_persona' | 'error';
+export type PipelineResult = 'enqueued' | 'duplicate' | 'no_persona' | 'denied' | 'error';
 
 // ---------------------------------------------------------------------------
 // PipelineStats

--- a/src/queue/queue-manager.ts
+++ b/src/queue/queue-manager.ts
@@ -17,6 +17,10 @@ import { DeadLetterHandler } from './dead-letter.js';
 import { QueueProcessor } from './queue-processor.js';
 import { type QueueItem, QueueItemStatus } from './queue-types.js';
 import { rowToQueueItem } from './queue-mapper.js';
+import type { LifecycleRuntime } from '../lifecycle/lifecycle-runtime.js';
+import type { LifecycleEventEnvelope, LifecycleItemType } from '../lifecycle/contracts/index.js';
+import type { LifecycleEventPublishInput } from '../lifecycle/lifecycle-event-bus.js';
+import type { TransactionContext } from '../lifecycle/transaction-context.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -42,12 +46,23 @@ export interface QueueStats {
   deadLetter: number;
 }
 
+export interface QueueDrainResult {
+  readonly status: 'drained' | 'timed_out';
+}
+
+/** Bootstrap/pipeline-owned scope; never inferred from arbitrary work payloads. */
+export interface LifecycleQueueScope {
+  readonly persona: string;
+  readonly itemType: Extract<LifecycleItemType, 'message' | 'schedule'>;
+}
+
 // ---------------------------------------------------------------------------
 // Manager
 // ---------------------------------------------------------------------------
 
 /** Polling interval for the processing loop in milliseconds. */
 const POLL_INTERVAL_MS = 500;
+const DEFAULT_DRAIN_TIMEOUT_MS = 25_000;
 
 /**
  * Orchestrates enqueueing, background processing, and queue statistics.
@@ -61,12 +76,16 @@ export class QueueManager {
   private readonly deadLetterHandler: DeadLetterHandler;
   private loopTimer: ReturnType<typeof setInterval> | null = null;
   private activeCount = 0;
+  private processing = false;
+  private readonly activeWork = new Set<Promise<QueueItem | null>>();
+  private readonly activeControllers = new Set<AbortController>();
 
   constructor(
     private readonly queueRepo: QueueRepository,
     private readonly threadRepo: ThreadRepository,
     private readonly config: QueueConfig,
     private readonly logger: pino.Logger,
+    private readonly lifecycleRuntime?: LifecycleRuntime,
   ) {
     this.deadLetterHandler = new DeadLetterHandler(queueRepo, logger);
     this.processor = new QueueProcessor(
@@ -76,6 +95,7 @@ export class QueueManager {
       logger,
       config.backoffBaseMs,
       config.backoffMaxMs,
+      lifecycleRuntime,
     );
   }
 
@@ -96,6 +116,7 @@ export class QueueManager {
     type: 'message' | 'schedule' | 'collaboration',
     payload: Record<string, unknown>,
     messageId?: string,
+    lifecycleScope?: LifecycleQueueScope,
   ): Result<QueueItem, QueueError> {
     // Verify the thread exists.
     const threadResult = this.threadRepo.findById(threadId);
@@ -111,14 +132,62 @@ export class QueueManager {
       return err(new QueueError(`Thread not found: ${threadId}`));
     }
 
-    const result = this.queueRepo.enqueue({
+    // Producers always supply their trusted scope; disabled mode must remain
+    // byte-for-byte on the legacy queue path and retain no lifecycle metadata.
+    const enabledLifecycleScope = this.lifecycleRuntime ? lifecycleScope : undefined;
+    if (
+      this.lifecycleRuntime &&
+      (type === 'message' || type === 'schedule') &&
+      !enabledLifecycleScope
+    ) {
+      return err(
+        new QueueError(
+          'Lifecycle-enabled message and schedule queue items require manager-owned lifecycle scope',
+        ),
+      );
+    }
+    const scopeError = this.validateLifecycleScope(type, enabledLifecycleScope);
+    if (scopeError) return err(scopeError);
+    const input = {
       id: uuidv4(),
       thread_id: threadId,
       message_id: messageId ?? null,
       type,
       payload: JSON.stringify(payload),
       max_attempts: this.config.maxAttempts,
-    });
+      lifecycle_persona: enabledLifecycleScope?.persona ?? null,
+      lifecycle_item_type: enabledLifecycleScope?.itemType ?? null,
+    };
+
+    const result =
+      this.lifecycleRuntime && enabledLifecycleScope
+        ? this.lifecycleRuntime.transaction((transaction) => {
+            const queued = this.queueRepo.enqueue(input);
+            if (queued.isErr())
+              return err(
+                new QueueError(
+                  `Failed to enqueue item for lifecycle event: ${queued.error.message}`,
+                ),
+              );
+            const publication = this.lifecycleRuntime!.publish(
+              this.lifecyclePublishInput(
+                'queue.item.enqueued.v1',
+                queued.value.id,
+                threadId,
+                enabledLifecycleScope,
+                queued.value.message_id,
+              ),
+              transaction,
+            );
+            if (publication.isErr())
+              return err(
+                new QueueError(
+                  `Failed to publish queue enqueue event: ${publication.error.message}`,
+                ),
+              );
+            return ok(queued.value);
+          })
+        : this.queueRepo.enqueue(input);
 
     if (result.isErr()) {
       return err(
@@ -135,6 +204,114 @@ export class QueueManager {
   }
 
   /**
+   * Enqueues and publishes through an already-open lifecycle bus transaction.
+   * This is intentionally not a general transaction API: callers receive the
+   * opaque context only from LifecycleRuntime, preserving exact bus authority.
+   */
+  enqueueInLifecycleTransaction(
+    threadId: string,
+    type: 'message' | 'schedule' | 'collaboration',
+    payload: Record<string, unknown>,
+    lifecycleScope: LifecycleQueueScope,
+    transaction: TransactionContext,
+    messageId?: string,
+  ): Result<QueueItem, QueueError> {
+    if (!this.lifecycleRuntime) {
+      return err(new QueueError('Lifecycle queue enqueue requires an enabled lifecycle runtime'));
+    }
+    const scopeError = this.validateLifecycleScope(type, lifecycleScope);
+    if (scopeError) return err(scopeError);
+    const authority = this.lifecycleRuntime.assertTransaction(transaction);
+    if (authority.isErr()) return err(new QueueError(authority.error.message, authority.error));
+    const threadResult = this.threadRepo.findById(threadId);
+    if (threadResult.isErr()) {
+      return err(
+        new QueueError(`Failed to look up thread ${threadId}: ${threadResult.error.message}`),
+      );
+    }
+    if (!threadResult.value) return err(new QueueError(`Thread not found: ${threadId}`));
+    const queued = this.queueRepo.enqueue({
+      id: uuidv4(),
+      thread_id: threadId,
+      message_id: messageId ?? null,
+      type,
+      payload: JSON.stringify(payload),
+      max_attempts: this.config.maxAttempts,
+      lifecycle_persona: lifecycleScope.persona,
+      lifecycle_item_type: lifecycleScope.itemType,
+    });
+    if (queued.isErr())
+      return err(new QueueError(`Failed to enqueue item: ${queued.error.message}`));
+    const publication = this.lifecycleRuntime.publish(
+      this.lifecyclePublishInput(
+        'queue.item.enqueued.v1',
+        queued.value.id,
+        threadId,
+        lifecycleScope,
+        queued.value.message_id,
+      ),
+      transaction,
+    );
+    if (publication.isErr()) {
+      return err(
+        new QueueError(`Failed to publish queue enqueue event: ${publication.error.message}`),
+      );
+    }
+    return ok(rowToQueueItem(queued.value));
+  }
+
+  private validateLifecycleScope(
+    queueType: 'message' | 'schedule' | 'collaboration',
+    scope: LifecycleQueueScope | undefined,
+  ): QueueError | undefined {
+    if (!scope) return undefined;
+    if (!this.lifecycleRuntime) return undefined;
+    if (queueType === 'collaboration') {
+      return new QueueError('Collaboration queue items have no lifecycle publication scope');
+    }
+    const expected = queueType === 'schedule' ? 'schedule' : 'message';
+    if (scope.persona.length === 0 || scope.itemType !== expected) {
+      return new QueueError(
+        'Lifecycle queue scope does not match the authoritative queue item type',
+      );
+    }
+    return undefined;
+  }
+
+  private lifecyclePublishInput(
+    type: LifecycleEventEnvelope['type'],
+    itemId: string,
+    threadId: string,
+    lifecycleScope: LifecycleQueueScope,
+    messageId: string | null,
+  ): LifecycleEventPublishInput {
+    return {
+      event: {
+        version: 'v1' as const,
+        type,
+        eventId: uuidv4(),
+        occurredAt: new Date().toISOString(),
+        context: {
+          aggregate: { type: 'queue_item', id: itemId },
+          correlationId: messageId ?? itemId,
+          recursion: { depth: 0, maxDepth: 8 },
+          provenance: { source: 'queue', sourceEventIds: [], sourceReferences: [] },
+        },
+        payload: {
+          references: [
+            { type: 'queue_item', id: itemId },
+            { type: 'thread', id: threadId },
+          ],
+          metadata: { itemType: lifecycleScope.itemType },
+        },
+      },
+      persona: lifecycleScope.persona,
+      itemOrigin: 'queue' as const,
+      itemType: lifecycleScope.itemType,
+    };
+  }
+
+  /**
    * Starts the background processing loop.
    *
    * On each poll tick, up to `concurrencyLimit - activeCount` new items are
@@ -142,13 +319,16 @@ export class QueueManager {
    *
    * @param handler - Async function invoked for each claimed queue item.
    */
-  startProcessing(handler: (item: QueueItem) => Promise<Result<void, Error>>): void {
+  startProcessing(
+    handler: (item: QueueItem, signal?: AbortSignal) => Promise<Result<void, Error>>,
+  ): void {
     if (this.loopTimer !== null) {
       this.logger.warn('startProcessing called while loop is already running');
       return;
     }
 
     this.logger.info({ pollIntervalMs: POLL_INTERVAL_MS }, 'queue processing loop started');
+    this.processing = true;
 
     this.loopTimer = setInterval(() => {
       void this.tick(handler);
@@ -161,12 +341,35 @@ export class QueueManager {
    * Any items currently being processed will run to completion; no new items
    * will be claimed after this call.
    */
-  stopProcessing(): void {
+  async stopProcessing(timeoutMs = DEFAULT_DRAIN_TIMEOUT_MS): Promise<QueueDrainResult> {
+    this.processing = false;
     if (this.loopTimer !== null) {
       clearInterval(this.loopTimer);
       this.loopTimer = null;
       this.logger.info('queue processing loop stopped');
     }
+    for (const controller of this.activeControllers) controller.abort();
+    // AgentRunner bounds provider execution. Joining these already-claimed
+    // items before callers close the database prevents an in-flight handler
+    // from writing through a closed repository during failed startup/restart.
+    const settled = Promise.allSettled([...this.activeWork]).then(() => 'drained' as const);
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      const status = await Promise.race([
+        settled,
+        new Promise<'timed_out'>((resolve) => {
+          timer = setTimeout(() => resolve('timed_out'), timeoutMs);
+          timer.unref();
+        }),
+      ]);
+      return { status };
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  waitForDrain(): Promise<void> {
+    return Promise.allSettled([...this.activeWork]).then(() => undefined);
   }
 
   /**
@@ -196,8 +399,9 @@ export class QueueManager {
    * Single processing loop tick: dispatches items up to the concurrency limit.
    */
   private async tick(
-    handler: (item: QueueItem) => Promise<Result<void, Error>>,
+    handler: (item: QueueItem, signal?: AbortSignal) => Promise<Result<void, Error>>,
   ): Promise<void> {
+    if (!this.processing) return;
     const slots = this.config.concurrencyLimit - this.activeCount;
     if (slots <= 0) {
       return;
@@ -206,7 +410,16 @@ export class QueueManager {
     // Dispatch up to `slots` items in parallel.
     const dispatches: Promise<QueueItem | null>[] = [];
     for (let i = 0; i < slots; i++) {
-      dispatches.push(this.dispatchOne(handler));
+      if (!this.processing) break;
+      const controller = new AbortController();
+      const dispatch = this.dispatchOne(handler, controller.signal);
+      this.activeWork.add(dispatch);
+      this.activeControllers.add(controller);
+      void dispatch.finally(() => {
+        this.activeWork.delete(dispatch);
+        this.activeControllers.delete(controller);
+      });
+      dispatches.push(dispatch);
     }
 
     await Promise.all(dispatches);
@@ -216,11 +429,12 @@ export class QueueManager {
    * Claims and processes a single item, tracking the active count.
    */
   private async dispatchOne(
-    handler: (item: QueueItem) => Promise<Result<void, Error>>,
+    handler: (item: QueueItem, signal?: AbortSignal) => Promise<Result<void, Error>>,
+    signal: AbortSignal,
   ): Promise<QueueItem | null> {
     this.activeCount++;
     try {
-      return await this.processor.processNext(handler);
+      return await this.processor.processNext(handler, signal);
     } finally {
       this.activeCount--;
     }

--- a/src/queue/queue-processor.ts
+++ b/src/queue/queue-processor.ts
@@ -14,6 +14,9 @@ import type { calculateBackoff } from './retry-strategy.js';
 import type { DeadLetterHandler } from './dead-letter.js';
 import { type QueueItem } from './queue-types.js';
 import { rowToQueueItem } from './queue-mapper.js';
+import { v4 as uuidv4 } from 'uuid';
+import type { LifecycleRuntime } from '../lifecycle/lifecycle-runtime.js';
+import type { LifecycleEventEnvelope } from '../lifecycle/contracts/index.js';
 
 /**
  * Processes queue items with retry and dead-letter support.
@@ -34,6 +37,7 @@ export class QueueProcessor {
     private readonly logger: pino.Logger,
     private readonly backoffBaseMs: number = 1000,
     private readonly backoffMaxMs: number = 60_000,
+    private readonly lifecycleRuntime?: LifecycleRuntime,
   ) {}
 
   /**
@@ -51,8 +55,10 @@ export class QueueProcessor {
    * @returns The claimed QueueItem, or null if nothing was available.
    */
   async processNext(
-    handler: (item: QueueItem) => Promise<Result<void, Error>>,
+    handler: (item: QueueItem, signal?: AbortSignal) => Promise<Result<void, Error>>,
+    signal?: AbortSignal,
   ): Promise<QueueItem | null> {
+    if (signal?.aborted) return null;
     // Find all pending items to discover eligible thread IDs.
     const pendingResult = this.queueRepo.findPending();
     if (pendingResult.isErr()) {
@@ -167,11 +173,16 @@ export class QueueProcessor {
       // Dispatch to handler.
       let handlerResult: Result<void, Error>;
       try {
-        handlerResult = await handler(item);
+        handlerResult = await handler(item, signal);
       } catch (caught) {
         const message = caught instanceof Error ? caught.message : String(caught);
         handlerResult = err(new Error(message));
       }
+
+      // A bounded daemon drain may return before a non-cooperative handler
+      // settles. Never touch repositories after its abort signal fires; the
+      // leased row remains recoverable by normal crash/lease recovery.
+      if (signal?.aborted) return item;
 
       if (handlerResult.isOk()) {
         const completeResult = this.complete(item.id);
@@ -204,6 +215,15 @@ export class QueueProcessor {
    * @returns Ok(void) on success, or a QueueError.
    */
   complete(itemId: string): Result<void, QueueError> {
+    if (this.lifecycleRuntime) {
+      const item = this.queueRepo.findById(itemId);
+      if (item.isErr() || !item.value) {
+        return err(new QueueError(`Failed to read queue item ${itemId} before completion`));
+      }
+      return this.transitionWithEvent(item.value, 'queue.item.completed.v1', () =>
+        this.queueRepo.completeClaimed(itemId),
+      );
+    }
     const result = this.queueRepo.complete(itemId);
     if (result.isErr()) {
       return err(
@@ -246,6 +266,12 @@ export class QueueProcessor {
 
     const newAttempts = row.attempts + 1;
 
+    if (this.lifecycleRuntime) {
+      const delayMs = this.retryStrategy(row.attempts, this.backoffBaseMs, this.backoffMaxMs);
+      const nextRetryAt = Date.now() + delayMs;
+      return this.transitionFailureWithEvent(row, error, nextRetryAt);
+    }
+
     if (newAttempts >= row.max_attempts) {
       // Exhausted all retries — dead-letter the item.
       const dlResult = this.deadLetterHandler.moveToDeadLetter(itemId, error);
@@ -283,5 +309,123 @@ export class QueueProcessor {
       'queue item failed, scheduled for retry',
     );
     return ok(undefined);
+  }
+
+  private transitionWithEvent(
+    row: import('../core/database/repositories/queue-repository.js').QueueItemRow,
+    type: LifecycleEventEnvelope['type'],
+    transition: () => Result<boolean, Error>,
+  ): Result<void, QueueError> {
+    const item = rowToQueueItem(row);
+    const scope = this.lifecycleScope(row);
+    if (!this.lifecycleRuntime || !scope) {
+      const result = transition();
+      return result.isErr()
+        ? err(new QueueError(result.error.message, result.error))
+        : ok(undefined);
+    }
+    const result = this.lifecycleRuntime.transaction((transaction) => {
+      const changed = transition();
+      if (changed.isErr()) return err(new QueueError(changed.error.message, changed.error));
+      if (!changed.value) return ok(undefined);
+      const publication = this.lifecycleRuntime!.publish(
+        this.lifecycleEvent(item, type, scope.persona, scope.itemType),
+        transaction,
+      );
+      if (publication.isErr())
+        return err(
+          new QueueError(`Failed to publish queue transition: ${publication.error.message}`),
+        );
+      return ok(undefined);
+    });
+    return result.isErr() ? err(new QueueError(result.error.message, result.error)) : ok(undefined);
+  }
+
+  private transitionFailureWithEvent(
+    row: import('../core/database/repositories/queue-repository.js').QueueItemRow,
+    errorMessage: string,
+    nextRetryAt: number,
+  ): Result<void, QueueError> {
+    const item = rowToQueueItem(row);
+    const scope = this.lifecycleScope(row);
+    if (!this.lifecycleRuntime || !scope) {
+      const transition = this.queueRepo.transitionClaimedFailure(
+        item.id,
+        errorMessage,
+        nextRetryAt,
+      );
+      return transition.isErr()
+        ? err(new QueueError(transition.error.message, transition.error))
+        : ok(undefined);
+    }
+    const result = this.lifecycleRuntime.transaction((transaction) => {
+      const transition = this.queueRepo.transitionClaimedFailure(
+        item.id,
+        errorMessage,
+        nextRetryAt,
+      );
+      if (transition.isErr())
+        return err(new QueueError(transition.error.message, transition.error));
+      if (!transition.value) return ok(undefined);
+      const eventType =
+        transition.value === 'dead_letter'
+          ? 'queue.item.dead_lettered.v1'
+          : 'queue.item.failed.v1';
+      const publication = this.lifecycleRuntime!.publish(
+        this.lifecycleEvent(item, eventType, scope.persona, scope.itemType),
+        transaction,
+      );
+      return publication.isErr()
+        ? err(new QueueError(`Failed to publish queue transition: ${publication.error.message}`))
+        : ok(undefined);
+    });
+    return result.isErr() ? err(new QueueError(result.error.message, result.error)) : ok(undefined);
+  }
+
+  private lifecycleScope(
+    row: import('../core/database/repositories/queue-repository.js').QueueItemRow,
+  ): Readonly<{ persona: string; itemType: 'message' | 'schedule' }> | undefined {
+    if (
+      !row.lifecycle_persona ||
+      (row.lifecycle_item_type !== 'message' && row.lifecycle_item_type !== 'schedule')
+    ) {
+      return undefined;
+    }
+    const expectedItemType = row.type === 'schedule' ? 'schedule' : row.type === 'message' ? 'message' : null;
+    return expectedItemType === row.lifecycle_item_type
+      ? { persona: row.lifecycle_persona, itemType: row.lifecycle_item_type }
+      : undefined;
+  }
+
+  private lifecycleEvent(
+    item: QueueItem,
+    type: LifecycleEventEnvelope['type'],
+    persona: string,
+    itemType: 'message' | 'schedule',
+  ) {
+    return {
+      event: {
+        version: 'v1' as const,
+        type,
+        eventId: uuidv4(),
+        occurredAt: new Date().toISOString(),
+        context: {
+          aggregate: { type: 'queue_item', id: item.id },
+          correlationId: item.messageId ?? item.id,
+          recursion: { depth: 0, maxDepth: 8 },
+          provenance: { source: 'queue', sourceEventIds: [], sourceReferences: [] },
+        },
+        payload: {
+          references: [
+            { type: 'queue_item', id: item.id },
+            { type: 'thread', id: item.threadId },
+          ],
+          metadata: { itemType },
+        },
+      },
+      persona,
+      itemOrigin: 'queue' as const,
+      itemType,
+    };
   }
 }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -7,12 +7,21 @@
  */
 
 import type pino from 'pino';
+import { err, ok } from 'neverthrow';
 import type { ScheduleRepository } from '../core/database/repositories/schedule-repository.js';
 import type { ScheduleRow } from '../core/database/repositories/schedule-repository.js';
 import type { PersonaLoader } from '../personas/persona-loader.js';
 import type { QueueManager } from '../queue/queue-manager.js';
 import { getNextCronTime } from './cron-evaluator.js';
 import type { ScheduleConfig, SchedulePayload } from './schedule-types.js';
+import { v4 as uuidv4 } from 'uuid';
+import type { LifecycleRuntime } from '../lifecycle/lifecycle-runtime.js';
+
+export interface SchedulerDrainResult {
+  readonly status: 'drained' | 'timed_out';
+}
+
+const DEFAULT_DRAIN_TIMEOUT_MS = 25_000;
 
 // ---------------------------------------------------------------------------
 // Scheduler
@@ -29,6 +38,7 @@ export class Scheduler {
   private timer: NodeJS.Timeout | null = null;
   /** Generation counter to prevent stale ticks from re-arming after stop()+start(). */
   private generation = 0;
+  private readonly activeTicks = new Set<Promise<void>>();
 
   constructor(
     private readonly scheduleRepo: ScheduleRepository,
@@ -36,6 +46,7 @@ export class Scheduler {
     private readonly personaLoader: PersonaLoader,
     private readonly config: ScheduleConfig,
     private readonly logger: pino.Logger,
+    private readonly lifecycleRuntime?: LifecycleRuntime,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -56,7 +67,7 @@ export class Scheduler {
     this.running = true;
     this.generation += 1;
     this.logger.info({ tickIntervalMs: this.config.tickIntervalMs }, 'scheduler started');
-    void this.tick(this.generation);
+    this.launchTick(this.generation);
   }
 
   /**
@@ -65,13 +76,31 @@ export class Scheduler {
    * Clears any pending timer. In-flight tick processing (if any) runs to
    * completion but no new ticks are scheduled.
    */
-  stop(): void {
+  async stop(timeoutMs = DEFAULT_DRAIN_TIMEOUT_MS): Promise<SchedulerDrainResult> {
     this.running = false;
     if (this.timer !== null) {
       clearTimeout(this.timer);
       this.timer = null;
     }
     this.logger.info('scheduler stopped');
+    const settled = Promise.allSettled([...this.activeTicks]).then(() => 'drained' as const);
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      const status = await Promise.race([
+        settled,
+        new Promise<'timed_out'>((resolve) => {
+          timer = setTimeout(() => resolve('timed_out'), timeoutMs);
+          timer.unref();
+        }),
+      ]);
+      return { status };
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  waitForDrain(): Promise<void> {
+    return Promise.allSettled([...this.activeTicks]).then(() => undefined);
   }
 
   // ---------------------------------------------------------------------------
@@ -104,7 +133,7 @@ export class Scheduler {
         // try/catch so one failure does not block the rest.
         for (const schedule of due) {
           try {
-            await this.processSchedule(schedule, now);
+            await this.processSchedule(schedule, now, gen);
           } catch (scheduleErr) {
             this.logger.error(
               { scheduleId: schedule.id, err: scheduleErr },
@@ -121,7 +150,7 @@ export class Scheduler {
       if (this.running && gen === this.generation) {
         this.timer = setTimeout(() => {
           this.timer = null;
-          void this.tick(gen);
+          this.launchTick(gen);
         }, this.config.tickIntervalMs);
       }
     }
@@ -133,7 +162,8 @@ export class Scheduler {
    * @param schedule - The schedule row to process.
    * @param now      - Current epoch ms (used for last_run_at).
    */
-  private async processSchedule(schedule: ScheduleRow, now: number): Promise<void> {
+  private async processSchedule(schedule: ScheduleRow, now: number, gen: number): Promise<void> {
+    if (!this.isCurrentGeneration(gen)) return;
     this.logger.info(
       { scheduleId: schedule.id, type: schedule.type, expression: schedule.expression },
       'scheduler: firing schedule',
@@ -148,6 +178,7 @@ export class Scheduler {
       );
       // Still advance / disable so we do not loop on it forever.
     } else {
+      const threadId = schedule.thread_id;
       let rawPayload: Record<string, unknown> = {};
       try {
         const parsed: unknown = JSON.parse(schedule.payload);
@@ -169,8 +200,7 @@ export class Scheduler {
       const schedulePayload = rawPayload as SchedulePayload & Record<string, unknown>;
       let promptFile =
         typeof schedulePayload.promptFile === 'string' ? schedulePayload.promptFile : undefined;
-      let content =
-        typeof schedulePayload.prompt === 'string' ? schedulePayload.prompt : '';
+      let content = typeof schedulePayload.prompt === 'string' ? schedulePayload.prompt : '';
 
       // Defensive: agents and humans sometimes invent `prompt: "file:NAME"`
       // as if it were a documented convention (it isn't). Without this
@@ -203,7 +233,11 @@ export class Scheduler {
       }
 
       if (promptFile) {
-        const promptResult = await this.personaLoader.resolveTaskPrompt(schedule.persona_id, promptFile);
+        const promptResult = await this.personaLoader.resolveTaskPrompt(
+          schedule.persona_id,
+          promptFile,
+        );
+        if (!this.isCurrentGeneration(gen)) return;
         if (promptResult.isErr()) {
           this.logger.error(
             {
@@ -218,6 +252,9 @@ export class Scheduler {
         }
         content = promptResult.value;
       }
+      // A stop may have raced an asynchronous prompt load. Do not enqueue or
+      // update schedule state after the daemon begins draining dependencies.
+      if (!this.isCurrentGeneration(gen)) return;
 
       // Map schedule fields to the payload shape AgentRunner expects:
       // personaId (from schedule row) and content (from payload.prompt).
@@ -227,7 +264,99 @@ export class Scheduler {
         content,
       };
 
-      const enqueueResult = this.queueManager.enqueue(schedule.thread_id, 'schedule', payload);
+      let personaName: string | undefined;
+      if (this.lifecycleRuntime) {
+        const persona = this.personaLoader.getById(schedule.persona_id);
+        if (persona.isOk() && persona.value) {
+          personaName = persona.value.config.name;
+        }
+        if (!personaName) {
+          this.logger.error(
+            { scheduleId: schedule.id, personaId: schedule.persona_id },
+            'scheduler: lifecycle persona unavailable; schedule will be retried without enqueue',
+          );
+          return;
+        }
+      }
+
+      if (this.lifecycleRuntime) {
+        if (!this.isCurrentGeneration(gen)) return;
+        // The enabled-mode resolution guard above establishes this immutable
+        // scope before the transactional callback captures it.
+        const lifecyclePersona = personaName;
+        if (!lifecyclePersona) return;
+        const nextRun = this.computeNextRun(schedule);
+        const fired = this.lifecycleRuntime.transaction((transaction) => {
+          const enqueued = this.queueManager.enqueueInLifecycleTransaction(
+            threadId,
+            'schedule',
+            payload,
+            { persona: lifecyclePersona, itemType: 'schedule' },
+            transaction,
+          );
+          if (enqueued.isErr()) return err(new Error(enqueued.error.message));
+
+          const scheduleUpdate =
+            nextRun === null
+              ? this.scheduleRepo
+                  .disable(schedule.id)
+                  .andThen(() => this.scheduleRepo.updateNextRun(schedule.id, now, null))
+              : this.scheduleRepo.updateNextRun(schedule.id, now, nextRun);
+          if (scheduleUpdate.isErr()) return err(new Error(scheduleUpdate.error.message));
+
+          const publication = this.lifecycleRuntime!.publish(
+            {
+              event: {
+                version: 'v1',
+                type: 'schedule.fired.v1',
+                eventId: uuidv4(),
+                occurredAt: new Date(now).toISOString(),
+                context: {
+                  aggregate: { type: 'schedule', id: schedule.id },
+                  correlationId: enqueued.value.id,
+                  recursion: { depth: 0, maxDepth: 8 },
+                  provenance: {
+                    source: 'scheduler',
+                    sourceEventIds: [],
+                    sourceReferences: [{ type: 'queue_item', id: enqueued.value.id }],
+                  },
+                },
+                payload: {
+                  references: [
+                    { type: 'schedule', id: schedule.id },
+                    { type: 'queue_item', id: enqueued.value.id },
+                    { type: 'thread', id: threadId },
+                  ],
+                  metadata: { scheduleType: schedule.type },
+                },
+              },
+              persona: lifecyclePersona,
+              itemOrigin: 'scheduler',
+              itemType: 'schedule',
+              scheduleSource:
+                schedule.type === 'one_shot'
+                  ? 'oneshot'
+                  : schedule.type === 'event'
+                    ? 'manual'
+                    : schedule.type,
+            },
+            transaction,
+          );
+          return publication.isErr()
+            ? err(new Error(`Failed to publish schedule fired event: ${publication.error.message}`))
+            : ok(undefined);
+        });
+        if (fired.isErr()) {
+          this.logger.error(
+            { scheduleId: schedule.id, err: fired.error },
+            'scheduler: failed to atomically fire schedule lifecycle event',
+          );
+        }
+        return;
+      }
+
+      if (!this.isCurrentGeneration(gen)) return;
+      const enqueueResult = this.queueManager.enqueue(threadId, 'schedule', payload);
       if (enqueueResult.isErr()) {
         this.logger.error(
           { scheduleId: schedule.id, err: enqueueResult.error },
@@ -239,6 +368,7 @@ export class Scheduler {
     }
 
     // Compute the next run time (null for one_shot / event).
+    if (!this.isCurrentGeneration(gen)) return;
     const nextRun = this.computeNextRun(schedule);
 
     if (nextRun === null) {
@@ -317,5 +447,15 @@ export class Scheduler {
         return null;
       }
     }
+  }
+
+  private launchTick(gen: number): void {
+    const tick = this.tick(gen);
+    this.activeTicks.add(tick);
+    void tick.finally(() => this.activeTicks.delete(tick));
+  }
+
+  private isCurrentGeneration(gen: number): boolean {
+    return this.running && gen === this.generation;
   }
 }

--- a/src/subagents/background/background-agent-manager.ts
+++ b/src/subagents/background/background-agent-manager.ts
@@ -70,6 +70,8 @@ export interface SpawnBackgroundAgentInput {
 interface BackgroundAgentManagerDeps {
   repository: BackgroundTaskRepository;
   queueManager: QueueManager;
+  /** Present only when lifecycle publication requires trusted persona scope. */
+  resolveLifecyclePersonaName?: (personaId: string) => string | undefined;
   maxConcurrent: number;
   defaultTimeoutMinutes: number;
   defaultProvider: string;
@@ -711,11 +713,34 @@ export class BackgroundAgentManager {
       );
     }
 
-    const messageResult = this.deps.queueManager.enqueue(task.threadId, 'message', {
-      personaId: task.personaId,
-      content,
-      providerName: task.providerName,
-    });
+    let personaName: string | undefined;
+    try {
+      personaName = this.deps.resolveLifecyclePersonaName?.(task.personaId);
+    } catch (cause) {
+      this.deps.logger.error(
+        { taskId: task.id, personaId: task.personaId, err: cause },
+        'background-agent: failed to resolve lifecycle persona for completion message',
+      );
+      return;
+    }
+    if (this.deps.resolveLifecyclePersonaName && !personaName) {
+      this.deps.logger.error(
+        { taskId: task.id, personaId: task.personaId },
+        'background-agent: lifecycle persona unavailable for completion message',
+      );
+      return;
+    }
+    const messageResult = this.deps.queueManager.enqueue(
+      task.threadId,
+      'message',
+      {
+        personaId: task.personaId,
+        content,
+        providerName: task.providerName,
+      },
+      undefined,
+      personaName ? { persona: personaName, itemType: 'message' } : undefined,
+    );
     if (messageResult.isErr()) {
       this.deps.logger.error(
         { taskId: task.id, err: messageResult.error },

--- a/tests/unit/core/database/migrations/runner.test.ts
+++ b/tests/unit/core/database/migrations/runner.test.ts
@@ -169,9 +169,9 @@ describe('runMigrations', () => {
     expect(db.pragma('user_version', { simple: true })).toBe(13);
 
     const upgrade = runMigrations(db, realMigrationsDir);
-    expect(upgrade._unsafeUnwrap()).toBe(2);
-    expect(db.pragma('user_version', { simple: true })).toBe(15);
-    for (const table of ['lifecycle_events', 'lifecycle_event_deliveries']) {
+    expect(upgrade._unsafeUnwrap()).toBe(4);
+    expect(db.pragma('user_version', { simple: true })).toBe(17);
+    for (const table of ['lifecycle_events', 'lifecycle_event_deliveries', 'lifecycle_signal_handoffs', 'lifecycle_signals']) {
       expect(
         db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`).get(table),
       ).toBeDefined();
@@ -423,8 +423,8 @@ describe('runMigrations', () => {
         )
         .run(identityFor('preserved-handler'));
 
-      expect(runMigrations(preservedDb, realMigrationsDir)._unsafeUnwrap()).toBe(1);
-      expect(preservedDb.pragma('user_version', { simple: true })).toBe(15);
+      expect(runMigrations(preservedDb, realMigrationsDir)._unsafeUnwrap()).toBe(3);
+      expect(preservedDb.pragma('user_version', { simple: true })).toBe(17);
       expect(
         preservedDb
           .prepare(

--- a/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
+++ b/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
@@ -863,8 +863,8 @@ describe('lifecycle event persistence', () => {
         import.meta.dirname,
         '../../../../../src/core/database/migrations',
       );
-      expect(runMigrations(legacyDb, currentMigrations)._unsafeUnwrap()).toBe(1);
-      expect(legacyDb.pragma('user_version', { simple: true })).toBe(15);
+      expect(runMigrations(legacyDb, currentMigrations)._unsafeUnwrap()).toBe(3);
+      expect(legacyDb.pragma('user_version', { simple: true })).toBe(17);
       const upgradedDeliveries = new LifecycleDeliveryRepository(legacyDb, () => upgradeLeaseNow);
       const terminal = upgradedDeliveries
         .fail(

--- a/tests/unit/core/database/repositories/lifecycle-signal-repository.test.ts
+++ b/tests/unit/core/database/repositories/lifecycle-signal-repository.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import {
+  LifecycleEventRepository,
+  LifecycleSignalRepository,
+} from '../../../../../src/core/database/repositories/index.js';
+import { createTestDb, uuid } from './helpers.js';
+import { lifecycleSignalHandoffKey } from '../../../../../src/lifecycle/handler-executor.js';
+
+describe('LifecycleSignalRepository', () => {
+  let db: Database.Database;
+  let events: LifecycleEventRepository;
+  let signals: LifecycleSignalRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    events = new LifecycleEventRepository(db);
+    signals = new LifecycleSignalRepository(db);
+  });
+
+  afterEach(() => db.close());
+
+  it('durably persists a causally valid signal once for a stable delivery handoff', () => {
+    const eventId = uuid();
+    expect(
+      events
+        .insert({
+          version: 'v1',
+          eventId,
+          type: 'message.persisted.v1',
+          occurredAt: '2026-07-16T12:00:00.000Z',
+          context: {
+            aggregate: { type: 'thread', id: uuid() },
+            correlationId: uuid(),
+            recursion: { depth: 0, maxDepth: 4 },
+            provenance: { source: 'test' },
+          },
+          payload: { references: [], metadata: {} },
+        })
+        .isOk(),
+    ).toBe(true);
+    const signalId = uuid();
+    const input = {
+      eventId,
+      handlerId: 'signal-producer',
+      persona: 'assistant',
+      idempotencyKey: `${eventId}:signal-producer`,
+      signals: [
+        {
+          version: 'v1',
+          type: 'behavior.feedback.detected.v1',
+          signalId,
+          occurredAt: '2026-07-16T12:00:01.000Z',
+          context: {
+            aggregate: { type: 'thread', id: uuid() },
+            correlationId: uuid(),
+            causationId: eventId,
+            recursion: { depth: 1, maxDepth: 4 },
+            provenance: { source: 'subagent' },
+          },
+          payload: { references: [], metadata: { verdict: 'positive' } },
+        },
+      ],
+    };
+
+    expect(signals.handoff(input).isOk()).toBe(true);
+    expect(signals.handoff(input).isOk()).toBe(true);
+    expect(
+      db.prepare('SELECT signal_id, persona, handoff_key FROM lifecycle_signals').all(),
+    ).toEqual([{ signal_id: signalId, persona: 'assistant', handoff_key: input.idempotencyKey }]);
+  });
+
+  it('rejects an idempotency-key collision instead of crossing persona ownership', () => {
+    const eventId = uuid();
+    events.insert({
+      version: 'v1',
+      eventId,
+      type: 'message.persisted.v1',
+      occurredAt: '2026-07-16T12:00:00.000Z',
+      context: {
+        aggregate: { type: 'thread', id: uuid() },
+        correlationId: uuid(),
+        recursion: { depth: 0, maxDepth: 4 },
+        provenance: { source: 'test' },
+      },
+      payload: { references: [], metadata: {} },
+    });
+    const input = {
+      eventId,
+      handlerId: 'signal-producer',
+      persona: 'assistant',
+      idempotencyKey: `${eventId}:signal-producer`,
+      signals: [],
+    };
+
+    expect(signals.handoff(input).isOk()).toBe(true);
+    expect(signals.handoff({ ...input, persona: 'other' }).isErr()).toBe(true);
+  });
+
+  it('keeps maximum contract-valid event and handler identities idempotent within the durable key bound', () => {
+    const eventId = `e${'x'.repeat(255)}`;
+    const handlerId = `h${'y'.repeat(127)}`;
+    const idempotencyKey = lifecycleSignalHandoffKey(eventId, handlerId);
+    expect(idempotencyKey.length).toBeLessThanOrEqual(256);
+    expect(
+      events
+        .insert({
+          version: 'v1',
+          eventId,
+          type: 'message.persisted.v1',
+          occurredAt: '2026-07-16T12:00:00.000Z',
+          context: {
+            aggregate: { type: 'thread', id: uuid() },
+            correlationId: uuid(),
+            recursion: { depth: 0, maxDepth: 4 },
+            provenance: { source: 'test' },
+          },
+          payload: { references: [], metadata: {} },
+        })
+        .isOk(),
+    ).toBe(true);
+    const handoff = { eventId, handlerId, persona: 'assistant', idempotencyKey, signals: [] };
+
+    expect(signals.handoff(handoff).isOk()).toBe(true);
+    expect(signals.handoff(handoff).isOk()).toBe(true);
+    expect(signals.handoff({ ...handoff, handlerId: 'other-handler' }).isErr()).toBe(true);
+  });
+});

--- a/tests/unit/daemon/agent-runner.test.ts
+++ b/tests/unit/daemon/agent-runner.test.ts
@@ -1112,6 +1112,7 @@ describe('AgentRunner', () => {
         'message',
         { personaId: 'persona-001', content: 'continue' },
         expect.any(String),
+        { persona: 'TestBot', itemType: 'message' },
       );
     });
 

--- a/tests/unit/daemon/daemon-bootstrap.test.ts
+++ b/tests/unit/daemon/daemon-bootstrap.test.ts
@@ -38,7 +38,11 @@ vi.mock('../../../src/core/database/repositories/index.js', () => ({
   ScheduleRepository: vi.fn().mockImplementation(() => ({
     // Bootstrap now invokes migrateLegacySchedules() before the scheduler
     // starts ticking; mock findAll() so the mocked repo satisfies it.
-    findAll: vi.fn().mockReturnValue({ isErr: () => true, isOk: () => false, error: new Error('mock: migration skipped') }),
+    findAll: vi.fn().mockReturnValue({
+      isErr: () => true,
+      isOk: () => false,
+      error: new Error('mock: migration skipped'),
+    }),
   })),
   AuditRepository: vi.fn().mockImplementation(() => ({})),
   MessageRepository: vi.fn().mockImplementation(() => ({})),
@@ -46,6 +50,15 @@ vi.mock('../../../src/core/database/repositories/index.js', () => ({
   BindingRepository: vi.fn().mockImplementation(() => ({})),
   MemoryRepository: vi.fn().mockImplementation(() => ({})),
   A2ATaskRepository: vi.fn().mockImplementation(() => ({})),
+  LifecycleEventRepository: vi.fn().mockImplementation(() => ({ db: { inTransaction: false } })),
+  LifecycleDeliveryRepository: vi.fn().mockImplementation(() => ({
+    claimNext: vi.fn(),
+    complete: vi.fn(),
+    fail: vi.fn(),
+  })),
+  LifecycleSignalRepository: vi
+    .fn()
+    .mockImplementation(() => ({ handoff: vi.fn().mockReturnValue(ok(undefined)) })),
 }));
 
 vi.mock('../../../src/core/database/repositories/audit-repository.js', () => ({
@@ -159,7 +172,11 @@ vi.mock('../../../src/a2a/index.js', () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { bootstrap } from '../../../src/daemon/daemon-bootstrap.js';
+import {
+  bootstrap,
+  hasExplicitLifecycleSubagentAuthority,
+  supportsLifecycleBootstrapHandler,
+} from '../../../src/daemon/daemon-bootstrap.js';
 import { loadConfig } from '../../../src/core/config/config-loader.js';
 import { createDatabase } from '../../../src/core/database/connection.js';
 import { runMigrations } from '../../../src/core/database/migrations/runner.js';
@@ -182,7 +199,9 @@ function createSilentLogger(): pino.Logger {
   return createDiscardLogger('silent');
 }
 
-function makeContextManagementConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function makeContextManagementConfig(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     enabled: true,
     triggerMetric: 'cache_read_input_tokens',
@@ -193,7 +212,9 @@ function makeContextManagementConfig(overrides: Record<string, unknown> = {}): R
   };
 }
 
-function makeAgentRunnerProviderConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function makeAgentRunnerProviderConfig(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     enabled: true,
     command: 'claude',
@@ -203,7 +224,9 @@ function makeAgentRunnerProviderConfig(overrides: Record<string, unknown> = {}):
   };
 }
 
-function makeBackgroundProviderConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function makeBackgroundProviderConfig(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     enabled: true,
     command: 'claude',
@@ -307,13 +330,19 @@ function setupSuccessfulMocks() {
   vi.mocked(createObservabilityService).mockResolvedValue(observability as any);
 
   // Restore constructor mocks in case previous tests overrode them.
-  vi.mocked(PersonaLoader).mockImplementation(() => ({
-    loadFromConfig: vi.fn().mockResolvedValue(ok(undefined)),
-    getByName: vi.fn().mockReturnValue(ok({})),
-  }) as any);
-  vi.mocked(SkillLoader).mockImplementation(() => ({
-    loadFromPersonaConfig: vi.fn().mockResolvedValue(ok([])),
-  }) as any);
+  vi.mocked(PersonaLoader).mockImplementation(
+    () =>
+      ({
+        loadFromConfig: vi.fn().mockResolvedValue(ok(undefined)),
+        getByName: vi.fn().mockReturnValue(ok({})),
+      }) as any,
+  );
+  vi.mocked(SkillLoader).mockImplementation(
+    () =>
+      ({
+        loadFromPersonaConfig: vi.fn().mockResolvedValue(ok([])),
+      }) as any,
+  );
 
   return { config, db, observability };
 }
@@ -330,15 +359,27 @@ describe('bootstrap', () => {
     vi.clearAllMocks();
   });
 
+  it('requires the owning persona to explicitly attach a lifecycle sub-agent', () => {
+    expect(hasExplicitLifecycleSubagentAuthority([], 'signal-projector')).toBe(false);
+    expect(hasExplicitLifecycleSubagentAuthority(undefined, 'signal-projector')).toBe(false);
+    expect(hasExplicitLifecycleSubagentAuthority(['signal-projector'], 'signal-projector')).toBe(
+      true,
+    );
+  });
+
+  it('rejects only unsupported sub-agent interceptor attachments at bootstrap', () => {
+    expect(supportsLifecycleBootstrapHandler('subagent', 'interceptor')).toBe(false);
+    expect(supportsLifecycleBootstrapHandler('subagent', 'event')).toBe(true);
+    expect(supportsLifecycleBootstrapHandler('native', 'interceptor')).toBe(true);
+  });
+
   // -------------------------------------------------------------------------
   // Failure scenarios
   // -------------------------------------------------------------------------
 
   describe('failure scenarios', () => {
     it('returns error when config loading fails', async () => {
-      vi.mocked(loadConfig).mockReturnValue(
-        err(new Error('config file not found') as any),
-      );
+      vi.mocked(loadConfig).mockReturnValue(err(new Error('config file not found') as any));
 
       const result = await bootstrap('/missing.yaml', logger);
 
@@ -349,9 +390,7 @@ describe('bootstrap', () => {
     it('returns error when database creation fails', async () => {
       const config = makeConfig();
       vi.mocked(loadConfig).mockReturnValue(ok(config as any));
-      vi.mocked(createDatabase).mockReturnValue(
-        err(new Error('cannot open database') as any),
-      );
+      vi.mocked(createDatabase).mockReturnValue(err(new Error('cannot open database') as any));
 
       const result = await bootstrap('/config.yaml', logger);
 
@@ -364,9 +403,7 @@ describe('bootstrap', () => {
       const db = makeMockDb();
       vi.mocked(loadConfig).mockReturnValue(ok(config as any));
       vi.mocked(createDatabase).mockReturnValue(ok(db as any));
-      vi.mocked(runMigrations).mockReturnValue(
-        err(new Error('migration 003 failed') as any),
-      );
+      vi.mocked(runMigrations).mockReturnValue(err(new Error('migration 003 failed') as any));
 
       const result = await bootstrap('/config.yaml', logger);
 
@@ -389,10 +426,13 @@ describe('bootstrap', () => {
       vi.mocked(createObservabilityService).mockResolvedValue(observability as any);
 
       // Override the PersonaLoader mock to make loadFromConfig fail.
-      vi.mocked(PersonaLoader).mockImplementation(() => ({
-        loadFromConfig: vi.fn().mockResolvedValue(err(new Error('persona parse error'))),
-        getByName: vi.fn(),
-      }) as any);
+      vi.mocked(PersonaLoader).mockImplementation(
+        () =>
+          ({
+            loadFromConfig: vi.fn().mockResolvedValue(err(new Error('persona parse error'))),
+            getByName: vi.fn(),
+          }) as any,
+      );
 
       const result = await bootstrap('/config.yaml', logger);
 
@@ -416,15 +456,23 @@ describe('bootstrap', () => {
       vi.mocked(createObservabilityService).mockResolvedValue(observability as any);
 
       // Restore PersonaLoader to success (may have been overridden by previous test).
-      vi.mocked(PersonaLoader).mockImplementation(() => ({
-        loadFromConfig: vi.fn().mockResolvedValue(ok(undefined)),
-        getByName: vi.fn().mockReturnValue(ok({})),
-      }) as any);
+      vi.mocked(PersonaLoader).mockImplementation(
+        () =>
+          ({
+            loadFromConfig: vi.fn().mockResolvedValue(ok(undefined)),
+            getByName: vi.fn().mockReturnValue(ok({})),
+          }) as any,
+      );
 
       // Override the SkillLoader mock to make loadFromPersonaConfig fail.
-      vi.mocked(SkillLoader).mockImplementation(() => ({
-        loadFromPersonaConfig: vi.fn().mockResolvedValue(err(new Error('skill manifest invalid'))),
-      }) as any);
+      vi.mocked(SkillLoader).mockImplementation(
+        () =>
+          ({
+            loadFromPersonaConfig: vi
+              .fn()
+              .mockResolvedValue(err(new Error('skill manifest invalid'))),
+          }) as any,
+      );
 
       const result = await bootstrap('/config.yaml', logger);
 
@@ -474,13 +522,19 @@ describe('bootstrap', () => {
       vi.mocked(createObservabilityService).mockResolvedValue(observability as any);
       // Restore PersonaLoader and SkillLoader to success — previous failure
       // tests override these and clearAllMocks does not reset implementations.
-      vi.mocked(PersonaLoader).mockImplementation(() => ({
-        loadFromConfig: vi.fn().mockResolvedValue(ok(undefined)),
-        getByName: vi.fn().mockReturnValue(ok({})),
-      }) as any);
-      vi.mocked(SkillLoader).mockImplementation(() => ({
-        loadFromPersonaConfig: vi.fn().mockResolvedValue(ok([])),
-      }) as any);
+      vi.mocked(PersonaLoader).mockImplementation(
+        () =>
+          ({
+            loadFromConfig: vi.fn().mockResolvedValue(ok(undefined)),
+            getByName: vi.fn().mockReturnValue(ok({})),
+          }) as any,
+      );
+      vi.mocked(SkillLoader).mockImplementation(
+        () =>
+          ({
+            loadFromPersonaConfig: vi.fn().mockResolvedValue(ok([])),
+          }) as any,
+      );
 
       const result = await bootstrap('/config.yaml', logger);
 
@@ -497,6 +551,97 @@ describe('bootstrap', () => {
   // -------------------------------------------------------------------------
 
   describe('successful bootstrap', () => {
+    it('constructs an enabled native lifecycle interceptor with bootstrap-owned authority', async () => {
+      const { config } = setupSuccessfulMocks();
+      const enabled = {
+        ...(config as Record<string, unknown>),
+        lifecycle: {
+          enabled: true,
+          handlers: [
+            {
+              version: 'v1',
+              id: 'allow-inbound',
+              mode: 'interceptor',
+              inputContract: 'talon.lifecycle.interceptor.input.v1',
+              outputContract: 'talon.lifecycle.enforcing.interceptor.output.v1',
+              interceptorSafety: 'enforcing',
+              runtime: {
+                kind: 'native',
+                ref: 'native-allow-interceptor',
+                implementationVersion: '1.0.0',
+              },
+            },
+          ],
+        },
+        personas: [
+          {
+            name: 'assistant',
+            lifecycle: {
+              subscriptions: [
+                {
+                  version: 'v1',
+                  handler: 'allow-inbound',
+                  priority: 1,
+                  subscription: {
+                    version: 'v1',
+                    kind: 'interceptor',
+                    interceptors: [{ version: 'v1', hook: 'message.before_persist' }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      vi.mocked(loadConfig).mockReturnValue(ok(enabled as any));
+
+      const result = await bootstrap('/config.yaml', logger);
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().lifecycleRuntime).not.toBeNull();
+    });
+
+    it('deduplicates one native lifecycle capability attached to multiple personas', async () => {
+      const { config } = setupSuccessfulMocks();
+      const nativeEventHandler = {
+        version: 'v1',
+        id: 'noop-event',
+        mode: 'event',
+        inputContract: 'talon.lifecycle.event.envelope.v1',
+        outputContract: 'talon.lifecycle.signal.envelopes.v1',
+        runtime: {
+          kind: 'native',
+          ref: 'native-noop-event',
+          implementationVersion: '1.0.0',
+        },
+      };
+      const eventSubscription = {
+        version: 'v1',
+        handler: 'noop-event',
+        priority: 1,
+        subscription: {
+          version: 'v1',
+          kind: 'event',
+          events: [{ version: 'v1', type: 'message.persisted.v1' }],
+        },
+      };
+      vi.mocked(loadConfig).mockReturnValue(
+        ok({
+          ...(config as Record<string, unknown>),
+          lifecycle: { enabled: true, handlers: [nativeEventHandler] },
+          personas: [
+            { name: 'assistant', lifecycle: { subscriptions: [eventSubscription] } },
+            { name: 'observer', lifecycle: { subscriptions: [eventSubscription] } },
+          ],
+        } as any),
+      );
+
+      const result = await bootstrap('/config.yaml', logger);
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().lifecycleRuntime).not.toBeNull();
+    });
+
     it('returns Ok(DaemonContext) with all fields populated', async () => {
       setupSuccessfulMocks();
 
@@ -590,7 +735,9 @@ describe('bootstrap', () => {
       const ctx = result._unsafeUnwrap();
       expect(ctx.dataDir.startsWith('/')).toBe(true);
       expect(ctx.dataDir.endsWith('/data')).toBe(true);
-      expect(ctx.threadWorkspace.ensureDirectories('thread-abs')._unsafeUnwrap().startsWith('/')).toBe(true);
+      expect(
+        ctx.threadWorkspace.ensureDirectories('thread-abs')._unsafeUnwrap().startsWith('/'),
+      ).toBe(true);
     });
 
     it('applies the configured log level during bootstrap', async () => {
@@ -666,18 +813,20 @@ describe('bootstrap', () => {
     it('wires ExecutionEnvManager when sprites are enabled', async () => {
       setupSuccessfulMocks();
       vi.mocked(loadConfig).mockReturnValue(
-        ok(makeConfig({
-          sprites: {
-            enabled: true,
-            token: 'sprites-token',
-            apiBaseUrl: 'https://api.sprites.dev',
-            workingDirectory: '/workspace',
-            createTimeoutMs: 60000,
-            execTimeoutMs: 1200000,
-            autoDestroyOnCompletion: true,
-            resourceLimits: { cpus: 2, memoryMb: 4096, diskGb: 20 },
-          },
-        }) as any),
+        ok(
+          makeConfig({
+            sprites: {
+              enabled: true,
+              token: 'sprites-token',
+              apiBaseUrl: 'https://api.sprites.dev',
+              workingDirectory: '/workspace',
+              createTimeoutMs: 60000,
+              execTimeoutMs: 1200000,
+              autoDestroyOnCompletion: true,
+              resourceLimits: { cpus: 2, memoryMb: 4096, diskGb: 20 },
+            },
+          }) as any,
+        ),
       );
 
       const result = await bootstrap('/config.yaml', logger);
@@ -814,8 +963,8 @@ describe('bootstrap', () => {
       expect(ctx.providerRegistry.get('codex-cli')?.provider.name).toBe('codex-cli');
       expect(ctx.providerRegistry.getDefault(['codex-cli'])?.provider.name).toBe('codex-cli');
 
-      const backgroundProviderRegistry = vi.mocked(BackgroundAgentManager).mock.calls[0]?.[0]
-        .providerRegistry;
+      const backgroundProviderRegistry =
+        vi.mocked(BackgroundAgentManager).mock.calls[0]?.[0].providerRegistry;
       expect(backgroundProviderRegistry.get('codex-cli')?.provider.name).toBe('codex-cli');
       expect(backgroundProviderRegistry.getDefault(['codex-cli'])?.provider.name).toBe('codex-cli');
       expect(BackgroundAgentManager).toHaveBeenCalledWith(
@@ -888,8 +1037,8 @@ describe('bootstrap', () => {
         'openai-compatible',
       );
 
-      const backgroundProviderRegistry = vi.mocked(BackgroundAgentManager).mock.calls[0]?.[0]
-        .providerRegistry;
+      const backgroundProviderRegistry =
+        vi.mocked(BackgroundAgentManager).mock.calls[0]?.[0].providerRegistry;
       expect(backgroundProviderRegistry.get('openai-compatible')?.provider.name).toBe(
         'openai-compatible',
       );
@@ -987,8 +1136,8 @@ describe('bootstrap', () => {
       expect(payload.baseUrl).toBe('http://mac.local:11434/v1');
       expect(payload.apiKey).toBe('local-key');
 
-      const backgroundProviderRegistry = vi.mocked(BackgroundAgentManager).mock.calls[0]?.[0]
-        .providerRegistry;
+      const backgroundProviderRegistry =
+        vi.mocked(BackgroundAgentManager).mock.calls[0]?.[0].providerRegistry;
       expect(backgroundProviderRegistry.get('ollama-mac')?.type).toBe('openai-compatible');
       expect(backgroundProviderRegistry.get('ollama-mac')?.provider.name).toBe('ollama-mac');
     });
@@ -1155,9 +1304,11 @@ describe('bootstrap', () => {
     });
 
     it('binds the session summarizer with the manifest maxTokens budget', async () => {
-      const summarizerRun = vi.fn().mockResolvedValue(ok({
-        summary: 'Summarized.',
-      }));
+      const summarizerRun = vi.fn().mockResolvedValue(
+        ok({
+          summary: 'Summarized.',
+        }),
+      );
 
       vi.doMock('../../../src/subagents/subagent-loader.js', () => ({
         SubAgentLoader: vi.fn().mockImplementation(() => ({
@@ -1196,11 +1347,16 @@ describe('bootstrap', () => {
       vi.resetModules();
 
       try {
-        const { loadConfig: isolatedLoadConfig } = await import('../../../src/core/config/config-loader.js');
-        const { createDatabase: isolatedCreateDatabase } = await import('../../../src/core/database/connection.js');
-        const { runMigrations: isolatedRunMigrations } = await import('../../../src/core/database/migrations/runner.js');
-        const { createObservabilityService: isolatedCreateObservabilityService } = await import('../../../src/observability/langfuse/index.js');
-        const { bootstrap: isolatedBootstrap } = await import('../../../src/daemon/daemon-bootstrap.js');
+        const { loadConfig: isolatedLoadConfig } =
+          await import('../../../src/core/config/config-loader.js');
+        const { createDatabase: isolatedCreateDatabase } =
+          await import('../../../src/core/database/connection.js');
+        const { runMigrations: isolatedRunMigrations } =
+          await import('../../../src/core/database/migrations/runner.js');
+        const { createObservabilityService: isolatedCreateObservabilityService } =
+          await import('../../../src/observability/langfuse/index.js');
+        const { bootstrap: isolatedBootstrap } =
+          await import('../../../src/daemon/daemon-bootstrap.js');
 
         const config = makeConfig();
         const db = makeMockDb();
@@ -1300,11 +1456,16 @@ describe('bootstrap', () => {
       vi.resetModules();
 
       try {
-        const { loadConfig: isolatedLoadConfig } = await import('../../../src/core/config/config-loader.js');
-        const { createDatabase: isolatedCreateDatabase } = await import('../../../src/core/database/connection.js');
-        const { runMigrations: isolatedRunMigrations } = await import('../../../src/core/database/migrations/runner.js');
-        const { createObservabilityService: isolatedCreateObservabilityService } = await import('../../../src/observability/langfuse/index.js');
-        const { bootstrap: isolatedBootstrap } = await import('../../../src/daemon/daemon-bootstrap.js');
+        const { loadConfig: isolatedLoadConfig } =
+          await import('../../../src/core/config/config-loader.js');
+        const { createDatabase: isolatedCreateDatabase } =
+          await import('../../../src/core/database/connection.js');
+        const { runMigrations: isolatedRunMigrations } =
+          await import('../../../src/core/database/migrations/runner.js');
+        const { createObservabilityService: isolatedCreateObservabilityService } =
+          await import('../../../src/observability/langfuse/index.js');
+        const { bootstrap: isolatedBootstrap } =
+          await import('../../../src/daemon/daemon-bootstrap.js');
 
         // Configure the provider to use the observer-based OM path.
         const config = makeConfig({
@@ -1335,7 +1496,9 @@ describe('bootstrap', () => {
         expect(ctx.contextRoller).toBeTruthy();
 
         const resolver = (ctx.contextRoller as any).deps.resolveSummarizerRun as
-          | ((name: string) => ((threadId: string, personaId: string, input: unknown) => Promise<unknown>) | null)
+          | ((
+              name: string,
+            ) => ((threadId: string, personaId: string, input: unknown) => Promise<unknown>) | null)
           | undefined;
         expect(resolver).toBeTypeOf('function');
 

--- a/tests/unit/daemon/daemon.test.ts
+++ b/tests/unit/daemon/daemon.test.ts
@@ -106,7 +106,13 @@ function makeMockContext(overrides: Partial<DaemonContext> = {}): DaemonContext 
       schedule: {} as any,
       audit: {} as any,
       message: {} as any,
-      run: { aggregateByPeriod: vi.fn().mockReturnValue(ok({ total_input_tokens: 0, total_output_tokens: 0, total_cost_usd: 0 })) } as any,
+      run: {
+        aggregateByPeriod: vi
+          .fn()
+          .mockReturnValue(
+            ok({ total_input_tokens: 0, total_output_tokens: 0, total_cost_usd: 0 }),
+          ),
+      } as any,
       binding: {} as any,
       memory: {} as any,
     },
@@ -307,7 +313,9 @@ describe('TalondDaemon', () => {
           logLevel: 'debug',
         } as any,
       });
-      const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true as any);
+      const stdoutWriteSpy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true as any);
       const logger = createDiscardLogger('info');
       const localDaemon = new TalondDaemon(logger);
 
@@ -338,13 +346,142 @@ describe('TalondDaemon', () => {
     });
 
     it('transitions state to error when bootstrap fails', async () => {
-      vi.mocked(bootstrap).mockResolvedValue(
-        err(new DaemonError('bootstrap failure')),
-      );
+      vi.mocked(bootstrap).mockResolvedValue(err(new DaemonError('bootstrap failure')));
 
       await daemon.start('/bad.yaml');
 
       expect(daemon.state).toBe('error');
+    });
+
+    it('cleans up a post-lifecycle startup failure and permits a successful restart', async () => {
+      const lifecycleRuntime = { start: vi.fn(), stop: vi.fn().mockResolvedValue(undefined) };
+      const failed = makeMockContext({
+        lifecycleRuntime: lifecycleRuntime as any,
+        scheduler: {
+          start: vi.fn(() => {
+            throw new Error('scheduler start failed');
+          }),
+          stop: vi.fn(),
+        } as any,
+      });
+      const recovered = makeMockContext();
+      vi.mocked(bootstrap).mockResolvedValueOnce(ok(failed)).mockResolvedValueOnce(ok(recovered));
+
+      const result = await daemon.start('/config.yaml');
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().code).toBe('DAEMON_ERROR');
+      expect(daemon.state).toBe('stopped');
+      expect(lifecycleRuntime.start).toHaveBeenCalledOnce();
+      expect(lifecycleRuntime.stop).toHaveBeenCalledOnce();
+      expect(failed.queueManager.stopProcessing).toHaveBeenCalledOnce();
+      expect(failed.hostToolsBridge.stop).toHaveBeenCalledOnce();
+      expect(failed.db.close).toHaveBeenCalledOnce();
+
+      expect((await daemon.start('/config.yaml')).isOk()).toBe(true);
+      expect(daemon.state).toBe('running');
+    });
+
+    it('joins started queue work before closing SQLite after startup failure', async () => {
+      let releaseQueue!: () => void;
+      const queueDrain = new Promise<void>((resolve) => {
+        releaseQueue = resolve;
+      });
+      const failed = makeMockContext({
+        scheduler: {
+          start: vi.fn(() => {
+            throw new Error('scheduler start failed');
+          }),
+          stop: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        queueManager: {
+          startProcessing: vi.fn(),
+          stopProcessing: vi.fn().mockReturnValue(queueDrain),
+          stats: vi.fn().mockReturnValue({ pending: 0, claimed: 0, processing: 0, deadLetter: 0 }),
+        } as any,
+      });
+      vi.mocked(bootstrap).mockResolvedValue(ok(failed));
+
+      const starting = daemon.start('/config.yaml');
+      await vi.waitFor(() => expect(failed.queueManager.stopProcessing).toHaveBeenCalledOnce());
+      expect(failed.db.close).not.toHaveBeenCalled();
+
+      releaseQueue();
+      expect((await starting).isErr()).toBe(true);
+      expect(failed.db.close).toHaveBeenCalledOnce();
+      expect(failed.queueManager.stopProcessing.mock.invocationCallOrder[0]).toBeLessThan(
+        failed.db.close.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('gates restart and defers SQLite teardown when a bounded scheduler drain times out', async () => {
+      let releaseDrain!: () => void;
+      const deferred = new Promise<void>((resolve) => {
+        releaseDrain = resolve;
+      });
+      const failed = makeMockContext({
+        scheduler: {
+          start: vi.fn(() => {
+            throw new Error('scheduler start failed');
+          }),
+          stop: vi
+            .fn()
+            .mockResolvedValueOnce({ status: 'timed_out' })
+            .mockResolvedValue({ status: 'drained' }),
+          waitForDrain: vi.fn().mockReturnValue(deferred),
+        } as any,
+        queueManager: {
+          startProcessing: vi.fn(),
+          stopProcessing: vi.fn().mockResolvedValue({ status: 'drained' }),
+          waitForDrain: vi.fn().mockResolvedValue(undefined),
+          stats: vi.fn(),
+        } as any,
+      });
+      vi.mocked(bootstrap).mockResolvedValue(ok(failed));
+
+      const result = await daemon.start('/config.yaml');
+      expect(result.isErr()).toBe(true);
+      expect(failed.db.close).not.toHaveBeenCalled();
+      expect((await daemon.start('/config.yaml')).isErr()).toBe(true);
+
+      releaseDrain();
+      await vi.waitFor(() => expect(failed.db.close).toHaveBeenCalledOnce());
+      expect(daemon.state).toBe('stopped');
+    });
+
+    it('fails closed on a startup drain exception until deferred cleanup confirms all work drained', async () => {
+      let releaseDrain!: () => void;
+      const deferred = new Promise<void>((resolve) => {
+        releaseDrain = resolve;
+      });
+      const failed = makeMockContext({
+        scheduler: {
+          start: vi.fn(() => {
+            throw new Error('scheduler start failed');
+          }),
+          stop: vi
+            .fn()
+            .mockRejectedValueOnce(new Error('scheduler drain failed'))
+            .mockResolvedValue({ status: 'drained' }),
+          waitForDrain: vi.fn().mockReturnValue(deferred),
+        } as any,
+        queueManager: {
+          startProcessing: vi.fn(),
+          stopProcessing: vi.fn().mockResolvedValue({ status: 'drained' }),
+          waitForDrain: vi.fn().mockResolvedValue(undefined),
+          stats: vi.fn(),
+        } as any,
+      });
+      vi.mocked(bootstrap).mockResolvedValue(ok(failed));
+
+      const result = await daemon.start('/config.yaml');
+      expect(result.isErr()).toBe(true);
+      expect(failed.db.close).not.toHaveBeenCalled();
+      expect((await daemon.start('/config.yaml')).isErr()).toBe(true);
+
+      releaseDrain();
+      await vi.waitFor(() => expect(failed.db.close).toHaveBeenCalledOnce());
+      expect(daemon.state).toBe('stopped');
     });
   });
 
@@ -378,6 +515,72 @@ describe('TalondDaemon', () => {
   // -------------------------------------------------------------------------
 
   describe('stop()', () => {
+    it('contains a rejected drain from an IPC shutdown callback', async () => {
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      } as any;
+      const ipcDaemon = new TalondDaemon(logger);
+      const stop = vi
+        .spyOn(ipcDaemon, 'stop')
+        .mockRejectedValue(new DaemonError('Daemon workloads are still draining'));
+      const unhandledRejection = vi.fn();
+      process.once('unhandledRejection', unhandledRejection);
+
+      const response = await (ipcDaemon as any).handleIpcCommand({
+        id: '00000000-0000-4000-8000-000000000007',
+        command: 'shutdown',
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await Promise.resolve();
+      process.off('unhandledRejection', unhandledRejection);
+
+      expect(response).toMatchObject({
+        success: true,
+        commandId: '00000000-0000-4000-8000-000000000007',
+      });
+      expect(stop).toHaveBeenCalledOnce();
+      expect(unhandledRejection).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ cause: expect.any(DaemonError) }),
+        'daemon: IPC shutdown deferred after drain failure',
+      );
+    });
+
+    it('defers teardown and remains restart-gated when a normal shutdown drain rejects', async () => {
+      let releaseDrain!: () => void;
+      const deferred = new Promise<void>((resolve) => {
+        releaseDrain = resolve;
+      });
+      const ctx = setupSuccessfulBootstrap({
+        scheduler: {
+          start: vi.fn(),
+          stop: vi
+            .fn()
+            .mockRejectedValueOnce(new Error('scheduler drain failed'))
+            .mockResolvedValue({ status: 'drained' }),
+          waitForDrain: vi.fn().mockReturnValue(deferred),
+        } as any,
+        queueManager: {
+          startProcessing: vi.fn(),
+          stopProcessing: vi.fn().mockResolvedValue({ status: 'drained' }),
+          waitForDrain: vi.fn().mockResolvedValue(undefined),
+          stats: vi.fn(),
+        } as any,
+      });
+      await daemon.start('/config.yaml');
+
+      await expect(daemon.stop()).rejects.toMatchObject({ code: 'DAEMON_ERROR' });
+      expect(ctx.db.close).not.toHaveBeenCalled();
+      expect((await daemon.start('/config.yaml')).isErr()).toBe(true);
+
+      releaseDrain();
+      await vi.waitFor(() => expect(ctx.db.close).toHaveBeenCalledOnce());
+      expect(daemon.state).toBe('stopped');
+    });
+
     it('transitions state to stopped after shutdown', async () => {
       setupSuccessfulBootstrap();
       await daemon.start('/config.yaml');

--- a/tests/unit/daemon/reload.test.ts
+++ b/tests/unit/daemon/reload.test.ts
@@ -260,6 +260,144 @@ describe('TalondDaemon.reload()', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Lifecycle config changes
+  // -------------------------------------------------------------------------
+
+  describe('lifecycle config changes', () => {
+    it('rejects top-level lifecycle changes before applying any reload mutations', async () => {
+      const ctx = setupSuccessfulStart({
+        lifecycle: { enabled: true, handlers: [] },
+      });
+      await daemon.start('/config.yaml');
+
+      const newConfig = makeConfig({
+        logLevel: 'debug',
+        lifecycle: { enabled: false, handlers: [] },
+      });
+      vi.mocked(loadConfig).mockReturnValue(ok(newConfig as any));
+
+      const result = await daemon.reload('/config.yaml');
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().message).toContain('restart required');
+      expect(ctx.personaLoader.loadFromConfig).not.toHaveBeenCalled();
+      expect(ctx.channelRegistry.stopAll).not.toHaveBeenCalled();
+      expect(ctx.config.logLevel).toBe('info');
+    });
+
+    it('rejects persona lifecycle subscription changes before reloading personas', async () => {
+      const oldSubscription = {
+        handler: 'audit-handler',
+        subscription: { eventTypes: ['message.received'] },
+      };
+      const newSubscription = {
+        handler: 'audit-handler',
+        subscription: { eventTypes: ['message.completed'] },
+      };
+      const persona = {
+        name: 'observer',
+        model: 'claude-sonnet-4-6',
+        skills: [],
+        capabilities: { allow: [], requireApproval: [] },
+        mounts: [],
+        lifecycle: { subscriptions: [oldSubscription] },
+      };
+      const ctx = setupSuccessfulStart({
+        lifecycle: { enabled: true, handlers: [] },
+        personas: [persona],
+      });
+      await daemon.start('/config.yaml');
+
+      const newConfig = makeConfig({
+        lifecycle: { enabled: true, handlers: [] },
+        personas: [
+          {
+            ...persona,
+            lifecycle: { subscriptions: [newSubscription] },
+          },
+        ],
+      });
+      vi.mocked(loadConfig).mockReturnValue(ok(newConfig as any));
+
+      const result = await daemon.reload('/config.yaml');
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().message).toContain('lifecycle-attached persona');
+      expect(ctx.personaLoader.loadFromConfig).not.toHaveBeenCalled();
+      expect(ctx.config.personas).toEqual([persona]);
+    });
+
+    it.each([
+      {
+        description: 'sub-agent assignment',
+        change: { subagents: [] },
+      },
+      {
+        description: 'capability policy',
+        change: { capabilities: { allow: [], requireApproval: ['tools.read:*'] } },
+      },
+    ])(
+      'rejects lifecycle-attached persona $description changes before reloading personas',
+      async ({ change }) => {
+        const persona = {
+          name: 'observer',
+          model: 'claude-sonnet-4-6',
+          skills: [],
+          subagents: ['lifecycle-auditor'],
+          capabilities: { allow: ['tools.read:*'], requireApproval: [] },
+          mounts: [],
+          lifecycle: {
+            subscriptions: [
+              {
+                handler: 'audit-handler',
+                subscription: { eventTypes: ['message.received'] },
+              },
+            ],
+          },
+        };
+        const ctx = setupSuccessfulStart({ personas: [persona] });
+        await daemon.start('/config.yaml');
+
+        const newConfig = makeConfig({
+          personas: [{ ...persona, ...change }],
+        });
+        vi.mocked(loadConfig).mockReturnValue(ok(newConfig as any));
+
+        const result = await daemon.reload('/config.yaml');
+
+        expect(result.isErr()).toBe(true);
+        expect(result._unsafeUnwrapErr().message).toContain('restart required');
+        expect(ctx.personaLoader.loadFromConfig).not.toHaveBeenCalled();
+        expect(ctx.config.personas).toEqual([persona]);
+      },
+    );
+
+    it('allows ordinary persona changes when lifecycle attachments are unchanged', async () => {
+      const lifecycle = { subscriptions: [] };
+      const persona = {
+        name: 'assistant',
+        model: 'claude-sonnet-4-6',
+        skills: [],
+        capabilities: { allow: [], requireApproval: [] },
+        mounts: [],
+        lifecycle,
+      };
+      const ctx = setupSuccessfulStart({ personas: [persona] });
+      await daemon.start('/config.yaml');
+
+      const newConfig = makeConfig({
+        personas: [{ ...persona, model: 'claude-opus-4-6' }],
+      });
+      vi.mocked(loadConfig).mockReturnValue(ok(newConfig as any));
+
+      const result = await daemon.reload('/config.yaml');
+
+      expect(result.isOk()).toBe(true);
+      expect(ctx.personaLoader.loadFromConfig).toHaveBeenCalledWith(newConfig.personas);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Log level changes
   // -------------------------------------------------------------------------
 

--- a/tests/unit/lifecycle/lifecycle-dispatcher.test.ts
+++ b/tests/unit/lifecycle/lifecycle-dispatcher.test.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../../src/core/database/repositories/lifecycle-delivery-repository.js';
 import {
   CapturedLifecycleHandlerExecutor,
+  lifecycleSignalHandoffKey,
   type LifecycleHandlerExecutor,
 } from '../../../src/lifecycle/handler-executor.js';
 import { LifecycleDispatcher } from '../../../src/lifecycle/lifecycle-dispatcher.js';
@@ -113,7 +114,9 @@ describe('LifecycleDispatcher', () => {
     deliveries.claimNext.mockReturnValueOnce(ok(claim()));
     const executor: LifecycleHandlerExecutor = {
       execute: vi.fn(async (execution) => {
-        expect(execution.idempotencyKey).toBe('event-projector:projector');
+        expect(execution.idempotencyKey).toBe(
+          lifecycleSignalHandoffKey('event-projector', 'projector'),
+        );
         expect(execution.identity.implementationVersion).toBe('1.0.0');
         expect('claim' in execution).toBe(false);
         expect(Object.isFrozen(execution.event)).toBe(true);
@@ -135,6 +138,9 @@ describe('LifecycleDispatcher', () => {
       signals.handoff.mock.invocationCallOrder[0]!,
     );
     expect(deliveries.fail).not.toHaveBeenCalled();
+    expect(signals.handoff).toHaveBeenCalledWith(
+      expect.objectContaining({ persona: 'assistant', eventId: 'event-projector' }),
+    );
   });
 
   it('enforces global and per-handler backpressure before claiming another delivery', async () => {
@@ -263,8 +269,8 @@ describe('LifecycleDispatcher', () => {
 
     expect(signals.handoff).toHaveBeenCalledTimes(2);
     expect(signals.handoff.mock.calls.map(([value]) => value.idempotencyKey)).toEqual([
-      'event-projector:projector',
-      'event-projector:projector',
+      lifecycleSignalHandoffKey('event-projector', 'projector'),
+      lifecycleSignalHandoffKey('event-projector', 'projector'),
     ]);
     expect(deliveries.complete).toHaveBeenCalledTimes(2);
   });

--- a/tests/unit/pipeline/message-pipeline.test.ts
+++ b/tests/unit/pipeline/message-pipeline.test.ts
@@ -8,13 +8,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ok, err } from 'neverthrow';
 import pino from 'pino';
+import Database from 'better-sqlite3';
 import { MessagePipeline } from '../../../src/pipeline/message-pipeline.js';
 import { PipelineError } from '../../../src/core/errors/index.js';
 import { DbError, ChannelError, QueueError } from '../../../src/core/errors/index.js';
 import type { InboundEvent } from '../../../src/channels/channel-types.js';
-import type { MessageRepository } from '../../../src/core/database/repositories/message-repository.js';
-import type { ThreadRepository } from '../../../src/core/database/repositories/thread-repository.js';
-import type { ChannelRepository } from '../../../src/core/database/repositories/channel-repository.js';
+import { MessageRepository } from '../../../src/core/database/repositories/message-repository.js';
+import { ThreadRepository } from '../../../src/core/database/repositories/thread-repository.js';
+import { ChannelRepository } from '../../../src/core/database/repositories/channel-repository.js';
 import type { ChannelRouter } from '../../../src/channels/channel-router.js';
 import type { QueueManager } from '../../../src/queue/queue-manager.js';
 import type { AuditLogger } from '../../../src/core/logging/audit-logger.js';
@@ -23,6 +24,13 @@ import type { ThreadRow } from '../../../src/core/database/repositories/thread-r
 import type { MessageRow } from '../../../src/core/database/repositories/message-repository.js';
 import type { QueueItem } from '../../../src/queue/queue-types.js';
 import { QueueItemStatus } from '../../../src/queue/queue-types.js';
+import { QueueRepository } from '../../../src/core/database/repositories/queue-repository.js';
+import { LifecycleEventRepository } from '../../../src/core/database/repositories/lifecycle-event-repository.js';
+import { LifecycleEventBus } from '../../../src/lifecycle/lifecycle-event-bus.js';
+import { LifecycleRuntime } from '../../../src/lifecycle/lifecycle-runtime.js';
+import { LifecycleInterceptorEngine } from '../../../src/lifecycle/interceptors/interceptor-engine.js';
+import { QueueManager } from '../../../src/queue/queue-manager.js';
+import { createTestDb, uuid } from '../core/database/repositories/helpers.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -108,6 +116,7 @@ function makeQueueItem(overrides: Partial<QueueItem> = {}): QueueItem {
 function makeMocks() {
   const messageRepo = {
     insert: vi.fn(),
+    insertIfAbsent: vi.fn(),
     findById: vi.fn(),
     findByThread: vi.fn(),
     existsByIdempotencyKey: vi.fn(),
@@ -132,6 +141,7 @@ function makeMocks() {
 
   const queueManager = {
     enqueue: vi.fn(),
+    enqueueInLifecycleTransaction: vi.fn(),
     startProcessing: vi.fn(),
     stopProcessing: vi.fn(),
     stats: vi.fn(),
@@ -183,8 +193,12 @@ describe('MessagePipeline', () => {
       vi.mocked(mocks.threadRepo.findByExternalId).mockReturnValue(ok(makeThreadRow()));
       vi.mocked(mocks.messageRepo.existsByIdempotencyKey).mockReturnValue(false);
       vi.mocked(mocks.messageRepo.insert).mockReturnValue(ok(makeMessageRow()));
+      vi.mocked(mocks.messageRepo.insertIfAbsent).mockReturnValue(
+        ok({ message: makeMessageRow(), inserted: true }),
+      );
       vi.mocked(mocks.router.resolvePersona).mockReturnValue(ok('persona-uuid-1'));
       vi.mocked(mocks.queueManager.enqueue).mockReturnValue(ok(makeQueueItem()));
+      vi.mocked(mocks.queueManager.enqueueInLifecycleTransaction).mockReturnValue(ok(makeQueueItem()));
     });
 
     it('returns Ok("enqueued") on a successful end-to-end run', async () => {
@@ -237,6 +251,162 @@ describe('MessagePipeline', () => {
       expect(stats.errors).toBe(0);
       expect(stats.duplicates).toBe(0);
       expect(stats.noPersona).toBe(0);
+    });
+  });
+
+  describe('enabled lifecycle inbound boundary', () => {
+    beforeEach(() => {
+      vi.mocked(mocks.channelRepo.findByName).mockReturnValue(ok(makeChannelRow()));
+      vi.mocked(mocks.threadRepo.findByExternalId).mockReturnValue(ok(makeThreadRow()));
+      vi.mocked(mocks.messageRepo.existsByIdempotencyKey).mockReturnValue(false);
+      vi.mocked(mocks.messageRepo.insert).mockReturnValue(ok(makeMessageRow()));
+      vi.mocked(mocks.messageRepo.insertIfAbsent).mockReturnValue(
+        ok({ message: makeMessageRow(), inserted: true }),
+      );
+      vi.mocked(mocks.router.resolvePersona).mockReturnValue(ok('persona-uuid-1'));
+      vi.mocked(mocks.queueManager.enqueue).mockReturnValue(ok(makeQueueItem()));
+      vi.mocked(mocks.queueManager.enqueueInLifecycleTransaction).mockReturnValue(ok(makeQueueItem()));
+    });
+
+    it('transforms before persistence and publishes bounded persisted/routed events', () => {
+      const runtime = {
+        transaction: vi.fn((callback) => callback({})),
+        intercept: vi.fn(() =>
+          ok({
+            outcome: 'allow' as const,
+            signals: [],
+            input: {
+              hook: 'message.before_persist' as const,
+              input: { content: 'redacted' },
+            },
+          }),
+        ),
+        publish: vi.fn(() => ok({})),
+      };
+      pipeline = new MessagePipeline(
+        mocks.messageRepo,
+        mocks.threadRepo,
+        mocks.channelRepo,
+        mocks.queueManager,
+        mocks.router,
+        mocks.auditLogger,
+        silentLogger(),
+        runtime as any,
+        () => ok('assistant'),
+      );
+
+      const result = pipeline.handleInboundEvent(makeEvent({ content: 'secret source text' }));
+
+      expect(result._unsafeUnwrap()).toBe('enqueued');
+      expect(mocks.messageRepo.insertIfAbsent).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'redacted' }),
+      );
+      expect(mocks.queueManager.enqueueInLifecycleTransaction).toHaveBeenCalledWith(
+        expect.any(String),
+        'message',
+        expect.objectContaining({ content: 'redacted' }),
+        { persona: 'assistant', itemType: 'message' },
+        expect.anything(),
+        expect.any(String),
+      );
+      expect(runtime.publish).toHaveBeenCalledTimes(2);
+      for (const [input] of runtime.publish.mock.calls) {
+        expect(input.event.payload).not.toHaveProperty('content');
+      }
+      expect(runtime.publish.mock.calls[1]?.[0].event.payload.references).toContainEqual({
+        type: 'persona',
+        id: 'persona-uuid-1',
+      });
+    });
+
+    it('does not persist or enqueue a message denied before persistence', () => {
+      const runtime = {
+        transaction: vi.fn((callback) => callback({})),
+        intercept: vi.fn(() =>
+          ok({
+            outcome: 'deny' as const,
+            reason: 'native_policy',
+            signals: [],
+            input: { hook: 'message.before_persist' as const, input: { content: 'ignored' } },
+          }),
+        ),
+        publish: vi.fn(() => ok({})),
+      };
+      pipeline = new MessagePipeline(
+        mocks.messageRepo,
+        mocks.threadRepo,
+        mocks.channelRepo,
+        mocks.queueManager,
+        mocks.router,
+        mocks.auditLogger,
+        silentLogger(),
+        runtime as any,
+        () => ok('assistant'),
+      );
+
+      const result = pipeline.handleInboundEvent(makeEvent());
+
+      expect(result._unsafeUnwrap()).toBe('denied');
+      expect(mocks.messageRepo.insert).not.toHaveBeenCalled();
+      expect(mocks.queueManager.enqueue).not.toHaveBeenCalled();
+      expect(runtime.publish).not.toHaveBeenCalled();
+    });
+
+    it.each([1, 2, 3])('rolls back stage %i and recovers idempotently on retry', (failureAt) => {
+      const db: Database.Database = createTestDb();
+      const channels = new ChannelRepository(db);
+      const threads = new ThreadRepository(db);
+      const messages = new MessageRepository(db);
+      const queue = new QueueRepository(db);
+      const channelId = uuid();
+      const threadId = uuid();
+      const personaId = uuid();
+      let injectFailure = true;
+      channels.insert({
+        id: channelId,
+        type: 'terminal',
+        name: 'test-bot',
+        config: '{}',
+        credentials_ref: null,
+        enabled: 1,
+      });
+      threads.insert({ id: threadId, channel_id: channelId, external_id: 'ext-thread-001', metadata: '{}' });
+      let publications = 0;
+      const runtime = new LifecycleRuntime(
+        new LifecycleEventBus(new LifecycleEventRepository(db), {
+          resolveEventHandlers: () => {
+            publications += 1;
+            if (injectFailure && publications === failureAt) throw new Error('injected publication failure');
+            return [];
+          },
+        }),
+        new LifecycleInterceptorEngine({ resolveHandlers: () => [], implementations: {} }),
+        {} as any,
+      );
+      const pipelineUnderTest = new MessagePipeline(
+        messages,
+        threads,
+        channels,
+        new QueueManager(queue, threads, { maxAttempts: 3, backoffBaseMs: 10, backoffMaxMs: 100, concurrencyLimit: 1 }, silentLogger(), runtime),
+        { resolvePersona: () => ok(personaId) } as unknown as ChannelRouter,
+        mocks.auditLogger,
+        silentLogger(),
+        runtime,
+        () => ok('assistant'),
+      );
+
+      expect(pipelineUnderTest.handleInboundEvent(makeEvent()).isErr()).toBe(true);
+      expect((db.prepare('SELECT COUNT(*) AS count FROM messages').get() as { count: number }).count).toBe(0);
+      expect((db.prepare('SELECT COUNT(*) AS count FROM queue_items').get() as { count: number }).count).toBe(0);
+      expect((db.prepare('SELECT COUNT(*) AS count FROM lifecycle_events').get() as { count: number }).count).toBe(0);
+
+      publications = 0;
+      injectFailure = false;
+      expect(pipelineUnderTest.handleInboundEvent(makeEvent())._unsafeUnwrap()).toBe('enqueued');
+      expect((db.prepare('SELECT COUNT(*) AS count FROM messages').get() as { count: number }).count).toBe(1);
+      expect((db.prepare('SELECT COUNT(*) AS count FROM queue_items').get() as { count: number }).count).toBe(1);
+      expect((db.prepare('SELECT COUNT(*) AS count FROM lifecycle_events').get() as { count: number }).count).toBe(3);
+      db.close();
     });
   });
 

--- a/tests/unit/queue/queue-manager.test.ts
+++ b/tests/unit/queue/queue-manager.test.ts
@@ -3,8 +3,14 @@ import Database from 'better-sqlite3';
 import { ok, err } from 'neverthrow';
 import { QueueRepository } from '../../../src/core/database/repositories/queue-repository.js';
 import { ThreadRepository } from '../../../src/core/database/repositories/thread-repository.js';
+import { MessageRepository } from '../../../src/core/database/repositories/message-repository.js';
 import { QueueManager, type QueueConfig } from '../../../src/queue/queue-manager.js';
 import { QueueItemStatus, type QueueItem } from '../../../src/queue/queue-types.js';
+import { LifecycleEventRepository } from '../../../src/core/database/repositories/lifecycle-event-repository.js';
+import { LifecycleEventBus } from '../../../src/lifecycle/lifecycle-event-bus.js';
+import { LifecycleRuntime } from '../../../src/lifecycle/lifecycle-runtime.js';
+import { LifecycleInterceptorEngine } from '../../../src/lifecycle/interceptors/interceptor-engine.js';
+import { TransactionContext } from '../../../src/lifecycle/transaction-context.js';
 import { createTestDb, createTestLogger, seedThread, uuid } from './helpers.js';
 
 const DEFAULT_CONFIG: QueueConfig = {
@@ -84,6 +90,232 @@ describe('QueueManager', () => {
       }
       expect(ids.size).toBe(10);
     });
+
+    it('atomically publishes a bounded lifecycle event for a scoped enqueue', () => {
+      const lifecycleRuntime = {
+        transaction: vi.fn((callback) => callback({})),
+        publish: vi.fn(() => ok({})),
+      };
+      const lifecycleManager = new QueueManager(
+        queueRepo,
+        threadRepo,
+        DEFAULT_CONFIG,
+        createTestLogger(),
+        lifecycleRuntime as any,
+      );
+
+      const result = lifecycleManager.enqueue(
+        threadId,
+        'message',
+        {
+          content: 'must not enter lifecycle payloads',
+        },
+        undefined,
+        { persona: 'assistant', itemType: 'message' },
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(lifecycleRuntime.transaction).toHaveBeenCalledOnce();
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: 'queue.item.enqueued.v1',
+            payload: expect.objectContaining({
+              references: expect.arrayContaining([expect.objectContaining({ type: 'queue_item' })]),
+              metadata: { itemType: 'message' },
+            }),
+          }),
+          persona: 'assistant',
+          itemOrigin: 'queue',
+        }),
+        expect.anything(),
+      );
+      expect(lifecycleRuntime.publish.mock.calls[0]?.[0].event.payload).not.toHaveProperty(
+        'content',
+      );
+      const stored = queueRepo.findById(result._unsafeUnwrap().id)._unsafeUnwrap();
+      expect(stored?.payload).toBe(
+        JSON.stringify({ content: 'must not enter lifecycle payloads' }),
+      );
+      expect(stored?.lifecycle_persona).toBe('assistant');
+      expect(stored?.lifecycle_item_type).toBe('message');
+    });
+
+    it('uses the message id as one stable lifecycle correlation chain', () => {
+      const lifecycleRuntime = {
+        transaction: vi.fn((callback) => callback({})),
+        publish: vi.fn(() => ok({})),
+      };
+      const lifecycleManager = new QueueManager(
+        queueRepo,
+        threadRepo,
+        DEFAULT_CONFIG,
+        createTestLogger(),
+        lifecycleRuntime as any,
+      );
+      const messageId = uuid();
+      expect(
+        new MessageRepository(db)
+          .insert({
+            id: messageId,
+            thread_id: threadId,
+            direction: 'inbound',
+            content: '{}',
+            idempotency_key: uuid(),
+            provider_id: null,
+            run_id: null,
+          })
+          .isOk(),
+      ).toBe(true);
+
+      expect(
+        lifecycleManager
+          .enqueue(threadId, 'message', {}, messageId, {
+            persona: 'assistant',
+            itemType: 'message',
+          })
+          .isOk(),
+      ).toBe(true);
+
+      expect(lifecycleRuntime.publish.mock.calls[0]?.[0].event.context.correlationId).toBe(
+        messageId,
+      );
+    });
+
+    it('uses the queue item id as the stable schedule correlation chain', () => {
+      const lifecycleRuntime = {
+        transaction: vi.fn((callback) => callback({})),
+        publish: vi.fn(() => ok({})),
+      };
+      const lifecycleManager = new QueueManager(
+        queueRepo,
+        threadRepo,
+        DEFAULT_CONFIG,
+        createTestLogger(),
+        lifecycleRuntime as any,
+      );
+
+      expect(
+        lifecycleManager
+          .enqueue(threadId, 'schedule', {}, undefined, {
+            persona: 'assistant',
+            itemType: 'schedule',
+          })
+          .isOk(),
+      ).toBe(true);
+
+      const event = lifecycleRuntime.publish.mock.calls[0]?.[0].event;
+      expect(event.context.correlationId).toBe(event.context.aggregate.id);
+    });
+
+    it('uses the unchanged legacy enqueue path without a lifecycle runtime', () => {
+      const result = manager.enqueue(threadId, 'message', { personaName: 'assistant' });
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().status).toBe(QueueItemStatus.Pending);
+    });
+
+    it('discards trusted producer lifecycle scope when lifecycle is disabled', () => {
+      const result = manager.enqueue(threadId, 'message', { content: 'legacy work' }, undefined, {
+        persona: 'assistant',
+        itemType: 'message',
+      });
+
+      expect(result.isOk()).toBe(true);
+      const stored = queueRepo.findById(result._unsafeUnwrap().id)._unsafeUnwrap();
+      expect(stored?.lifecycle_persona).toBeNull();
+      expect(stored?.lifecycle_item_type).toBeNull();
+    });
+
+    it('rejects a new lifecycle-enabled message enqueue without trusted scope', () => {
+      const lifecycleRuntime = {
+        transaction: vi.fn(),
+        publish: vi.fn(),
+      };
+      const lifecycleManager = new QueueManager(
+        queueRepo,
+        threadRepo,
+        DEFAULT_CONFIG,
+        createTestLogger(),
+        lifecycleRuntime as any,
+      );
+
+      const result = lifecycleManager.enqueue(threadId, 'message', { content: 'ordinary work' });
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().message).toContain('require manager-owned lifecycle scope');
+      expect(lifecycleRuntime.transaction).not.toHaveBeenCalled();
+      expect(lifecycleRuntime.publish).not.toHaveBeenCalled();
+      expect(
+        (db.prepare('SELECT COUNT(*) AS count FROM queue_items').get() as { count: number }).count,
+      ).toBe(0);
+    });
+
+    it('keeps lifecycle-enabled collaboration work on the compatibility path without scope', () => {
+      const lifecycleRuntime = {
+        transaction: vi.fn(),
+        publish: vi.fn(),
+      };
+      const lifecycleManager = new QueueManager(
+        queueRepo,
+        threadRepo,
+        DEFAULT_CONFIG,
+        createTestLogger(),
+        lifecycleRuntime as any,
+      );
+
+      expect(lifecycleManager.enqueue(threadId, 'collaboration', { kind: 'notice' }).isOk()).toBe(
+        true,
+      );
+      expect(lifecycleRuntime.transaction).not.toHaveBeenCalled();
+      expect(lifecycleRuntime.publish).not.toHaveBeenCalled();
+    });
+
+    it('rejects forged and cross-runtime transaction contexts before queue mutation', () => {
+      const createRuntime = () =>
+        new LifecycleRuntime(
+          new LifecycleEventBus(new LifecycleEventRepository(db), {
+            resolveEventHandlers: () => [],
+          }),
+          new LifecycleInterceptorEngine({ resolveHandlers: () => [], implementations: {} }),
+          {} as any,
+        );
+      const owner = createRuntime();
+      const other = createRuntime();
+      const lifecycleManager = new QueueManager(
+        queueRepo,
+        threadRepo,
+        DEFAULT_CONFIG,
+        createTestLogger(),
+        owner,
+      );
+      const scope = { persona: 'assistant', itemType: 'message' as const };
+      const before = db.prepare('SELECT COUNT(*) AS count FROM queue_items').get() as {
+        count: number;
+      };
+
+      expect(
+        lifecycleManager
+          .enqueueInLifecycleTransaction(threadId, 'message', {}, scope, new TransactionContext())
+          .isErr(),
+      ).toBe(true);
+      other.transaction((transaction) => {
+        const result = lifecycleManager.enqueueInLifecycleTransaction(
+          threadId,
+          'message',
+          {},
+          scope,
+          transaction,
+        );
+        expect(result.isErr()).toBe(true);
+        return ok(undefined);
+      });
+
+      const after = db.prepare('SELECT COUNT(*) AS count FROM queue_items').get() as {
+        count: number;
+      };
+      expect(after.count).toBe(before.count);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -120,6 +352,31 @@ describe('QueueManager', () => {
   // -------------------------------------------------------------------------
 
   describe('startProcessing / stopProcessing', () => {
+    it('returns a bounded timeout and aborts a non-settling handler without a later repository transition', async () => {
+      vi.useFakeTimers();
+      const item = manager.enqueue(threadId, 'message', {})._unsafeUnwrap();
+      let resolveHandler!: (value: ReturnType<typeof ok>) => void;
+      const pending = new Promise<ReturnType<typeof ok>>((resolve) => {
+        resolveHandler = resolve;
+      });
+      let signal: AbortSignal | undefined;
+      manager.startProcessing(async (_item, handlerSignal) => {
+        signal = handlerSignal;
+        return pending;
+      });
+      await vi.advanceTimersByTimeAsync(500);
+
+      const stopping = manager.stopProcessing(10);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(await stopping).toEqual({ status: 'timed_out' });
+      expect(signal?.aborted).toBe(true);
+
+      resolveHandler(ok(undefined));
+      await vi.runAllTimersAsync();
+      expect(queueRepo.findById(item.id)._unsafeUnwrap()?.status).toBe('claimed');
+      vi.useRealTimers();
+    });
+
     it('processes an enqueued item within the poll interval', async () => {
       manager.enqueue(threadId, 'message', { task: 'do-work' });
       const processed: QueueItem[] = [];

--- a/tests/unit/queue/queue-processor.test.ts
+++ b/tests/unit/queue/queue-processor.test.ts
@@ -3,6 +3,10 @@ import Database from 'better-sqlite3';
 import { ok, err } from 'neverthrow';
 import { QueueRepository } from '../../../src/core/database/repositories/queue-repository.js';
 import { DeadLetterHandler } from '../../../src/queue/dead-letter.js';
+import { LifecycleEventRepository } from '../../../src/core/database/repositories/lifecycle-event-repository.js';
+import { LifecycleEventBus } from '../../../src/lifecycle/lifecycle-event-bus.js';
+import { LifecycleRuntime } from '../../../src/lifecycle/lifecycle-runtime.js';
+import { LifecycleInterceptorEngine } from '../../../src/lifecycle/interceptors/interceptor-engine.js';
 import { QueueProcessor } from '../../../src/queue/queue-processor.js';
 import { calculateBackoff } from '../../../src/queue/retry-strategy.js';
 import { QueueItemStatus, type QueueItem } from '../../../src/queue/queue-types.js';
@@ -226,6 +230,65 @@ describe('QueueProcessor', () => {
       };
       expect(row.status).toBe('completed');
     });
+
+    it('publishes a completed transition only when lifecycle is enabled', () => {
+      const lifecycleRuntime = {
+        transaction: vi.fn((callback) => callback({})),
+        publish: vi.fn(() => ok({})),
+      };
+      const logger = createTestLogger();
+      const lifecycleProcessor = new QueueProcessor(
+        repo,
+        calculateBackoff,
+        new DeadLetterHandler(repo, logger),
+        logger,
+        1000,
+        60_000,
+        lifecycleRuntime as any,
+      );
+      const itemId = enqueueItem(repo, threadId, {
+        lifecycle_persona: 'assistant',
+        lifecycle_item_type: 'message',
+      });
+      repo.claimNext(threadId);
+
+      expect(lifecycleProcessor.complete(itemId).isOk()).toBe(true);
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'queue.item.completed.v1' }),
+          persona: 'assistant',
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('publishes one authoritative terminal event for repeated or stale completion calls', () => {
+      const runtime = new LifecycleRuntime(
+        new LifecycleEventBus(new LifecycleEventRepository(db), { resolveEventHandlers: () => [] }),
+        new LifecycleInterceptorEngine({ resolveHandlers: () => [], implementations: {} }),
+        {} as any,
+      );
+      const logger = createTestLogger();
+      const lifecycleProcessor = new QueueProcessor(
+        repo,
+        calculateBackoff,
+        new DeadLetterHandler(repo, logger),
+        logger,
+        1000,
+        60_000,
+        runtime,
+      );
+      const itemId = enqueueItem(repo, threadId, {
+        lifecycle_persona: 'assistant',
+        lifecycle_item_type: 'message',
+      });
+      repo.claimNext(threadId);
+
+      expect(lifecycleProcessor.complete(itemId).isOk()).toBe(true);
+      expect(lifecycleProcessor.complete(itemId).isOk()).toBe(true);
+      const events = db.prepare('SELECT type FROM lifecycle_events WHERE aggregate_id = ?').all(itemId) as Array<{ type: string }>;
+      expect(events).toEqual([{ type: 'queue.item.completed.v1' }]);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -327,6 +390,145 @@ describe('QueueProcessor', () => {
         status: string;
       };
       expect(row.status).toBe('dead_letter');
+    });
+
+    it('publishes retry and dead-letter transitions with the same scoped runtime', () => {
+      const lifecycleRuntime = {
+        transaction: vi.fn((callback) => callback({})),
+        publish: vi.fn(() => ok({})),
+      };
+      const logger = createTestLogger();
+      const lifecycleProcessor = new QueueProcessor(
+        repo,
+        calculateBackoff,
+        new DeadLetterHandler(repo, logger),
+        logger,
+        1000,
+        60_000,
+        lifecycleRuntime as any,
+      );
+      const retryId = enqueueItem(repo, threadId, {
+        max_attempts: 2,
+        lifecycle_persona: 'assistant',
+        lifecycle_item_type: 'message',
+      });
+      repo.claimNext(threadId);
+      expect(lifecycleProcessor.fail(retryId, 'retry').isOk()).toBe(true);
+
+      const deadLetterId = enqueueItem(repo, threadId, {
+        max_attempts: 1,
+        lifecycle_persona: 'assistant',
+        lifecycle_item_type: 'message',
+      });
+      repo.claimNext(threadId);
+      expect(lifecycleProcessor.fail(deadLetterId, 'terminal').isOk()).toBe(true);
+
+      expect(lifecycleRuntime.publish).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'queue.item.failed.v1' }),
+        }),
+        expect.anything(),
+      );
+      expect(lifecycleRuntime.publish).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'queue.item.dead_lettered.v1' }),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('preserves queue retry semantics without publishing when a legacy item has no lifecycle scope', () => {
+      const lifecycleRuntime = { transaction: vi.fn(), publish: vi.fn() };
+      const logger = createTestLogger();
+      const lifecycleProcessor = new QueueProcessor(
+        repo,
+        calculateBackoff,
+        new DeadLetterHandler(repo, logger),
+        logger,
+        1000,
+        60_000,
+        lifecycleRuntime as any,
+      );
+      const itemId = enqueueItem(repo, threadId, { max_attempts: 2 });
+      repo.claimNext(threadId);
+
+      expect(lifecycleProcessor.fail(itemId, 'legacy retry').isOk()).toBe(true);
+      expect(lifecycleRuntime.publish).not.toHaveBeenCalled();
+      expect(repo.findById(itemId)._unsafeUnwrap()?.status).toBe('failed');
+    });
+
+    it('does not trust a forged lifecycle object in ordinary queue payloads', () => {
+      const lifecycleRuntime = { transaction: vi.fn(), publish: vi.fn() };
+      const logger = createTestLogger();
+      const lifecycleProcessor = new QueueProcessor(
+        repo,
+        calculateBackoff,
+        new DeadLetterHandler(repo, logger),
+        logger,
+        1000,
+        60_000,
+        lifecycleRuntime as any,
+      );
+      const itemId = enqueueItem(repo, threadId, {
+        payload: JSON.stringify({ __lifecycle: { persona: 'forged', itemType: 'message' } }),
+      });
+      repo.claimNext(threadId);
+
+      expect(lifecycleProcessor.complete(itemId).isOk()).toBe(true);
+      expect(lifecycleRuntime.publish).not.toHaveBeenCalled();
+    });
+
+    it('does not publish a mismatched manager-owned scope', () => {
+      const lifecycleRuntime = { transaction: vi.fn(), publish: vi.fn() };
+      const logger = createTestLogger();
+      const lifecycleProcessor = new QueueProcessor(
+        repo,
+        calculateBackoff,
+        new DeadLetterHandler(repo, logger),
+        logger,
+        1000,
+        60_000,
+        lifecycleRuntime as any,
+      );
+      const itemId = enqueueItem(repo, threadId, {
+        lifecycle_persona: 'assistant',
+        lifecycle_item_type: 'schedule',
+      });
+      repo.claimNext(threadId);
+
+      expect(lifecycleProcessor.complete(itemId).isOk()).toBe(true);
+      expect(lifecycleRuntime.publish).not.toHaveBeenCalled();
+    });
+
+    it('publishes no duplicate failure event for a stale or conflicting transition', () => {
+      const runtime = new LifecycleRuntime(
+        new LifecycleEventBus(new LifecycleEventRepository(db), { resolveEventHandlers: () => [] }),
+        new LifecycleInterceptorEngine({ resolveHandlers: () => [], implementations: {} }),
+        {} as any,
+      );
+      const logger = createTestLogger();
+      const lifecycleProcessor = new QueueProcessor(
+        repo,
+        calculateBackoff,
+        new DeadLetterHandler(repo, logger),
+        logger,
+        1000,
+        60_000,
+        runtime,
+      );
+      const itemId = enqueueItem(repo, threadId, {
+        max_attempts: 2,
+        lifecycle_persona: 'assistant',
+        lifecycle_item_type: 'message',
+      });
+      repo.claimNext(threadId);
+
+      expect(lifecycleProcessor.fail(itemId, 'retry').isOk()).toBe(true);
+      expect(lifecycleProcessor.fail(itemId, 'stale retry').isOk()).toBe(true);
+      const events = db.prepare('SELECT type FROM lifecycle_events WHERE aggregate_id = ?').all(itemId) as Array<{ type: string }>;
+      expect(events).toEqual([{ type: 'queue.item.failed.v1' }]);
     });
   });
 

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -16,11 +16,15 @@ import { createTestDb, seedPersona, seedThread, seedDueSchedule, uuid } from './
 // ---------------------------------------------------------------------------
 
 function makeQueueStub(
-  enqueueImpl: (threadId: string, type: string, payload: Record<string, unknown>) => ReturnType<QueueManager['enqueue']> = () =>
-    ok(makeQueueItem()),
+  enqueueImpl: (
+    threadId: string,
+    type: string,
+    payload: Record<string, unknown>,
+  ) => ReturnType<QueueManager['enqueue']> = () => ok(makeQueueItem()),
 ): QueueManager {
   return {
     enqueue: vi.fn(enqueueImpl),
+    enqueueInLifecycleTransaction: vi.fn(() => ok(makeQueueItem())),
     startProcessing: vi.fn(),
     stopProcessing: vi.fn(),
     stats: vi.fn(),
@@ -84,6 +88,7 @@ describe('Scheduler', () => {
     logger = makeLogger();
     personaLoader = {
       resolveTaskPrompt: vi.fn(),
+      getById: vi.fn(() => ok({ config: { name: 'assistant' } })),
     } as unknown as PersonaLoader;
     scheduler = new Scheduler(scheduleRepo, queueStub, personaLoader, FAST_CONFIG, logger);
   });
@@ -134,6 +139,93 @@ describe('Scheduler', () => {
       const callsLater = (queueStub.enqueue as ReturnType<typeof vi.fn>).mock.calls.length;
       expect(callsLater).toBe(callsAfterStop);
     });
+
+    it('joins an in-flight prompt lookup and does not enqueue after draining starts', async () => {
+      let resolvePrompt!: (value: ReturnType<typeof ok>) => void;
+      const prompt = new Promise<ReturnType<typeof ok>>((resolve) => {
+        resolvePrompt = resolve;
+      });
+      seedDueSchedule(db, personaId, threadId, {
+        type: 'one_shot',
+        payload: JSON.stringify({ promptFile: 'slow-prompt' }),
+      });
+      vi.mocked(personaLoader.resolveTaskPrompt).mockReturnValue(prompt as any);
+
+      scheduler.start();
+      await vi.waitFor(() => expect(personaLoader.resolveTaskPrompt).toHaveBeenCalledOnce());
+      const stopping = scheduler.stop();
+      expect(queueStub.enqueue).not.toHaveBeenCalled();
+
+      resolvePrompt(ok('late prompt'));
+      await stopping;
+      expect(queueStub.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('does not let a stale prompt lookup enqueue or mutate state after a direct restart', async () => {
+      vi.useFakeTimers();
+      let resolveOldPrompt!: (value: ReturnType<typeof ok>) => void;
+      let resolveNewPrompt!: (value: ReturnType<typeof ok>) => void;
+      const oldPrompt = new Promise<ReturnType<typeof ok>>((resolve) => {
+        resolveOldPrompt = resolve;
+      });
+      const newPrompt = new Promise<ReturnType<typeof ok>>((resolve) => {
+        resolveNewPrompt = resolve;
+      });
+      const scheduleId = seedDueSchedule(db, personaId, threadId, {
+        type: 'one_shot',
+        payload: JSON.stringify({ promptFile: 'slow-prompt' }),
+      });
+      vi.mocked(personaLoader.resolveTaskPrompt)
+        .mockReturnValueOnce(oldPrompt as any)
+        .mockReturnValueOnce(newPrompt as any);
+
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.waitFor(() => expect(personaLoader.resolveTaskPrompt).toHaveBeenCalledOnce());
+      const firstStop = scheduler.stop(10);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(await firstStop).toEqual({ status: 'timed_out' });
+
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.waitFor(() => expect(personaLoader.resolveTaskPrompt).toHaveBeenCalledTimes(2));
+
+      resolveOldPrompt(ok('stale prompt'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(queueStub.enqueue).not.toHaveBeenCalled();
+      expect(scheduleRepo.findById(scheduleId)._unsafeUnwrap()?.enabled).toBe(1);
+
+      const secondStop = scheduler.stop(10);
+      resolveNewPrompt(ok('current prompt'));
+      await vi.advanceTimersByTimeAsync(10);
+      await secondStop;
+      vi.useRealTimers();
+    });
+
+    it('returns a finite timeout for a non-settling prompt lookup without later enqueue', async () => {
+      vi.useFakeTimers();
+      let resolvePrompt!: (value: ReturnType<typeof ok>) => void;
+      const prompt = new Promise<ReturnType<typeof ok>>((resolve) => {
+        resolvePrompt = resolve;
+      });
+      seedDueSchedule(db, personaId, threadId, {
+        type: 'one_shot',
+        payload: JSON.stringify({ promptFile: 'never-settles' }),
+      });
+      vi.mocked(personaLoader.resolveTaskPrompt).mockReturnValue(prompt as any);
+
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(0);
+      const stopping = scheduler.stop(10);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(await stopping).toEqual({ status: 'timed_out' });
+
+      resolvePrompt(ok('late prompt'));
+      await vi.runAllTimersAsync();
+      expect(queueStub.enqueue).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -149,6 +241,93 @@ describe('Scheduler', () => {
       scheduler.stop();
 
       expect(queueStub.enqueue).toHaveBeenCalledOnce();
+    });
+
+    it('publishes schedule provenance atomically with the queue and schedule state', async () => {
+      const lifecycleRuntime = {
+        transaction: vi.fn((callback) => callback({})),
+        publish: vi.fn(() => ok({})),
+      };
+      const lifecycleQueue = makeQueueStub();
+      vi.mocked(lifecycleQueue.enqueueInLifecycleTransaction).mockReturnValue(
+        ok(makeQueueItem({ id: 'queue-item-1', threadId })),
+      );
+      scheduler = new Scheduler(
+        scheduleRepo,
+        lifecycleQueue,
+        personaLoader,
+        FAST_CONFIG,
+        logger,
+        lifecycleRuntime as any,
+      );
+      const scheduleId = seedDueSchedule(db, personaId, threadId, { type: 'one_shot' });
+
+      scheduler.start();
+      await wait(150);
+      scheduler.stop();
+
+      expect(lifecycleRuntime.transaction).toHaveBeenCalledOnce();
+      expect(lifecycleQueue.enqueueInLifecycleTransaction).toHaveBeenCalledWith(
+        threadId,
+        'schedule',
+        expect.objectContaining({ personaId }),
+        { persona: 'assistant', itemType: 'schedule' },
+        expect.anything(),
+      );
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: 'schedule.fired.v1',
+            context: expect.objectContaining({
+              aggregate: { type: 'schedule', id: scheduleId },
+              provenance: expect.objectContaining({ source: 'scheduler' }),
+            }),
+            payload: expect.objectContaining({
+              references: expect.arrayContaining([
+                { type: 'schedule', id: scheduleId },
+                { type: 'queue_item', id: 'queue-item-1' },
+              ]),
+              metadata: { scheduleType: 'one_shot' },
+            }),
+          }),
+          persona: 'assistant',
+          itemOrigin: 'scheduler',
+          scheduleSource: 'oneshot',
+        }),
+        expect.anything(),
+      );
+      expect(scheduleRepo.findById(scheduleId)._unsafeUnwrap()?.enabled).toBe(0);
+    });
+
+    it('does not enqueue or advance a lifecycle schedule when persona scope is unavailable', async () => {
+      const lifecycleRuntime = {
+        transaction: vi.fn(),
+        publish: vi.fn(),
+      };
+      const lifecycleQueue = makeQueueStub();
+      vi.mocked(personaLoader.getById).mockReturnValue(ok(undefined) as any);
+      scheduler = new Scheduler(
+        scheduleRepo,
+        lifecycleQueue,
+        personaLoader,
+        FAST_CONFIG,
+        logger,
+        lifecycleRuntime as any,
+      );
+      const scheduleId = seedDueSchedule(db, personaId, threadId, { type: 'one_shot' });
+
+      scheduler.start();
+      await wait(150);
+      await scheduler.stop();
+
+      expect(lifecycleQueue.enqueue).not.toHaveBeenCalled();
+      expect(lifecycleQueue.enqueueInLifecycleTransaction).not.toHaveBeenCalled();
+      expect(lifecycleRuntime.transaction).not.toHaveBeenCalled();
+      expect(scheduleRepo.findById(scheduleId)._unsafeUnwrap()?.enabled).toBe(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ scheduleId, personaId }),
+        'scheduler: lifecycle persona unavailable; schedule will be retried without enqueue',
+      );
     });
 
     it('disables the schedule after firing', async () => {
@@ -215,7 +394,9 @@ describe('Scheduler', () => {
     });
 
     it('resolves promptFile to content when the schedule fires', async () => {
-      vi.mocked(personaLoader.resolveTaskPrompt).mockResolvedValue(ok('Rendered prompt file contents'));
+      vi.mocked(personaLoader.resolveTaskPrompt).mockResolvedValue(
+        ok('Rendered prompt file contents'),
+      );
       const payload = { label: 'Morning briefing', promptFile: 'morning-briefing' };
       seedDueSchedule(db, personaId, threadId, {
         type: 'one_shot',
@@ -290,12 +471,7 @@ describe('Scheduler', () => {
     it('does NOT promote "file:" followed by content with spaces or special chars', async () => {
       // A few near-miss patterns that must NOT be treated as aliases:
       // file:name with space, file:name@host, file:/absolute/path, etc.
-      const nearMisses = [
-        'file:my name',
-        'file:user@host',
-        'file:/etc/passwd',
-        'file:name?query',
-      ];
+      const nearMisses = ['file:my name', 'file:user@host', 'file:/etc/passwd', 'file:name?query'];
 
       for (const prompt of nearMisses) {
         vi.mocked(personaLoader.resolveTaskPrompt).mockClear();
@@ -418,7 +594,9 @@ describe('Scheduler', () => {
       await wait(150);
       scheduler.stop();
 
-      const row = db.prepare('SELECT next_run_at, last_run_at, enabled FROM schedules WHERE id = ?').get(scheduleId) as {
+      const row = db
+        .prepare('SELECT next_run_at, last_run_at, enabled FROM schedules WHERE id = ?')
+        .get(scheduleId) as {
         next_run_at: number;
         last_run_at: number;
         enabled: number;
@@ -494,7 +672,9 @@ describe('Scheduler', () => {
       await wait(150);
       scheduler.stop();
 
-      const row = db.prepare('SELECT next_run_at, last_run_at, enabled FROM schedules WHERE id = ?').get(scheduleId) as {
+      const row = db
+        .prepare('SELECT next_run_at, last_run_at, enabled FROM schedules WHERE id = ?')
+        .get(scheduleId) as {
         next_run_at: number;
         last_run_at: number;
         enabled: number;
@@ -613,7 +793,10 @@ describe('Scheduler', () => {
     });
 
     it('does not advance schedule state when enqueue fails', async () => {
-      const scheduleId = seedDueSchedule(db, personaId, threadId, { type: 'interval', expression: '10000' });
+      const scheduleId = seedDueSchedule(db, personaId, threadId, {
+        type: 'interval',
+        expression: '10000',
+      });
 
       const errorStub = makeQueueStub(() => err(new QueueError('enqueue failed')));
       scheduler = new Scheduler(scheduleRepo, errorStub, personaLoader, FAST_CONFIG, logger);
@@ -677,7 +860,9 @@ describe('Scheduler', () => {
       scheduler.stop();
 
       expect(queueStub.enqueue).not.toHaveBeenCalled();
-      const row = db.prepare('SELECT next_run_at, last_run_at FROM schedules WHERE id = ?').get(scheduleId) as {
+      const row = db
+        .prepare('SELECT next_run_at, last_run_at FROM schedules WHERE id = ?')
+        .get(scheduleId) as {
         next_run_at: number;
         last_run_at: number | null;
       };

--- a/tests/unit/subagents/background/background-agent-manager.test.ts
+++ b/tests/unit/subagents/background/background-agent-manager.test.ts
@@ -648,7 +648,9 @@ describe('BackgroundAgentManager', () => {
   });
 
   it('marks the task completed and enqueues both direct and agent notifications when the process resolves', async () => {
-    const manager = createManager();
+    const manager = createManager({
+      resolveLifecyclePersonaName: vi.fn().mockReturnValue('assistant'),
+    });
     const taskId = (await manager.spawn(spawnInput))._unsafeUnwrap();
 
     completionResolve?.(
@@ -694,6 +696,40 @@ describe('BackgroundAgentManager', () => {
         personaId: 'persona-1',
         content: expect.stringContaining('Background Task Complete'),
       }),
+      undefined,
+      { persona: 'assistant', itemType: 'message' },
+    );
+  });
+
+  it('does not enqueue an unscoped completion message when lifecycle persona resolution fails', async () => {
+    const logger = makeLogger();
+    const manager = createManager({
+      logger,
+      resolveLifecyclePersonaName: vi.fn().mockReturnValue(undefined),
+    });
+    const taskId = (await manager.spawn(spawnInput))._unsafeUnwrap();
+
+    completionResolve?.(
+      ok({
+        stdout: 'Done!',
+        stderr: '',
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(repository.findById(taskId)._unsafeUnwrap()?.status).toBe('completed');
+    expect(queueManager.enqueue).toHaveBeenCalledTimes(1);
+    expect(queueManager.enqueue).toHaveBeenCalledWith(
+      'thread-1',
+      'collaboration',
+      expect.objectContaining({ taskId }),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId, personaId: 'persona-1' }),
+      'background-agent: lifecycle persona unavailable for completion message',
     );
   });
 


### PR DESCRIPTION
## Summary
- add the durable lifecycle signal outbox and queue scope persistence
- emit transactional message, queue, and schedule lifecycle events with stable provenance
- bootstrap the lifecycle runtime as a single daemon authority and drain it safely on shutdown
- cover repository, pipeline, queue, scheduler, daemon, and background-agent integration paths

## Verification
- 385 focused tests across 12 files (Node v24.15.0)
- `npm run build`
- source-scoped lint and targeted formatting checks
- `git diff --check`
- GPT-5.5/xhigh full refresh review: 0 Critical, 0 High, 0 Medium, 0 Low

Part of #256 / WAVE-004 TASK-007.