### PR TITLE
feat(lifecycle): persist behavior ledger

### DIFF
--- a/src/core/database/migrations/018-behavior-ledger.sql
+++ b/src/core/database/migrations/018-behavior-ledger.sql
@@ -1,0 +1,380 @@
+-- Migration 018: persona-scoped behavior evidence and governed promotion ledger.
+--
+-- This is storage only. Detectors, reducers, prompt writes, reload, and UI are
+-- later tasks. Rows keep bounded provenance and guarded transition history so
+-- future projectors can be idempotent and reversible.
+
+CREATE TABLE behavior_evidence (
+  evidence_id        TEXT PRIMARY KEY CHECK (typeof(evidence_id) = 'text' AND lifecycle_runtime_id_valid(evidence_id)),
+  persona            TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  source_kind        TEXT NOT NULL CHECK (source_kind IN ('message', 'schedule', 'run', 'tool', 'manual')),
+  source_id          TEXT NOT NULL CHECK (typeof(source_id) = 'text' AND lifecycle_runtime_id_valid(source_id)),
+  source_occurred_at TEXT NOT NULL CHECK (typeof(source_occurred_at) = 'text' AND source_occurred_at GLOB '????-??-??T??:??:??.???Z' AND strftime('%Y-%m-%dT%H:%M:%fZ', source_occurred_at) IS source_occurred_at),
+  fingerprint        TEXT NOT NULL CHECK (typeof(fingerprint) = 'text' AND lifecycle_runtime_id_valid(fingerprint)),
+  sentiment          TEXT NOT NULL CHECK (sentiment IN ('positive', 'negative', 'neutral')),
+  confidence         REAL NOT NULL CHECK (typeof(confidence) = 'real' AND confidence >= 0 AND confidence <= 1),
+  summary            TEXT NOT NULL CHECK (typeof(summary) = 'text' AND length(summary) BETWEEN 1 AND 4096 AND instr(summary, char(0)) = 0),
+  metadata           TEXT NOT NULL DEFAULT '{}' CHECK (typeof(metadata) = 'text' AND json_valid(metadata) AND length(metadata) <= 32768),
+  created_at         INTEGER NOT NULL CHECK (typeof(created_at) = 'integer' AND created_at BETWEEN -9007199254740991 AND 9007199254740991),
+  UNIQUE (persona, evidence_id),
+  UNIQUE (persona, fingerprint),
+  UNIQUE (persona, source_kind, source_id, fingerprint)
+);
+
+CREATE INDEX idx_behavior_evidence_persona_created ON behavior_evidence(persona, created_at);
+CREATE INDEX idx_behavior_evidence_persona_source ON behavior_evidence(persona, source_kind, source_id);
+
+CREATE TRIGGER behavior_evidence_reject_replacements
+BEFORE INSERT ON behavior_evidence
+FOR EACH ROW
+WHEN EXISTS (
+  SELECT 1
+  FROM behavior_evidence
+  WHERE evidence_id IS NEW.evidence_id
+     OR (persona IS NEW.persona AND fingerprint IS NEW.fingerprint)
+)
+BEGIN
+  SELECT RAISE(ABORT, 'behavior evidence cannot be replaced');
+END;
+
+CREATE TRIGGER behavior_evidence_reject_updates
+BEFORE UPDATE ON behavior_evidence
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'behavior evidence is immutable');
+END;
+
+CREATE TABLE behavior_candidates (
+  candidate_id       TEXT PRIMARY KEY CHECK (typeof(candidate_id) = 'text' AND lifecycle_runtime_id_valid(candidate_id)),
+  persona            TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  kind               TEXT NOT NULL CHECK (kind IN ('style', 'preference', 'safety', 'tooling', 'context')),
+  status             TEXT NOT NULL CHECK (status IN ('collecting', 'ready', 'proposed', 'rejected', 'expired')),
+  summary            TEXT NOT NULL CHECK (typeof(summary) = 'text' AND length(summary) BETWEEN 1 AND 4096 AND instr(summary, char(0)) = 0),
+  proposed_behavior  TEXT NOT NULL CHECK (typeof(proposed_behavior) = 'text' AND length(proposed_behavior) BETWEEN 1 AND 4096 AND instr(proposed_behavior, char(0)) = 0),
+  confidence         REAL NOT NULL CHECK (typeof(confidence) = 'real' AND confidence >= 0 AND confidence <= 1),
+  created_at         INTEGER NOT NULL CHECK (typeof(created_at) = 'integer' AND created_at BETWEEN -9007199254740991 AND 9007199254740991),
+  updated_at         INTEGER NOT NULL CHECK (typeof(updated_at) = 'integer' AND updated_at BETWEEN -9007199254740991 AND 9007199254740991),
+  expired_at         INTEGER CHECK (expired_at IS NULL OR (typeof(expired_at) = 'integer' AND expired_at BETWEEN -9007199254740991 AND 9007199254740991))
+  , UNIQUE (persona, candidate_id)
+);
+
+CREATE INDEX idx_behavior_candidates_persona_status ON behavior_candidates(persona, status, updated_at);
+
+CREATE TABLE behavior_candidate_evidence (
+  candidate_id TEXT NOT NULL REFERENCES behavior_candidates(candidate_id) ON DELETE CASCADE,
+  persona      TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  evidence_id  TEXT NOT NULL REFERENCES behavior_evidence(evidence_id) ON DELETE CASCADE,
+  created_at   INTEGER NOT NULL CHECK (typeof(created_at) = 'integer' AND created_at BETWEEN -9007199254740991 AND 9007199254740991),
+  PRIMARY KEY (candidate_id, evidence_id),
+  FOREIGN KEY (persona, candidate_id) REFERENCES behavior_candidates(persona, candidate_id) ON DELETE CASCADE,
+  FOREIGN KEY (persona, evidence_id) REFERENCES behavior_evidence(persona, evidence_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_behavior_candidate_evidence_persona ON behavior_candidate_evidence(persona, evidence_id);
+
+CREATE TRIGGER behavior_candidate_evidence_reject_updates
+BEFORE UPDATE ON behavior_candidate_evidence
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'behavior candidate evidence links are immutable');
+END;
+
+CREATE TRIGGER behavior_candidate_evidence_reject_deletes
+BEFORE DELETE ON behavior_candidate_evidence
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'behavior candidate evidence links are append-only');
+END;
+
+CREATE TRIGGER behavior_candidates_reject_replacements
+BEFORE INSERT ON behavior_candidates
+FOR EACH ROW
+WHEN EXISTS (SELECT 1 FROM behavior_candidates WHERE candidate_id IS NEW.candidate_id)
+BEGIN
+  SELECT RAISE(ABORT, 'behavior candidates cannot be replaced');
+END;
+
+CREATE TRIGGER behavior_candidates_guard_initial_insert
+BEFORE INSERT ON behavior_candidates
+FOR EACH ROW
+WHEN NEW.status IS NOT 'collecting'
+   OR NEW.expired_at IS NOT NULL
+   OR NEW.created_at IS NOT NEW.updated_at
+BEGIN
+  SELECT RAISE(ABORT, 'behavior candidates must be inserted collecting');
+END;
+
+CREATE TRIGGER behavior_candidates_guard_transitions
+BEFORE UPDATE ON behavior_candidates
+FOR EACH ROW
+WHEN NOT (
+  NEW.candidate_id IS OLD.candidate_id
+  AND NEW.persona IS OLD.persona
+  AND NEW.kind IS OLD.kind
+  AND NEW.summary IS OLD.summary
+  AND NEW.proposed_behavior IS OLD.proposed_behavior
+  AND NEW.confidence IS OLD.confidence
+  AND NEW.created_at IS OLD.created_at
+  AND NEW.updated_at > OLD.updated_at
+  AND (
+    (OLD.status = 'collecting' AND NEW.status IN ('ready', 'rejected') AND NEW.expired_at IS OLD.expired_at)
+    OR (OLD.status = 'ready' AND NEW.status IN ('proposed', 'rejected') AND NEW.expired_at IS OLD.expired_at)
+    OR (OLD.status = 'proposed' AND NEW.status = 'rejected' AND NEW.expired_at IS OLD.expired_at)
+    OR (OLD.status IN ('collecting', 'ready', 'proposed', 'rejected') AND NEW.status = 'expired' AND NEW.expired_at IS NOT NULL)
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid behavior candidate update');
+END;
+
+CREATE TRIGGER behavior_candidates_guard_ready_evidence
+BEFORE UPDATE OF status ON behavior_candidates
+FOR EACH ROW
+WHEN NEW.status = 'ready'
+  AND (
+    SELECT COUNT(*)
+    FROM (
+      SELECT e.source_kind, e.source_id
+      FROM behavior_candidate_evidence ce
+      JOIN behavior_evidence e
+        ON e.evidence_id = ce.evidence_id
+       AND e.persona = ce.persona
+      WHERE ce.persona = NEW.persona
+        AND ce.candidate_id = NEW.candidate_id
+      GROUP BY e.source_kind, e.source_id
+    )
+  ) < 2
+BEGIN
+  SELECT RAISE(ABORT, 'ready behavior candidates require distinct linked evidence');
+END;
+
+CREATE TABLE behavior_promotions (
+  promotion_id TEXT PRIMARY KEY CHECK (typeof(promotion_id) = 'text' AND lifecycle_runtime_id_valid(promotion_id)),
+  persona      TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  candidate_id TEXT NOT NULL REFERENCES behavior_candidates(candidate_id) ON DELETE CASCADE,
+  status       TEXT NOT NULL CHECK (status IN ('proposed', 'evaluating', 'approved', 'activating', 'active', 'rolled_back', 'reopened', 'rejected', 'expired')),
+  policy       TEXT NOT NULL CHECK (typeof(policy) = 'text' AND json_valid(policy) AND length(policy) <= 32768),
+  evaluation   TEXT NOT NULL CHECK (typeof(evaluation) = 'text' AND json_valid(evaluation) AND length(evaluation) <= 32768),
+  created_at   INTEGER NOT NULL CHECK (typeof(created_at) = 'integer' AND created_at BETWEEN -9007199254740991 AND 9007199254740991),
+  updated_at   INTEGER NOT NULL CHECK (typeof(updated_at) = 'integer' AND updated_at BETWEEN -9007199254740991 AND 9007199254740991),
+  UNIQUE (persona, promotion_id),
+  UNIQUE (persona, candidate_id),
+  FOREIGN KEY (persona, candidate_id) REFERENCES behavior_candidates(persona, candidate_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_behavior_promotions_persona_status ON behavior_promotions(persona, status, updated_at);
+
+CREATE TRIGGER behavior_promotions_reject_replacements
+BEFORE INSERT ON behavior_promotions
+FOR EACH ROW
+WHEN EXISTS (SELECT 1 FROM behavior_promotions WHERE promotion_id IS NEW.promotion_id)
+BEGIN
+  SELECT RAISE(ABORT, 'behavior promotions cannot be replaced');
+END;
+
+CREATE TRIGGER behavior_promotions_guard_initial_insert
+BEFORE INSERT ON behavior_promotions
+FOR EACH ROW
+WHEN NEW.status IS NOT 'proposed'
+  OR NEW.created_at IS NOT NEW.updated_at
+  OR NOT EXISTS (
+    SELECT 1
+    FROM behavior_candidates c
+    WHERE c.persona = NEW.persona
+      AND c.candidate_id = NEW.candidate_id
+      AND c.status = 'ready'
+  )
+  OR (
+    SELECT COUNT(*)
+    FROM (
+      SELECT e.source_kind, e.source_id
+      FROM behavior_candidate_evidence ce
+      JOIN behavior_evidence e
+        ON e.evidence_id = ce.evidence_id
+       AND e.persona = ce.persona
+      WHERE ce.persona = NEW.persona
+        AND ce.candidate_id = NEW.candidate_id
+      GROUP BY e.source_kind, e.source_id
+    )
+  ) < 2
+BEGIN
+  SELECT RAISE(ABORT, 'behavior promotions require a ready candidate with distinct evidence');
+END;
+
+CREATE TRIGGER behavior_promotions_guard_transitions
+BEFORE UPDATE ON behavior_promotions
+FOR EACH ROW
+WHEN NOT (
+  NEW.promotion_id IS OLD.promotion_id
+  AND NEW.persona IS OLD.persona
+  AND NEW.candidate_id IS OLD.candidate_id
+  AND NEW.policy IS OLD.policy
+  AND NEW.evaluation IS OLD.evaluation
+  AND NEW.created_at IS OLD.created_at
+  AND NEW.updated_at > OLD.updated_at
+  AND (
+    (OLD.status = 'proposed' AND NEW.status IN ('evaluating', 'rejected', 'expired'))
+    OR (OLD.status = 'evaluating' AND NEW.status IN ('approved', 'rejected', 'expired'))
+    OR (OLD.status = 'approved' AND NEW.status IN ('activating', 'rejected', 'expired'))
+    OR (
+      OLD.status = 'activating'
+      AND NEW.status = 'active'
+      AND EXISTS (
+        SELECT 1
+        FROM behavior_promotion_activations a
+        WHERE a.persona = NEW.persona
+          AND a.promotion_id = NEW.promotion_id
+          AND a.activated_at IS NEW.updated_at
+      )
+    )
+    OR (OLD.status = 'activating' AND NEW.status IN ('rejected', 'expired'))
+    OR (
+      OLD.status = 'active'
+      AND NEW.status = 'rolled_back'
+      AND EXISTS (
+        SELECT 1
+        FROM behavior_promotion_rollbacks r
+        WHERE r.persona = NEW.persona
+          AND r.promotion_id = NEW.promotion_id
+          AND r.rolled_back_at IS NEW.updated_at
+      )
+    )
+    OR (OLD.status = 'rolled_back' AND NEW.status = 'reopened')
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid behavior promotion update');
+END;
+
+CREATE TRIGGER behavior_promotions_guard_candidate_evidence_transitions
+BEFORE UPDATE OF status ON behavior_promotions
+FOR EACH ROW
+WHEN NEW.status IN ('evaluating', 'approved', 'activating', 'active')
+  AND (
+    NOT EXISTS (
+      SELECT 1
+      FROM behavior_candidates c
+      WHERE c.persona = NEW.persona
+        AND c.candidate_id = NEW.candidate_id
+        AND c.status IN ('ready', 'proposed')
+    )
+    OR (
+      SELECT COUNT(*)
+      FROM (
+        SELECT e.source_kind, e.source_id
+        FROM behavior_candidate_evidence ce
+        JOIN behavior_evidence e
+          ON e.evidence_id = ce.evidence_id
+         AND e.persona = ce.persona
+        WHERE ce.persona = NEW.persona
+          AND ce.candidate_id = NEW.candidate_id
+        GROUP BY e.source_kind, e.source_id
+      )
+    ) < 2
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'behavior promotion transitions require candidate evidence');
+END;
+
+CREATE TABLE behavior_promotion_activations (
+  activation_id      TEXT PRIMARY KEY CHECK (typeof(activation_id) = 'text' AND lifecycle_runtime_id_valid(activation_id)),
+  persona            TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  promotion_id       TEXT NOT NULL REFERENCES behavior_promotions(promotion_id) ON DELETE CASCADE,
+  prompt_artifact_id TEXT NOT NULL CHECK (typeof(prompt_artifact_id) = 'text' AND lifecycle_runtime_id_valid(prompt_artifact_id)),
+  reload_id          TEXT NOT NULL CHECK (typeof(reload_id) = 'text' AND lifecycle_runtime_id_valid(reload_id)),
+  activated_at       INTEGER NOT NULL CHECK (typeof(activated_at) = 'integer' AND activated_at BETWEEN -9007199254740991 AND 9007199254740991),
+  UNIQUE (persona, activation_id),
+  UNIQUE (persona, activation_id, promotion_id),
+  UNIQUE (persona, promotion_id, prompt_artifact_id),
+  FOREIGN KEY (persona, promotion_id) REFERENCES behavior_promotions(persona, promotion_id) ON DELETE CASCADE
+);
+
+CREATE TRIGGER behavior_promotion_activations_guard_lineage
+BEFORE INSERT ON behavior_promotion_activations
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM behavior_promotions p
+  JOIN behavior_candidates c
+    ON c.persona = p.persona
+   AND c.candidate_id = p.candidate_id
+  WHERE p.persona = NEW.persona
+    AND p.promotion_id = NEW.promotion_id
+    AND p.status = 'activating'
+    AND c.status IN ('ready', 'proposed')
+    AND (
+      SELECT COUNT(*)
+      FROM (
+        SELECT e.source_kind, e.source_id
+        FROM behavior_candidate_evidence ce
+        JOIN behavior_evidence e
+          ON e.evidence_id = ce.evidence_id
+         AND e.persona = ce.persona
+        WHERE ce.persona = c.persona
+          AND ce.candidate_id = c.candidate_id
+        GROUP BY e.source_kind, e.source_id
+      )
+    ) >= 2
+)
+BEGIN
+  SELECT RAISE(ABORT, 'behavior promotion activations require activating evidenced promotion lineage');
+END;
+
+CREATE TRIGGER behavior_promotion_activations_reject_updates
+BEFORE UPDATE ON behavior_promotion_activations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'behavior promotion activations are immutable');
+END;
+
+CREATE TRIGGER behavior_promotion_activations_reject_deletes
+BEFORE DELETE ON behavior_promotion_activations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'behavior promotion activations are append-only');
+END;
+
+CREATE TABLE behavior_promotion_rollbacks (
+  rollback_id   TEXT PRIMARY KEY CHECK (typeof(rollback_id) = 'text' AND lifecycle_runtime_id_valid(rollback_id)),
+  persona       TEXT NOT NULL CHECK (typeof(persona) = 'text' AND lifecycle_persona_valid(persona)),
+  activation_id TEXT NOT NULL REFERENCES behavior_promotion_activations(activation_id) ON DELETE CASCADE,
+  promotion_id  TEXT NOT NULL REFERENCES behavior_promotions(promotion_id) ON DELETE CASCADE,
+  reason        TEXT NOT NULL CHECK (typeof(reason) = 'text' AND lifecycle_identifier_valid(reason)),
+  rolled_back_at INTEGER NOT NULL CHECK (typeof(rolled_back_at) = 'integer' AND rolled_back_at BETWEEN -9007199254740991 AND 9007199254740991),
+  UNIQUE (activation_id),
+  FOREIGN KEY (persona, promotion_id) REFERENCES behavior_promotions(persona, promotion_id) ON DELETE CASCADE,
+  FOREIGN KEY (persona, activation_id) REFERENCES behavior_promotion_activations(persona, activation_id) ON DELETE CASCADE,
+  FOREIGN KEY (persona, activation_id, promotion_id) REFERENCES behavior_promotion_activations(persona, activation_id, promotion_id) ON DELETE CASCADE
+);
+
+CREATE TRIGGER behavior_promotion_rollbacks_guard_active_lineage
+BEFORE INSERT ON behavior_promotion_rollbacks
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM behavior_promotion_activations a
+  JOIN behavior_promotions p
+    ON p.persona = a.persona
+   AND p.promotion_id = a.promotion_id
+  WHERE a.persona = NEW.persona
+    AND a.activation_id = NEW.activation_id
+    AND a.promotion_id = NEW.promotion_id
+    AND p.status = 'active'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'behavior promotion rollbacks require active activation lineage');
+END;
+
+CREATE TRIGGER behavior_promotion_rollbacks_reject_updates
+BEFORE UPDATE ON behavior_promotion_rollbacks
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'behavior promotion rollbacks are immutable');
+END;
+
+CREATE TRIGGER behavior_promotion_rollbacks_reject_deletes
+BEFORE DELETE ON behavior_promotion_rollbacks
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'behavior promotion rollbacks are append-only');
+END;

--- a/src/core/database/repositories/base-repository.ts
+++ b/src/core/database/repositories/base-repository.ts
@@ -67,7 +67,16 @@ export abstract class BaseRepository {
              COALESCE((SELECT MAX(created_at) FROM lifecycle_events), 0),
              COALESCE((SELECT MAX(created_at) FROM lifecycle_event_deliveries), 0),
              COALESCE((SELECT MAX(updated_at) FROM lifecycle_event_deliveries), 0),
-             COALESCE((SELECT MAX(completed_at) FROM lifecycle_event_deliveries), 0)
+             COALESCE((SELECT MAX(completed_at) FROM lifecycle_event_deliveries), 0),
+             COALESCE((SELECT MAX(created_at) FROM behavior_evidence), 0),
+             COALESCE((SELECT MAX(created_at) FROM behavior_candidates), 0),
+             COALESCE((SELECT MAX(updated_at) FROM behavior_candidates), 0),
+             COALESCE((SELECT MAX(expired_at) FROM behavior_candidates), 0),
+             COALESCE((SELECT MAX(created_at) FROM behavior_candidate_evidence), 0),
+             COALESCE((SELECT MAX(created_at) FROM behavior_promotions), 0),
+             COALESCE((SELECT MAX(updated_at) FROM behavior_promotions), 0),
+             COALESCE((SELECT MAX(activated_at) FROM behavior_promotion_activations), 0),
+             COALESCE((SELECT MAX(rolled_back_at) FROM behavior_promotion_rollbacks), 0)
            ) AS max_ts`,
         )
         .get() as { max_ts: number | null } | undefined;

--- a/src/core/database/repositories/behavior-signal-repository.ts
+++ b/src/core/database/repositories/behavior-signal-repository.ts
@@ -1,0 +1,920 @@
+/** Persona-scoped behavior evidence, candidate, promotion, activation, and rollback ledger. */
+
+import { types } from 'node:util';
+import type Database from 'better-sqlite3';
+import { err, ok, type Result } from 'neverthrow';
+
+import { DbError } from '../../errors/index.js';
+import {
+  BehaviorCandidateKindSchema,
+  BehaviorCandidateStatusSchema,
+  BehaviorConfidenceSchema,
+  BehaviorEvidenceSentimentSchema,
+  BehaviorEvidenceSourceKindSchema,
+  BehaviorLineageReasonSchema,
+  BehaviorPromotionStatusSchema,
+  BehaviorSummarySchema,
+  BehaviorTimestampSchema,
+  isBehaviorIdentifier,
+  isBehaviorPersona,
+  isBehaviorRuntimeId,
+  type BehaviorCandidateKind,
+  type BehaviorCandidateStatus,
+  type BehaviorEvidenceSentiment,
+  type BehaviorEvidenceSourceKind,
+  type BehaviorPromotionStatus,
+} from '../../../lifecycle/behavior/types.js';
+import {
+  isBoundedWellFormedUtf8,
+  snapshotBoundedPlainDataRecord,
+} from './lifecycle-persistence-validation.js';
+import { BaseRepository } from './base-repository.js';
+
+type JsonScalar = string | number | boolean | null;
+export type BehaviorMetadata = Record<string, JsonScalar>;
+
+export interface BehaviorEvidenceInput {
+  readonly evidenceId: string;
+  readonly persona: string;
+  readonly sourceKind: BehaviorEvidenceSourceKind;
+  readonly sourceId: string;
+  readonly sourceOccurredAt: string;
+  readonly fingerprint: string;
+  readonly sentiment: BehaviorEvidenceSentiment;
+  readonly confidence: number;
+  readonly summary: string;
+  readonly metadata?: BehaviorMetadata;
+}
+
+export interface BehaviorEvidenceRow {
+  evidence_id: string;
+  persona: string;
+  source_kind: BehaviorEvidenceSourceKind;
+  source_id: string;
+  source_occurred_at: string;
+  fingerprint: string;
+  sentiment: BehaviorEvidenceSentiment;
+  confidence: number;
+  summary: string;
+  metadata: string;
+  created_at: number;
+}
+
+export interface BehaviorCandidateInput {
+  readonly candidateId: string;
+  readonly persona: string;
+  readonly kind: BehaviorCandidateKind;
+  readonly status?: Extract<BehaviorCandidateStatus, 'collecting' | 'ready'>;
+  readonly summary: string;
+  readonly proposedBehavior: string;
+  readonly confidence: number;
+  readonly createdFromEvidenceIds?: readonly string[];
+}
+
+export interface BehaviorCandidateRow {
+  candidate_id: string;
+  persona: string;
+  kind: BehaviorCandidateKind;
+  status: BehaviorCandidateStatus;
+  summary: string;
+  proposed_behavior: string;
+  confidence: number;
+  created_at: number;
+  updated_at: number;
+  expired_at: number | null;
+}
+
+export interface BehaviorPromotionInput {
+  readonly promotionId: string;
+  readonly persona: string;
+  readonly candidateId: string;
+  readonly status?: Extract<BehaviorPromotionStatus, 'proposed'>;
+  readonly policy?: BehaviorMetadata;
+  readonly evaluation?: BehaviorMetadata;
+}
+
+export interface BehaviorPromotionRow {
+  promotion_id: string;
+  persona: string;
+  candidate_id: string;
+  status: BehaviorPromotionStatus;
+  policy: string;
+  evaluation: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface BehaviorPromotionActivationInput {
+  readonly persona: string;
+  readonly promotionId: string;
+  readonly activationId: string;
+  readonly promptArtifactId: string;
+  readonly reloadId: string;
+}
+
+export interface BehaviorPromotionRollbackInput {
+  readonly persona: string;
+  readonly activationId: string;
+  readonly rollbackId: string;
+  readonly reason: string;
+}
+
+function toDbError(operation: string, cause: unknown): DbError {
+  void cause;
+  return new DbError(`Failed to ${operation}`);
+}
+
+function readRecord(
+  value: unknown,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): Record<string, unknown> | null {
+  const allowed = new Set([...required, ...optional]);
+  const record = snapshotBoundedPlainDataRecord(value, allowed.size);
+  if (!record) return null;
+  const keys = Object.keys(record);
+  if (keys.some((key) => !allowed.has(key))) return null;
+  for (const key of required) {
+    if (!Object.hasOwn(record, key)) return null;
+  }
+  return record;
+}
+
+function readStringArray(value: unknown, maxLength: number): string[] | null {
+  if (!Array.isArray(value) || types.isProxy(value)) return null;
+  try {
+    if (Reflect.getPrototypeOf(value) !== Array.prototype) return null;
+    const length = Object.getOwnPropertyDescriptor(value, 'length');
+    if (!length || !('value' in length) || !Number.isSafeInteger(length.value)) return null;
+    if (length.value > maxLength) return null;
+    const keys = Reflect.ownKeys(value);
+    if (keys.length !== length.value + 1 || keys.some((key) => typeof key !== 'string')) {
+      return null;
+    }
+    const result: string[] = [];
+    for (let index = 0; index < length.value; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      if (!descriptor?.enumerable || !('value' in descriptor)) return null;
+      if (!isBehaviorRuntimeId(descriptor.value)) return null;
+      result.push(descriptor.value);
+    }
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+function boundedSummary(value: unknown): value is string {
+  return typeof value === 'string' && BehaviorSummarySchema.safeParse(value).success;
+}
+
+function boundedMetadata(value: unknown): BehaviorMetadata | null {
+  if (value === undefined) return {};
+  const record = snapshotBoundedPlainDataRecord(value, 32);
+  if (!record) return null;
+  const normalized = new Set<string>();
+  const result: Record<string, JsonScalar> = {};
+  for (const [key, item] of Object.entries(record)) {
+    if (
+      key.length === 0 ||
+      key.trim() !== key ||
+      !isBoundedWellFormedUtf8(key, 128, 512) ||
+      key.indexOf('\0') !== -1
+    ) {
+      return null;
+    }
+    const normalizedKey = key.normalize('NFKC');
+    if (normalized.has(normalizedKey)) return null;
+    normalized.add(normalizedKey);
+    if (typeof item === 'string') {
+      if (!isBoundedWellFormedUtf8(item, 1024, 4096) || item.indexOf('\0') !== -1) return null;
+      result[key] = item;
+    } else if (typeof item === 'number') {
+      if (!Number.isFinite(item)) return null;
+      result[key] = item;
+    } else if (typeof item === 'boolean' || item === null) {
+      result[key] = item;
+    } else {
+      return null;
+    }
+  }
+  return result;
+}
+
+interface NormalizedEvidence {
+  evidenceId: string;
+  persona: string;
+  sourceKind: BehaviorEvidenceSourceKind;
+  sourceId: string;
+  sourceOccurredAt: string;
+  fingerprint: string;
+  sentiment: BehaviorEvidenceSentiment;
+  confidence: number;
+  summary: string;
+  metadata: BehaviorMetadata;
+}
+
+interface NormalizedCandidate {
+  candidateId: string;
+  persona: string;
+  kind: BehaviorCandidateKind;
+  status: Extract<BehaviorCandidateStatus, 'collecting' | 'ready'>;
+  summary: string;
+  proposedBehavior: string;
+  confidence: number;
+  evidenceIds: string[];
+}
+
+interface NormalizedPromotion {
+  promotionId: string;
+  persona: string;
+  candidateId: string;
+  policy: BehaviorMetadata;
+  evaluation: BehaviorMetadata;
+}
+
+/** Repository for the native behavior-learning ledger. */
+export class BehaviorSignalRepository extends BaseRepository {
+  private readonly findEvidenceByIdStmt: Database.Statement;
+  private readonly findEvidenceByFingerprintStmt: Database.Statement;
+  private readonly insertEvidenceStmt: Database.Statement;
+  private readonly findEvidenceByPersonaStmt: Database.Statement;
+  private readonly insertCandidateStmt: Database.Statement;
+  private readonly insertCandidateEvidenceStmt: Database.Statement;
+  private readonly findCandidateStmt: Database.Statement;
+  private readonly findCandidatesByPersonaStmt: Database.Statement;
+  private readonly transitionCandidateStmt: Database.Statement;
+  private readonly expireCandidateStmt: Database.Statement;
+  private readonly countDistinctSourcesStmt: Database.Statement;
+  private readonly candidateEvidenceSourcesStmt: Database.Statement;
+  private readonly insertPromotionStmt: Database.Statement;
+  private readonly findPromotionStmt: Database.Statement;
+  private readonly findPromotionsByPersonaStmt: Database.Statement;
+  private readonly transitionPromotionStmt: Database.Statement;
+  private readonly insertActivationStmt: Database.Statement;
+  private readonly activatePromotionStmt: Database.Statement;
+  private readonly findActivationStmt: Database.Statement;
+  private readonly insertRollbackStmt: Database.Statement;
+  private readonly rollbackPromotionStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    super(db);
+    this.findEvidenceByIdStmt = db.prepare(`SELECT * FROM behavior_evidence WHERE evidence_id = ?`);
+    this.findEvidenceByFingerprintStmt = db.prepare(`
+      SELECT * FROM behavior_evidence WHERE persona = ? AND fingerprint = ?
+    `);
+    this.insertEvidenceStmt = db.prepare(`
+      INSERT INTO behavior_evidence (
+        evidence_id, persona, source_kind, source_id, source_occurred_at, fingerprint,
+        sentiment, confidence, summary, metadata, created_at
+      ) VALUES (
+        @evidence_id, @persona, @source_kind, @source_id, @source_occurred_at, @fingerprint,
+        @sentiment, @confidence, @summary, @metadata, @created_at
+      )
+    `);
+    this.findEvidenceByPersonaStmt = db.prepare(`
+      SELECT * FROM behavior_evidence WHERE persona = ? ORDER BY created_at ASC, evidence_id ASC
+    `);
+    this.insertCandidateStmt = db.prepare(`
+      INSERT INTO behavior_candidates (
+        candidate_id, persona, kind, status, summary, proposed_behavior, confidence,
+        created_at, updated_at, expired_at
+      ) VALUES (
+        @candidate_id, @persona, @kind, @status, @summary, @proposed_behavior, @confidence,
+        @created_at, @updated_at, NULL
+      )
+    `);
+    this.insertCandidateEvidenceStmt = db.prepare(`
+      INSERT INTO behavior_candidate_evidence (candidate_id, persona, evidence_id, created_at)
+      VALUES (@candidate_id, @persona, @evidence_id, @created_at)
+    `);
+    this.findCandidateStmt = db.prepare(`
+      SELECT * FROM behavior_candidates WHERE persona = ? AND candidate_id = ?
+    `);
+    this.findCandidatesByPersonaStmt = db.prepare(`
+      SELECT * FROM behavior_candidates WHERE persona = ? ORDER BY created_at ASC, candidate_id ASC
+    `);
+    this.transitionCandidateStmt = db.prepare(`
+      UPDATE behavior_candidates
+      SET status = @status, updated_at = @updated_at
+      WHERE persona = @persona AND candidate_id = @candidate_id
+      RETURNING *
+    `);
+    this.expireCandidateStmt = db.prepare(`
+      UPDATE behavior_candidates
+      SET status = 'expired', updated_at = @updated_at, expired_at = @updated_at
+      WHERE persona = @persona AND candidate_id = @candidate_id
+      RETURNING *
+    `);
+    this.countDistinctSourcesStmt = db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM (
+        SELECT e.source_kind, e.source_id
+        FROM behavior_candidate_evidence ce
+        JOIN behavior_evidence e ON e.evidence_id = ce.evidence_id AND e.persona = ce.persona
+        WHERE ce.candidate_id = ?
+        GROUP BY e.source_kind, e.source_id
+      )
+    `);
+    this.candidateEvidenceSourcesStmt = db.prepare(`
+      SELECT e.source_kind, e.source_id
+      FROM behavior_evidence e
+      WHERE e.persona = @persona
+        AND EXISTS (
+          SELECT 1 FROM json_each(@evidence_ids) ids WHERE ids.value = e.evidence_id
+        )
+      GROUP BY e.source_kind, e.source_id
+    `);
+    this.insertPromotionStmt = db.prepare(`
+      INSERT INTO behavior_promotions (
+        promotion_id, persona, candidate_id, status, policy, evaluation, created_at, updated_at
+      ) VALUES (
+        @promotion_id, @persona, @candidate_id, 'proposed', @policy, @evaluation,
+        @created_at, @updated_at
+      )
+    `);
+    this.findPromotionStmt = db.prepare(`
+      SELECT * FROM behavior_promotions WHERE persona = ? AND promotion_id = ?
+    `);
+    this.findPromotionsByPersonaStmt = db.prepare(`
+      SELECT * FROM behavior_promotions WHERE persona = ? ORDER BY created_at ASC, promotion_id ASC
+    `);
+    this.transitionPromotionStmt = db.prepare(`
+      UPDATE behavior_promotions
+      SET status = @status, updated_at = @updated_at
+      WHERE persona = @persona AND promotion_id = @promotion_id
+      RETURNING *
+    `);
+    this.insertActivationStmt = db.prepare(`
+      INSERT INTO behavior_promotion_activations (
+        activation_id, persona, promotion_id, prompt_artifact_id, reload_id, activated_at
+      ) VALUES (
+        @activation_id, @persona, @promotion_id, @prompt_artifact_id, @reload_id, @activated_at
+      )
+    `);
+    this.activatePromotionStmt = db.prepare(`
+      UPDATE behavior_promotions
+      SET status = 'active', updated_at = @updated_at
+      WHERE persona = @persona AND promotion_id = @promotion_id
+        AND status = 'activating'
+      RETURNING *
+    `);
+    this.findActivationStmt = db.prepare(`
+      SELECT activation_id, persona, promotion_id FROM behavior_promotion_activations
+      WHERE persona = ? AND activation_id = ?
+    `);
+    this.insertRollbackStmt = db.prepare(`
+      INSERT INTO behavior_promotion_rollbacks (
+        rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+      ) VALUES (
+        @rollback_id, @persona, @activation_id, @promotion_id, @reason, @rolled_back_at
+      )
+    `);
+    this.rollbackPromotionStmt = db.prepare(`
+      UPDATE behavior_promotions
+      SET status = 'rolled_back', updated_at = @updated_at
+      WHERE persona = @persona AND promotion_id = @promotion_id
+        AND status = 'active'
+      RETURNING *
+    `);
+  }
+
+  recordEvidence(input: BehaviorEvidenceInput): Result<BehaviorEvidenceRow, DbError> {
+    try {
+      const normalized = this.normalizeEvidence(input);
+      if (!normalized) {
+        return err(new DbError('Failed to record behavior evidence: invalid evidence'));
+      }
+      const write = this.db.transaction((): BehaviorEvidenceRow => {
+        const byId = this.findEvidenceByIdStmt.get(normalized.evidenceId) as
+          | BehaviorEvidenceRow
+          | undefined;
+        if (byId) {
+          if (byId.persona !== normalized.persona || byId.fingerprint !== normalized.fingerprint) {
+            throw new Error('behavior evidence id collision');
+          }
+          return this.validateEvidenceRow(byId);
+        }
+        const byFingerprint = this.findEvidenceByFingerprintStmt.get(
+          normalized.persona,
+          normalized.fingerprint,
+        ) as BehaviorEvidenceRow | undefined;
+        if (byFingerprint) {
+          return this.validateEvidenceRow(byFingerprint);
+        }
+        this.insertEvidenceStmt.run({
+          evidence_id: normalized.evidenceId,
+          persona: normalized.persona,
+          source_kind: normalized.sourceKind,
+          source_id: normalized.sourceId,
+          source_occurred_at: normalized.sourceOccurredAt,
+          fingerprint: normalized.fingerprint,
+          sentiment: normalized.sentiment,
+          confidence: normalized.confidence,
+          summary: normalized.summary,
+          metadata: JSON.stringify(normalized.metadata),
+          created_at: this.now(),
+        });
+        const row = this.findEvidenceByIdStmt.get(normalized.evidenceId) as BehaviorEvidenceRow;
+        return this.validateEvidenceRow(row);
+      });
+      return ok(write());
+    } catch (cause) {
+      return err(toDbError('record behavior evidence', cause));
+    }
+  }
+
+  findEvidenceByPersona(persona: string): Result<BehaviorEvidenceRow[], DbError> {
+    try {
+      if (!isBehaviorPersona(persona)) {
+        return err(new DbError('Failed to find behavior evidence: invalid persona'));
+      }
+      const rows = this.findEvidenceByPersonaStmt.all(persona) as BehaviorEvidenceRow[];
+      return ok(rows.map((row) => this.validateEvidenceRow(row)));
+    } catch (cause) {
+      return err(toDbError('find behavior evidence', cause));
+    }
+  }
+
+  createCandidate(input: BehaviorCandidateInput): Result<BehaviorCandidateRow, DbError> {
+    try {
+      const normalized = this.normalizeCandidate(input);
+      if (!normalized) {
+        return err(new DbError('Failed to create behavior candidate: invalid candidate'));
+      }
+      const write = this.db.transaction((): BehaviorCandidateRow => {
+        if (!this.hasDistinctEvidenceSources(normalized.persona, normalized.evidenceIds)) {
+          throw new Error('behavior candidate needs distinct evidence sources');
+        }
+        const now = this.now();
+        this.insertCandidateStmt.run({
+          candidate_id: normalized.candidateId,
+          persona: normalized.persona,
+          kind: normalized.kind,
+          status: 'collecting',
+          summary: normalized.summary,
+          proposed_behavior: normalized.proposedBehavior,
+          confidence: normalized.confidence,
+          created_at: now,
+          updated_at: now,
+        });
+        for (const evidenceId of normalized.evidenceIds) {
+          this.insertCandidateEvidenceStmt.run({
+            candidate_id: normalized.candidateId,
+            persona: normalized.persona,
+            evidence_id: evidenceId,
+            created_at: this.now(),
+          });
+        }
+        if (normalized.status === 'ready') {
+          this.transitionCandidateStmt.get({
+            persona: normalized.persona,
+            candidate_id: normalized.candidateId,
+            status: 'ready',
+            updated_at: this.now(),
+          });
+        }
+        const row = this.findCandidateStmt.get(
+          normalized.persona,
+          normalized.candidateId,
+        ) as BehaviorCandidateRow;
+        return this.validateCandidateRow(row);
+      });
+      return ok(write());
+    } catch (cause) {
+      return err(toDbError('create behavior candidate', cause));
+    }
+  }
+
+  findCandidatesByPersona(persona: string): Result<BehaviorCandidateRow[], DbError> {
+    try {
+      if (!isBehaviorPersona(persona)) {
+        return err(new DbError('Failed to find behavior candidates: invalid persona'));
+      }
+      const rows = this.findCandidatesByPersonaStmt.all(persona) as BehaviorCandidateRow[];
+      return ok(rows.map((row) => this.validateCandidateRow(row)));
+    } catch (cause) {
+      return err(toDbError('find behavior candidates', cause));
+    }
+  }
+
+  transitionCandidate(
+    persona: string,
+    candidateId: string,
+    status: BehaviorCandidateStatus,
+  ): Result<BehaviorCandidateRow, DbError> {
+    try {
+      if (
+        !isBehaviorPersona(persona) ||
+        !isBehaviorRuntimeId(candidateId) ||
+        !BehaviorCandidateStatusSchema.safeParse(status).success
+      ) {
+        return err(new DbError('Failed to transition behavior candidate: invalid transition'));
+      }
+      const transition = this.db.transaction((): BehaviorCandidateRow | null => {
+        if (status === 'ready' && !this.hasPersistedDistinctEvidenceSources(candidateId)) {
+          throw new Error('behavior candidate needs distinct evidence sources');
+        }
+        const row = this.transitionCandidateStmt.get({
+          persona,
+          candidate_id: candidateId,
+          status,
+          updated_at: this.now(),
+        }) as BehaviorCandidateRow | undefined;
+        return row ? this.validateCandidateRow(row) : null;
+      });
+      const row = transition();
+      return row
+        ? ok(row)
+        : err(new DbError('Failed to transition behavior candidate: illegal transition'));
+    } catch (cause) {
+      return err(toDbError('transition behavior candidate', cause));
+    }
+  }
+
+  expireCandidate(persona: string, candidateId: string): Result<BehaviorCandidateRow, DbError> {
+    try {
+      if (!isBehaviorPersona(persona) || !isBehaviorRuntimeId(candidateId)) {
+        return err(new DbError('Failed to expire behavior candidate: invalid candidate identity'));
+      }
+      const expire = this.db.transaction((): BehaviorCandidateRow | null => {
+        const row = this.expireCandidateStmt.get({
+          persona,
+          candidate_id: candidateId,
+          updated_at: this.now(),
+        }) as BehaviorCandidateRow | undefined;
+        return row ? this.validateCandidateRow(row) : null;
+      });
+      const row = expire();
+      return row ? ok(row) : err(new DbError('Failed to expire behavior candidate'));
+    } catch (cause) {
+      return err(toDbError('expire behavior candidate', cause));
+    }
+  }
+
+  countDistinctEvidenceSources(candidateId: string): Result<number, DbError> {
+    try {
+      if (!isBehaviorRuntimeId(candidateId)) {
+        return err(new DbError('Failed to count behavior evidence sources: invalid candidate id'));
+      }
+      const row = this.countDistinctSourcesStmt.get(candidateId) as { count: number };
+      return ok(row.count);
+    } catch (cause) {
+      return err(toDbError('count behavior evidence sources', cause));
+    }
+  }
+
+  createPromotion(input: BehaviorPromotionInput): Result<BehaviorPromotionRow, DbError> {
+    try {
+      const normalized = this.normalizePromotion(input);
+      if (!normalized) {
+        return err(new DbError('Failed to create behavior promotion: invalid promotion'));
+      }
+      const write = this.db.transaction((): BehaviorPromotionRow => {
+        const now = this.now();
+        this.insertPromotionStmt.run({
+          promotion_id: normalized.promotionId,
+          persona: normalized.persona,
+          candidate_id: normalized.candidateId,
+          policy: JSON.stringify(normalized.policy),
+          evaluation: JSON.stringify(normalized.evaluation),
+          created_at: now,
+          updated_at: now,
+        });
+        const row = this.findPromotionStmt.get(
+          normalized.persona,
+          normalized.promotionId,
+        ) as BehaviorPromotionRow;
+        return this.validatePromotionRow(row);
+      });
+      return ok(write());
+    } catch (cause) {
+      return err(toDbError('create behavior promotion', cause));
+    }
+  }
+
+  transitionPromotion(
+    persona: string,
+    promotionId: string,
+    status: BehaviorPromotionStatus,
+  ): Result<BehaviorPromotionRow, DbError> {
+    try {
+      if (
+        !isBehaviorPersona(persona) ||
+        !isBehaviorRuntimeId(promotionId) ||
+        !BehaviorPromotionStatusSchema.safeParse(status).success ||
+        status === 'active' ||
+        status === 'rolled_back'
+      ) {
+        return err(new DbError('Failed to transition behavior promotion: invalid transition'));
+      }
+      const transition = this.db.transaction((): BehaviorPromotionRow | null => {
+        const row = this.transitionPromotionStmt.get({
+          persona,
+          promotion_id: promotionId,
+          status,
+          updated_at: this.now(),
+        }) as BehaviorPromotionRow | undefined;
+        return row ? this.validatePromotionRow(row) : null;
+      });
+      const row = transition();
+      return row
+        ? ok(row)
+        : err(new DbError('Failed to transition behavior promotion: illegal transition'));
+    } catch (cause) {
+      return err(toDbError('transition behavior promotion', cause));
+    }
+  }
+
+  activatePromotion(
+    input: BehaviorPromotionActivationInput,
+  ): Result<BehaviorPromotionRow, DbError> {
+    try {
+      if (
+        !isBehaviorPersona(input.persona) ||
+        !isBehaviorRuntimeId(input.promotionId) ||
+        !isBehaviorRuntimeId(input.activationId) ||
+        !isBehaviorRuntimeId(input.promptArtifactId) ||
+        !isBehaviorRuntimeId(input.reloadId)
+      ) {
+        return err(new DbError('Failed to activate behavior promotion: invalid activation'));
+      }
+      const write = this.db.transaction((): BehaviorPromotionRow | null => {
+        const now = this.now();
+        this.insertActivationStmt.run({
+          activation_id: input.activationId,
+          persona: input.persona,
+          promotion_id: input.promotionId,
+          prompt_artifact_id: input.promptArtifactId,
+          reload_id: input.reloadId,
+          activated_at: now,
+        });
+        const row = this.activatePromotionStmt.get({
+          persona: input.persona,
+          promotion_id: input.promotionId,
+          updated_at: now,
+        }) as BehaviorPromotionRow | undefined;
+        if (!row) return null;
+        return this.validatePromotionRow(row);
+      });
+      const row = write();
+      return row ? ok(row) : err(new DbError('Failed to activate behavior promotion'));
+    } catch (cause) {
+      return err(toDbError('activate behavior promotion', cause));
+    }
+  }
+
+  rollbackActivation(input: BehaviorPromotionRollbackInput): Result<BehaviorPromotionRow, DbError> {
+    try {
+      if (
+        !isBehaviorPersona(input.persona) ||
+        !isBehaviorRuntimeId(input.activationId) ||
+        !isBehaviorRuntimeId(input.rollbackId) ||
+        !BehaviorLineageReasonSchema.safeParse(input.reason).success ||
+        !isBehaviorIdentifier(input.reason)
+      ) {
+        return err(new DbError('Failed to rollback behavior promotion: invalid rollback'));
+      }
+      const write = this.db.transaction((): BehaviorPromotionRow | null => {
+        const activation = this.findActivationStmt.get(input.persona, input.activationId) as
+          | { activation_id: string; persona: string; promotion_id: string }
+          | undefined;
+        if (!activation) return null;
+        const now = this.now();
+        this.insertRollbackStmt.run({
+          rollback_id: input.rollbackId,
+          persona: input.persona,
+          activation_id: input.activationId,
+          promotion_id: activation.promotion_id,
+          reason: input.reason,
+          rolled_back_at: now,
+        });
+        const row = this.rollbackPromotionStmt.get({
+          persona: input.persona,
+          promotion_id: activation.promotion_id,
+          updated_at: now,
+        }) as BehaviorPromotionRow | undefined;
+        if (!row) {
+          throw new DbError('Failed to rollback behavior promotion');
+        }
+        return this.validatePromotionRow(row);
+      });
+      const row = write();
+      return row ? ok(row) : err(new DbError('Failed to rollback behavior promotion'));
+    } catch (cause) {
+      return err(toDbError('rollback behavior promotion', cause));
+    }
+  }
+
+  findPromotionsByPersona(persona: string): Result<BehaviorPromotionRow[], DbError> {
+    try {
+      if (!isBehaviorPersona(persona)) {
+        return err(new DbError('Failed to find behavior promotions: invalid persona'));
+      }
+      const rows = this.findPromotionsByPersonaStmt.all(persona) as BehaviorPromotionRow[];
+      return ok(rows.map((row) => this.validatePromotionRow(row)));
+    } catch (cause) {
+      return err(toDbError('find behavior promotions', cause));
+    }
+  }
+
+  private normalizeEvidence(input: BehaviorEvidenceInput): NormalizedEvidence | null {
+    const record = readRecord(
+      input,
+      [
+        'evidenceId',
+        'persona',
+        'sourceKind',
+        'sourceId',
+        'sourceOccurredAt',
+        'fingerprint',
+        'sentiment',
+        'confidence',
+        'summary',
+      ],
+      ['metadata'],
+    );
+    if (!record) return null;
+    const sourceKind = BehaviorEvidenceSourceKindSchema.safeParse(record.sourceKind);
+    const sentiment = BehaviorEvidenceSentimentSchema.safeParse(record.sentiment);
+    const confidence = BehaviorConfidenceSchema.safeParse(record.confidence);
+    const occurredAt = BehaviorTimestampSchema.safeParse(record.sourceOccurredAt);
+    const metadata = boundedMetadata(record.metadata);
+    if (
+      !isBehaviorRuntimeId(record.evidenceId) ||
+      !isBehaviorPersona(record.persona) ||
+      !sourceKind.success ||
+      !isBehaviorRuntimeId(record.sourceId) ||
+      !occurredAt.success ||
+      !isBehaviorRuntimeId(record.fingerprint) ||
+      !sentiment.success ||
+      !confidence.success ||
+      !boundedSummary(record.summary) ||
+      !metadata
+    ) {
+      return null;
+    }
+    return {
+      evidenceId: record.evidenceId,
+      persona: record.persona,
+      sourceKind: sourceKind.data,
+      sourceId: record.sourceId,
+      sourceOccurredAt: occurredAt.data,
+      fingerprint: record.fingerprint,
+      sentiment: sentiment.data,
+      confidence: confidence.data,
+      summary: record.summary,
+      metadata,
+    };
+  }
+
+  private normalizeCandidate(input: BehaviorCandidateInput): NormalizedCandidate | null {
+    const record = readRecord(
+      input,
+      ['candidateId', 'persona', 'kind', 'summary', 'proposedBehavior', 'confidence'],
+      ['status', 'createdFromEvidenceIds'],
+    );
+    if (!record) return null;
+    const kind = BehaviorCandidateKindSchema.safeParse(record.kind);
+    const status = BehaviorCandidateStatusSchema.safeParse(record.status ?? 'collecting');
+    const confidence = BehaviorConfidenceSchema.safeParse(record.confidence);
+    const evidenceIds =
+      record.createdFromEvidenceIds === undefined
+        ? []
+        : readStringArray(record.createdFromEvidenceIds, 32);
+    if (
+      !isBehaviorRuntimeId(record.candidateId) ||
+      !isBehaviorPersona(record.persona) ||
+      !kind.success ||
+      !status.success ||
+      (status.data !== 'collecting' && status.data !== 'ready') ||
+      !boundedSummary(record.summary) ||
+      !boundedSummary(record.proposedBehavior) ||
+      !confidence.success ||
+      !evidenceIds ||
+      (status.data === 'ready' && evidenceIds.length === 0) ||
+      new Set(evidenceIds).size !== evidenceIds.length
+    ) {
+      return null;
+    }
+    return {
+      candidateId: record.candidateId,
+      persona: record.persona,
+      kind: kind.data,
+      status: status.data,
+      summary: record.summary,
+      proposedBehavior: record.proposedBehavior,
+      confidence: confidence.data,
+      evidenceIds,
+    };
+  }
+
+  private normalizePromotion(input: BehaviorPromotionInput): NormalizedPromotion | null {
+    const record = readRecord(
+      input,
+      ['promotionId', 'persona', 'candidateId'],
+      ['status', 'policy', 'evaluation'],
+    );
+    if (!record) return null;
+    const status = BehaviorPromotionStatusSchema.safeParse(record.status ?? 'proposed');
+    const policy = boundedMetadata(record.policy);
+    const evaluation = boundedMetadata(record.evaluation);
+    if (
+      !isBehaviorRuntimeId(record.promotionId) ||
+      !isBehaviorPersona(record.persona) ||
+      !isBehaviorRuntimeId(record.candidateId) ||
+      !status.success ||
+      status.data !== 'proposed' ||
+      !policy ||
+      !evaluation
+    ) {
+      return null;
+    }
+    return {
+      promotionId: record.promotionId,
+      persona: record.persona,
+      candidateId: record.candidateId,
+      policy,
+      evaluation,
+    };
+  }
+
+  private hasDistinctEvidenceSources(persona: string, evidenceIds: readonly string[]): boolean {
+    if (evidenceIds.length === 0) return true;
+    if (evidenceIds.length < 2) return false;
+    const rows = this.candidateEvidenceSourcesStmt.all({
+      persona,
+      evidence_ids: JSON.stringify(evidenceIds),
+    }) as Array<{ source_kind: string; source_id: string }>;
+    return rows.length === evidenceIds.length && rows.length >= 2;
+  }
+
+  private hasPersistedDistinctEvidenceSources(candidateId: string): boolean {
+    const row = this.countDistinctSourcesStmt.get(candidateId) as { count: number };
+    return row.count >= 2;
+  }
+
+  private validateEvidenceRow(row: BehaviorEvidenceRow): BehaviorEvidenceRow {
+    if (
+      !isBehaviorRuntimeId(row.evidence_id) ||
+      !isBehaviorPersona(row.persona) ||
+      !BehaviorEvidenceSourceKindSchema.safeParse(row.source_kind).success ||
+      !isBehaviorRuntimeId(row.source_id) ||
+      !BehaviorTimestampSchema.safeParse(row.source_occurred_at).success ||
+      !isBehaviorRuntimeId(row.fingerprint) ||
+      !BehaviorEvidenceSentimentSchema.safeParse(row.sentiment).success ||
+      !BehaviorConfidenceSchema.safeParse(row.confidence).success ||
+      !boundedSummary(row.summary) ||
+      !this.parseMetadata(row.metadata) ||
+      !Number.isSafeInteger(row.created_at)
+    ) {
+      throw new Error('invalid persisted behavior evidence row');
+    }
+    return row;
+  }
+
+  private validateCandidateRow(row: BehaviorCandidateRow): BehaviorCandidateRow {
+    if (
+      !isBehaviorRuntimeId(row.candidate_id) ||
+      !isBehaviorPersona(row.persona) ||
+      !BehaviorCandidateKindSchema.safeParse(row.kind).success ||
+      !BehaviorCandidateStatusSchema.safeParse(row.status).success ||
+      !boundedSummary(row.summary) ||
+      !boundedSummary(row.proposed_behavior) ||
+      !BehaviorConfidenceSchema.safeParse(row.confidence).success ||
+      !Number.isSafeInteger(row.created_at) ||
+      !Number.isSafeInteger(row.updated_at) ||
+      (row.expired_at !== null && !Number.isSafeInteger(row.expired_at))
+    ) {
+      throw new Error('invalid persisted behavior candidate row');
+    }
+    return row;
+  }
+
+  private validatePromotionRow(row: BehaviorPromotionRow): BehaviorPromotionRow {
+    if (
+      !isBehaviorRuntimeId(row.promotion_id) ||
+      !isBehaviorPersona(row.persona) ||
+      !isBehaviorRuntimeId(row.candidate_id) ||
+      !BehaviorPromotionStatusSchema.safeParse(row.status).success ||
+      !this.parseMetadata(row.policy) ||
+      !this.parseMetadata(row.evaluation) ||
+      !Number.isSafeInteger(row.created_at) ||
+      !Number.isSafeInteger(row.updated_at)
+    ) {
+      throw new Error('invalid persisted behavior promotion row');
+    }
+    return row;
+  }
+
+  private parseMetadata(raw: string): BehaviorMetadata | null {
+    if (typeof raw !== 'string' || raw.length > 32768 || Buffer.byteLength(raw, 'utf8') > 32768) {
+      return null;
+    }
+    try {
+      return boundedMetadata(JSON.parse(raw) as unknown);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/core/database/repositories/index.ts
+++ b/src/core/database/repositories/index.ts
@@ -87,5 +87,21 @@ export type {
 } from './lifecycle-delivery-repository.js';
 export { LifecycleDeliveryRepository } from './lifecycle-delivery-repository.js';
 
-export type { LifecycleSignalHandoffInput, LifecycleSignalRow } from './lifecycle-signal-repository.js';
+export type {
+  LifecycleSignalHandoffInput,
+  LifecycleSignalRow,
+} from './lifecycle-signal-repository.js';
 export { LifecycleSignalRepository } from './lifecycle-signal-repository.js';
+
+export type {
+  BehaviorCandidateInput,
+  BehaviorCandidateRow,
+  BehaviorEvidenceInput,
+  BehaviorEvidenceRow,
+  BehaviorMetadata,
+  BehaviorPromotionActivationInput,
+  BehaviorPromotionInput,
+  BehaviorPromotionRollbackInput,
+  BehaviorPromotionRow,
+} from './behavior-signal-repository.js';
+export { BehaviorSignalRepository } from './behavior-signal-repository.js';

--- a/src/lifecycle/behavior/types.ts
+++ b/src/lifecycle/behavior/types.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod';
+import {
+  isBoundedUnicodeScalarsUtf8,
+  isBoundedWellFormedUtf8,
+  LifecycleDurablePersonaOwnerNameSchema,
+  LifecycleIdentifierSchema,
+  LifecycleRuntimeIdSchema,
+} from '../contracts/common.js';
+
+export const BehaviorEvidenceSourceKindSchema = z.enum([
+  'message',
+  'schedule',
+  'run',
+  'tool',
+  'manual',
+]);
+
+export const BehaviorEvidenceSentimentSchema = z.enum(['positive', 'negative', 'neutral']);
+
+export const BehaviorCandidateKindSchema = z.enum([
+  'style',
+  'preference',
+  'safety',
+  'tooling',
+  'context',
+]);
+
+export const BehaviorCandidateStatusSchema = z.enum([
+  'collecting',
+  'ready',
+  'proposed',
+  'rejected',
+  'expired',
+]);
+
+export const BehaviorPromotionStatusSchema = z.enum([
+  'proposed',
+  'evaluating',
+  'approved',
+  'activating',
+  'active',
+  'rolled_back',
+  'reopened',
+  'rejected',
+  'expired',
+]);
+
+export const BehaviorTimestampSchema = z.string().refine((value) => {
+  if (
+    !isBoundedWellFormedUtf8(value, 64, 256) ||
+    value.indexOf('\0') !== -1 ||
+    value.trim() !== value
+  ) {
+    return false;
+  }
+  return new Date(value).toISOString() === value;
+});
+
+export const BehaviorSummarySchema = z
+  .string()
+  .min(1)
+  .max(4096)
+  .refine((value) => value.indexOf('\0') === -1 && isBoundedWellFormedUtf8(value, 4096, 16384));
+
+export const BehaviorLineageReasonSchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .refine((value) => value.indexOf('\0') === -1 && isBoundedWellFormedUtf8(value, 512, 2048));
+
+export const BehaviorConfidenceSchema = z.number().min(0).max(1).finite();
+
+export type BehaviorEvidenceSourceKind = z.infer<typeof BehaviorEvidenceSourceKindSchema>;
+export type BehaviorEvidenceSentiment = z.infer<typeof BehaviorEvidenceSentimentSchema>;
+export type BehaviorCandidateKind = z.infer<typeof BehaviorCandidateKindSchema>;
+export type BehaviorCandidateStatus = z.infer<typeof BehaviorCandidateStatusSchema>;
+export type BehaviorPromotionStatus = z.infer<typeof BehaviorPromotionStatusSchema>;
+
+export function isBehaviorRuntimeId(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    isBoundedWellFormedUtf8(value, 256, 1024) &&
+    value.indexOf('\0') === -1 &&
+    LifecycleRuntimeIdSchema.safeParse(value).success
+  );
+}
+
+export function isBehaviorIdentifier(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    isBoundedWellFormedUtf8(value, 128, 512) &&
+    value.indexOf('\0') === -1 &&
+    LifecycleIdentifierSchema.safeParse(value).success
+  );
+}
+
+export function isBehaviorPersona(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.indexOf('\0') === -1 &&
+    isBoundedUnicodeScalarsUtf8(value, 256, 1024) &&
+    LifecycleDurablePersonaOwnerNameSchema.safeParse(value).success
+  );
+}

--- a/tests/unit/core/database/migrations/runner.test.ts
+++ b/tests/unit/core/database/migrations/runner.test.ts
@@ -153,6 +153,276 @@ describe('runMigrations', () => {
     expect(tbl).toBeDefined();
   });
 
+  it('enforces behavior ledger evidence and lineage invariants at the migration boundary', () => {
+    const realMigrationsDir = join(
+      import.meta.dirname,
+      '../../../../../src/core/database/migrations',
+    );
+    const result = runMigrations(db, realMigrationsDir);
+    expect(result.isOk()).toBe(true);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_candidates (
+            candidate_id, persona, kind, status, summary, proposed_behavior, confidence,
+            created_at, updated_at
+          ) VALUES (
+            'direct-ready-no-evidence', 'support', 'style', 'ready',
+            'Direct SQL should not bypass evidence.',
+            'Keep answers concise unless detail is explicitly requested.',
+            0.7, 1, 1
+          )`,
+        )
+        .run(),
+    ).toThrow();
+
+    const insertEvidence = db.prepare(
+      `INSERT INTO behavior_evidence (
+        evidence_id, persona, source_kind, source_id, source_occurred_at, fingerprint,
+        sentiment, confidence, summary, metadata, created_at
+      ) VALUES (
+        @evidenceId, 'support', 'message', @sourceId, '2026-07-25T12:00:00.000Z',
+        @fingerprint, 'positive', 0.8, 'User explicitly asked for concise responses.',
+        '{"detector":"migration-test"}', @createdAt
+      )`,
+    );
+    insertEvidence.run({
+      evidenceId: 'direct-evidence-a',
+      sourceId: 'direct-message-a',
+      fingerprint: 'direct-fingerprint-a',
+      createdAt: 1,
+    });
+    insertEvidence.run({
+      evidenceId: 'direct-evidence-b',
+      sourceId: 'direct-message-b',
+      fingerprint: 'direct-fingerprint-b',
+      createdAt: 2,
+    });
+
+    db.prepare(
+      `INSERT INTO behavior_candidates (
+        candidate_id, persona, kind, status, summary, proposed_behavior, confidence,
+        created_at, updated_at
+      ) VALUES (
+        'direct-candidate-a', 'support', 'style', 'collecting',
+        'Prefer concise responses.',
+        'Keep answers concise unless detail is explicitly requested.',
+        0.7, 3, 3
+      )`,
+    ).run();
+    db.prepare(
+      `INSERT INTO behavior_candidate_evidence (
+        candidate_id, persona, evidence_id, created_at
+      ) VALUES ('direct-candidate-a', 'support', 'direct-evidence-a', 4)`,
+    ).run();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE behavior_candidates
+           SET status = 'ready', updated_at = 5
+           WHERE candidate_id = 'direct-candidate-a'`,
+        )
+        .run(),
+    ).toThrow();
+    db.prepare(
+      `INSERT INTO behavior_candidate_evidence (
+        candidate_id, persona, evidence_id, created_at
+      ) VALUES ('direct-candidate-a', 'support', 'direct-evidence-b', 6)`,
+    ).run();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE behavior_candidates
+           SET status = 'ready', updated_at = 7
+           WHERE candidate_id = 'direct-candidate-a'`,
+        )
+        .run(),
+    ).not.toThrow();
+
+    db.prepare(
+      `INSERT INTO behavior_promotions (
+        promotion_id, persona, candidate_id, status, policy, evaluation, created_at, updated_at
+      ) VALUES (
+        'direct-promotion-a', 'support', 'direct-candidate-a', 'proposed',
+        '{"approval":"operator"}', '{"dryRun":"passed"}', 8, 8
+      )`,
+    ).run();
+    for (const [status, updatedAt] of [
+      ['evaluating', 9],
+      ['approved', 10],
+      ['activating', 11],
+    ] as const) {
+      db.prepare(
+        `UPDATE behavior_promotions
+         SET status = ?, updated_at = ?
+         WHERE promotion_id = 'direct-promotion-a'`,
+      ).run(status, updatedAt);
+    }
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE behavior_promotions
+           SET status = 'active', updated_at = 12
+           WHERE promotion_id = 'direct-promotion-a'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(
+      db
+        .prepare(`SELECT status FROM behavior_promotions WHERE promotion_id = 'direct-promotion-a'`)
+        .get(),
+    ).toEqual({ status: 'activating' });
+    db.prepare(
+      `INSERT INTO behavior_promotion_activations (
+        activation_id, persona, promotion_id, prompt_artifact_id, reload_id, activated_at
+      ) VALUES (
+        'direct-activation-a', 'support', 'direct-promotion-a',
+        'direct-prompt-a', 'direct-reload-a', 12
+      )`,
+    ).run();
+    db.prepare(
+      `INSERT INTO behavior_promotion_activations (
+        activation_id, persona, promotion_id, prompt_artifact_id, reload_id, activated_at
+      ) VALUES (
+        'direct-activation-b', 'support', 'direct-promotion-a',
+        'direct-prompt-b', 'direct-reload-b', 12
+      )`,
+    ).run();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_promotion_rollbacks (
+            rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+          ) VALUES (
+            'direct-rollback-before-active', 'support', 'direct-activation-a',
+            'direct-promotion-a', 'operator-rejected', 12
+          )`,
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE behavior_promotions
+           SET status = 'active', updated_at = 12
+           WHERE promotion_id = 'direct-promotion-a'`,
+        )
+        .run(),
+    ).not.toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE behavior_promotions
+           SET status = 'rolled_back', updated_at = 14
+           WHERE promotion_id = 'direct-promotion-a'`,
+        )
+        .run(),
+    ).toThrow();
+    expect(
+      db
+        .prepare(`SELECT status FROM behavior_promotions WHERE promotion_id = 'direct-promotion-a'`)
+        .get(),
+    ).toEqual({ status: 'active' });
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_promotion_rollbacks (
+            rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+          ) VALUES (
+            'direct-rollback-active', 'support', 'direct-activation-a',
+            'direct-promotion-a', 'operator-rejected', 13
+          )`,
+        )
+        .run(),
+    ).not.toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT rollback_id FROM behavior_promotion_rollbacks
+           WHERE rollback_id = 'direct-rollback-active'`,
+        )
+        .get(),
+    ).toEqual({ rollback_id: 'direct-rollback-active' });
+    db.prepare(
+      `UPDATE behavior_promotions
+       SET status = 'rolled_back', updated_at = 13
+       WHERE promotion_id = 'direct-promotion-a'`,
+    ).run();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_promotion_rollbacks (
+            rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+          ) VALUES (
+            'direct-rollback-after-rollback', 'support', 'direct-activation-b',
+            'direct-promotion-a', 'operator-rejected', 14
+          )`,
+        )
+        .run(),
+    ).toThrow();
+
+    insertEvidence.run({
+      evidenceId: 'direct-evidence-c',
+      sourceId: 'direct-message-c',
+      fingerprint: 'direct-fingerprint-c',
+      createdAt: 14,
+    });
+    insertEvidence.run({
+      evidenceId: 'direct-evidence-d',
+      sourceId: 'direct-message-d',
+      fingerprint: 'direct-fingerprint-d',
+      createdAt: 15,
+    });
+    db.prepare(
+      `INSERT INTO behavior_candidates (
+        candidate_id, persona, kind, status, summary, proposed_behavior, confidence,
+        created_at, updated_at
+      ) VALUES (
+        'direct-candidate-b', 'support', 'style', 'collecting',
+        'Prefer brief replies.',
+        'Use a compact answer shape unless asked for detail.',
+        0.7, 16, 16
+      )`,
+    ).run();
+    for (const [evidenceId, createdAt] of [
+      ['direct-evidence-c', 17],
+      ['direct-evidence-d', 18],
+    ] as const) {
+      db.prepare(
+        `INSERT INTO behavior_candidate_evidence (
+          candidate_id, persona, evidence_id, created_at
+        ) VALUES ('direct-candidate-b', 'support', ?, ?)`,
+      ).run(evidenceId, createdAt);
+    }
+    db.prepare(
+      `UPDATE behavior_candidates
+       SET status = 'ready', updated_at = 19
+       WHERE candidate_id = 'direct-candidate-b'`,
+    ).run();
+    db.prepare(
+      `INSERT INTO behavior_promotions (
+        promotion_id, persona, candidate_id, status, policy, evaluation, created_at, updated_at
+      ) VALUES (
+        'direct-promotion-b', 'support', 'direct-candidate-b', 'proposed',
+        '{"approval":"operator"}', '{"dryRun":"passed"}', 20, 20
+      )`,
+    ).run();
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_promotion_rollbacks (
+            rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+          ) VALUES (
+            'direct-rollback-mismatch', 'support', 'direct-activation-a',
+            'direct-promotion-b', 'operator-rejected', 21
+          )`,
+        )
+        .run(),
+    ).toThrow();
+  });
+
   it('upgrades a pre-lifecycle schema with the durable event tables', () => {
     const realMigrationsDir = join(
       import.meta.dirname,
@@ -169,9 +439,19 @@ describe('runMigrations', () => {
     expect(db.pragma('user_version', { simple: true })).toBe(13);
 
     const upgrade = runMigrations(db, realMigrationsDir);
-    expect(upgrade._unsafeUnwrap()).toBe(4);
-    expect(db.pragma('user_version', { simple: true })).toBe(17);
-    for (const table of ['lifecycle_events', 'lifecycle_event_deliveries', 'lifecycle_signal_handoffs', 'lifecycle_signals']) {
+    expect(upgrade._unsafeUnwrap()).toBe(5);
+    expect(db.pragma('user_version', { simple: true })).toBe(18);
+    for (const table of [
+      'lifecycle_events',
+      'lifecycle_event_deliveries',
+      'lifecycle_signal_handoffs',
+      'lifecycle_signals',
+      'behavior_evidence',
+      'behavior_candidates',
+      'behavior_promotions',
+      'behavior_promotion_activations',
+      'behavior_promotion_rollbacks',
+    ]) {
       expect(
         db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`).get(table),
       ).toBeDefined();
@@ -423,8 +703,8 @@ describe('runMigrations', () => {
         )
         .run(identityFor('preserved-handler'));
 
-      expect(runMigrations(preservedDb, realMigrationsDir)._unsafeUnwrap()).toBe(3);
-      expect(preservedDb.pragma('user_version', { simple: true })).toBe(17);
+      expect(runMigrations(preservedDb, realMigrationsDir)._unsafeUnwrap()).toBe(4);
+      expect(preservedDb.pragma('user_version', { simple: true })).toBe(18);
       expect(
         preservedDb
           .prepare(

--- a/tests/unit/core/database/repositories/behavior-signal-repository.test.ts
+++ b/tests/unit/core/database/repositories/behavior-signal-repository.test.ts
@@ -1,0 +1,885 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import {
+  BaseRepository,
+  BehaviorSignalRepository,
+  type BehaviorCandidateInput,
+  type BehaviorEvidenceInput,
+  type BehaviorPromotionInput,
+} from '../../../../../src/core/database/repositories/index.js';
+import { createTestDb, uuid } from './helpers.js';
+
+describe('BehaviorSignalRepository', () => {
+  let db: Database.Database;
+  let repository: BehaviorSignalRepository;
+
+  beforeEach(() => {
+    BaseRepository.__resetMonotonicClockForTests();
+    db = createTestDb();
+    repository = new BehaviorSignalRepository(db);
+  });
+
+  afterEach(() => db.close());
+
+  function evidence(overrides: Partial<BehaviorEvidenceInput> = {}): BehaviorEvidenceInput {
+    return {
+      evidenceId: uuid(),
+      persona: 'support',
+      sourceKind: 'message',
+      sourceId: uuid(),
+      sourceOccurredAt: '2026-07-25T12:00:00.000Z',
+      fingerprint: `fingerprint-${uuid()}`,
+      sentiment: 'positive',
+      confidence: 0.87,
+      summary: 'User explicitly asked the assistant to keep responses concise.',
+      metadata: { detector: 'test' },
+      ...overrides,
+    };
+  }
+
+  function candidate(overrides: Partial<BehaviorCandidateInput> = {}): BehaviorCandidateInput {
+    return {
+      candidateId: uuid(),
+      persona: 'support',
+      kind: 'style',
+      status: 'collecting',
+      summary: 'Prefer concise responses.',
+      proposedBehavior: 'Keep answers concise unless detail is explicitly requested.',
+      confidence: 0.72,
+      createdFromEvidenceIds: [],
+      ...overrides,
+    };
+  }
+
+  function promotion(
+    candidateId: string,
+    overrides: Partial<BehaviorPromotionInput> = {},
+  ): BehaviorPromotionInput {
+    return {
+      promotionId: uuid(),
+      persona: 'support',
+      candidateId,
+      status: 'proposed',
+      policy: { approval: 'operator' },
+      evaluation: { dryRun: 'passed' },
+      ...overrides,
+    };
+  }
+
+  function recordDistinctEvidence(): [BehaviorEvidenceInput, BehaviorEvidenceInput] {
+    const first = evidence({ evidenceId: uuid(), sourceId: uuid() });
+    const second = evidence({ evidenceId: uuid(), sourceId: uuid() });
+    expect(repository.recordEvidence(first).isOk()).toBe(true);
+    expect(repository.recordEvidence(second).isOk()).toBe(true);
+    return [first, second];
+  }
+
+  function createActivePromotion(
+    ids: {
+      candidateId: string;
+      promotionId: string;
+      activationId: string;
+      promptArtifactId: string;
+      reloadId: string;
+    } = {
+      candidateId: uuid(),
+      promotionId: uuid(),
+      activationId: uuid(),
+      promptArtifactId: uuid(),
+      reloadId: uuid(),
+    },
+  ): void {
+    const [firstEvidence, secondEvidence] = recordDistinctEvidence();
+    expect(
+      repository
+        .createCandidate(
+          candidate({
+            candidateId: ids.candidateId,
+            status: 'ready',
+            createdFromEvidenceIds: [firstEvidence.evidenceId, secondEvidence.evidenceId],
+          }),
+        )
+        .isOk(),
+    ).toBe(true);
+    expect(
+      repository
+        .createPromotion(promotion(ids.candidateId, { promotionId: ids.promotionId }))
+        .isOk(),
+    ).toBe(true);
+    for (const status of ['evaluating', 'approved', 'activating'] as const) {
+      expect(repository.transitionPromotion('support', ids.promotionId, status).isOk()).toBe(
+        true,
+      );
+    }
+    expect(
+      repository
+        .activatePromotion({
+          persona: 'support',
+          promotionId: ids.promotionId,
+          activationId: ids.activationId,
+          promptArtifactId: ids.promptArtifactId,
+          reloadId: ids.reloadId,
+        })
+        .isOk(),
+    ).toBe(true);
+  }
+
+  it('suppresses schedule/direct copies by persona-scoped evidence fingerprint', () => {
+    const direct = evidence({ sourceKind: 'message', fingerprint: 'copy-fingerprint' });
+    const scheduleCopy = evidence({
+      sourceKind: 'schedule',
+      sourceId: uuid(),
+      fingerprint: direct.fingerprint,
+    });
+
+    const inserted = repository.recordEvidence(direct);
+    expect(inserted.isOk()).toBe(true);
+    expect(repository.recordEvidence(scheduleCopy).isOk()).toBe(true);
+    expect(repository.findEvidenceByPersona('support')._unsafeUnwrap()).toHaveLength(1);
+
+    const otherPersonaCopy = repository.recordEvidence({
+      ...scheduleCopy,
+      evidenceId: uuid(),
+      persona: 'coach',
+    });
+    expect(otherPersonaCopy.isOk()).toBe(true);
+    expect(repository.findEvidenceByPersona('coach')._unsafeUnwrap()).toHaveLength(1);
+  });
+
+  it('requires distinct persona-local evidence sources before inferred promotion readiness', () => {
+    const first = evidence({ evidenceId: 'evidence-a', sourceId: 'message-a' });
+    const duplicateSource = evidence({
+      evidenceId: 'evidence-b',
+      sourceId: first.sourceId,
+      fingerprint: 'different-fingerprint',
+    });
+    const second = evidence({ evidenceId: 'evidence-c', sourceId: 'message-c' });
+    expect(repository.recordEvidence(first).isOk()).toBe(true);
+    expect(repository.recordEvidence(duplicateSource).isOk()).toBe(true);
+    expect(repository.recordEvidence(second).isOk()).toBe(true);
+
+    const candidateId = uuid();
+    expect(
+      repository
+        .createCandidate(
+          candidate({
+            candidateId,
+            createdFromEvidenceIds: [first.evidenceId, duplicateSource.evidenceId],
+          }),
+        )
+        .isErr(),
+    ).toBe(true);
+    expect(
+      repository
+        .createCandidate(
+          candidate({
+            candidateId,
+            createdFromEvidenceIds: [first.evidenceId, second.evidenceId],
+          }),
+        )
+        .isOk(),
+    ).toBe(true);
+    expect(repository.countDistinctEvidenceSources(candidateId)._unsafeUnwrap()).toBe(2);
+  });
+
+  it('rejects ready candidates without created evidence provenance', () => {
+    expect(
+      repository.createCandidate(
+        candidate({
+          status: 'ready',
+          createdFromEvidenceIds: [],
+        }),
+      ).isErr(),
+    ).toBe(true);
+  });
+
+  it('rejects direct SQL ready candidates without linked evidence provenance', () => {
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_candidates (
+            candidate_id, persona, kind, status, summary, proposed_behavior, confidence,
+            created_at, updated_at
+          ) VALUES (
+            'direct-ready-no-evidence', 'support', 'style', 'ready',
+            'Direct SQL should not bypass evidence.',
+            'Keep answers concise unless detail is explicitly requested.',
+            0.7, 1, 1
+          )`,
+        )
+        .run(),
+    ).toThrow();
+    expect(
+      db
+        .prepare(`SELECT candidate_id FROM behavior_candidates WHERE candidate_id = ?`)
+        .get('direct-ready-no-evidence'),
+    ).toBeUndefined();
+  });
+
+  it('rejects readiness transitions without persisted evidence provenance', () => {
+    const candidateId = 'unproven-candidate';
+    expect(repository.createCandidate(candidate({ candidateId })).isOk()).toBe(true);
+
+    expect(repository.transitionCandidate('support', candidateId, 'ready').isErr()).toBe(true);
+  });
+
+  it('rejects promotions for collecting candidates without persisted readiness evidence', () => {
+    const candidateId = 'collecting-no-evidence-candidate';
+    expect(repository.createCandidate(candidate({ candidateId })).isOk()).toBe(true);
+
+    expect(repository.createPromotion(promotion(candidateId)).isErr()).toBe(true);
+    expect(repository.findPromotionsByPersona('support')._unsafeUnwrap()).toEqual([]);
+  });
+
+  it('constrains behavior candidate evidence links to the candidate persona', () => {
+    const supportCandidate = candidate({ candidateId: 'support-candidate' });
+    const coachEvidence = evidence({ persona: 'coach', evidenceId: 'coach-evidence' });
+    expect(repository.createCandidate(supportCandidate).isOk()).toBe(true);
+    expect(repository.recordEvidence(coachEvidence).isOk()).toBe(true);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_candidate_evidence (
+            candidate_id, persona, evidence_id, created_at
+          ) VALUES ('support-candidate', 'coach', 'coach-evidence', 1)`,
+        )
+        .run(),
+    ).toThrow();
+  });
+
+  it('rejects direct SQL changes to accepted candidate evidence lineage', () => {
+    createActivePromotion({
+      candidateId: 'lineage-candidate',
+      promotionId: 'lineage-promotion',
+      activationId: 'lineage-activation',
+      promptArtifactId: 'lineage-prompt',
+      reloadId: 'lineage-reload',
+    });
+    const evidenceLinksBefore = db
+      .prepare(
+        `SELECT candidate_id, persona, evidence_id, created_at
+         FROM behavior_candidate_evidence
+         WHERE candidate_id = 'lineage-candidate'
+         ORDER BY evidence_id ASC`,
+      )
+      .all();
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE behavior_candidate_evidence
+           SET created_at = created_at + 1
+           WHERE candidate_id = 'lineage-candidate'`,
+        )
+        .run(),
+    ).toThrow(/immutable/);
+    expect(() =>
+      db
+        .prepare(
+          `DELETE FROM behavior_candidate_evidence
+           WHERE candidate_id = 'lineage-candidate'`,
+        )
+        .run(),
+    ).toThrow(/append-only/);
+
+    expect(
+      db
+        .prepare(
+          `SELECT candidate_id, persona, evidence_id, created_at
+           FROM behavior_candidate_evidence
+           WHERE candidate_id = 'lineage-candidate'
+           ORDER BY evidence_id ASC`,
+        )
+        .all(),
+    ).toEqual(evidenceLinksBefore);
+    expect(
+      db
+        .prepare(
+          `SELECT c.status AS candidate_status, p.status AS promotion_status, COUNT(ce.evidence_id) AS evidence_count
+           FROM behavior_candidates c
+           JOIN behavior_promotions p
+             ON p.persona = c.persona
+            AND p.candidate_id = c.candidate_id
+           JOIN behavior_candidate_evidence ce
+             ON ce.persona = c.persona
+            AND ce.candidate_id = c.candidate_id
+           WHERE c.candidate_id = 'lineage-candidate'
+           GROUP BY c.status, p.status`,
+        )
+        .get(),
+    ).toEqual({ candidate_status: 'ready', promotion_status: 'active', evidence_count: 2 });
+  });
+
+  it('keeps candidates and transitions isolated by persona and legal status flow', () => {
+    const [supportEvidenceA, supportEvidenceB] = recordDistinctEvidence();
+    const supportCandidate = candidate({
+      candidateId: 'support-candidate',
+      createdFromEvidenceIds: [supportEvidenceA.evidenceId, supportEvidenceB.evidenceId],
+    });
+    const coachCandidate = candidate({
+      candidateId: 'coach-candidate',
+      persona: 'coach',
+      summary: 'Prefer structured check-ins.',
+    });
+    expect(repository.createCandidate(supportCandidate).isOk()).toBe(true);
+    expect(repository.createCandidate(coachCandidate).isOk()).toBe(true);
+
+    expect(
+      repository.transitionCandidate('support', supportCandidate.candidateId, 'ready').isOk(),
+    ).toBe(true);
+    expect(
+      repository.transitionCandidate('support', supportCandidate.candidateId, 'active').isErr(),
+    ).toBe(true);
+    expect(
+      repository.transitionCandidate('coach', supportCandidate.candidateId, 'ready').isErr(),
+    ).toBe(true);
+
+    expect(repository.findCandidatesByPersona('support')._unsafeUnwrap()).toMatchObject([
+      { candidate_id: supportCandidate.candidateId, status: 'ready' },
+    ]);
+    expect(repository.findCandidatesByPersona('coach')._unsafeUnwrap()).toMatchObject([
+      { candidate_id: coachCandidate.candidateId, status: 'collecting' },
+    ]);
+  });
+
+  it('persists evaluation, activation, rollback lineage, expiry, and reopen transitions', () => {
+    const [firstEvidence, secondEvidence] = recordDistinctEvidence();
+    const candidateId = uuid();
+    expect(
+      repository
+        .createCandidate(
+          candidate({
+            candidateId,
+            status: 'ready',
+            createdFromEvidenceIds: [firstEvidence.evidenceId, secondEvidence.evidenceId],
+          }),
+        )
+        .isOk(),
+    ).toBe(true);
+
+    const createdPromotion = repository.createPromotion(promotion(candidateId));
+    expect(createdPromotion.isOk()).toBe(true);
+    const promotionId = createdPromotion._unsafeUnwrap().promotion_id;
+    expect(repository.transitionPromotion('support', promotionId, 'evaluating').isOk()).toBe(true);
+    expect(repository.transitionPromotion('support', promotionId, 'active').isErr()).toBe(true);
+    expect(repository.transitionPromotion('support', promotionId, 'approved').isOk()).toBe(true);
+    expect(repository.transitionPromotion('support', promotionId, 'activating').isOk()).toBe(true);
+    expect(repository.transitionPromotion('support', promotionId, 'active').isErr()).toBe(true);
+    expect(db.prepare(`SELECT activation_id FROM behavior_promotion_activations`).all()).toEqual(
+      [],
+    );
+    expect(
+      db.prepare(`SELECT status FROM behavior_promotions WHERE promotion_id = ?`).get(promotionId),
+    ).toEqual({ status: 'activating' });
+    expect(
+      repository
+        .activatePromotion({
+          persona: 'support',
+          promotionId,
+          activationId: 'activation-1',
+          promptArtifactId: 'prompt-artifact-1',
+          reloadId: 'reload-1',
+        })
+        .isOk(),
+    ).toBe(true);
+    expect(
+      db
+        .prepare(
+          `SELECT activation_id, activated_at FROM behavior_promotion_activations
+           WHERE promotion_id = ?`,
+        )
+        .get(promotionId),
+    ).toEqual({
+      activation_id: 'activation-1',
+      activated_at: db
+        .prepare(`SELECT updated_at FROM behavior_promotions WHERE promotion_id = ?`)
+        .get(promotionId)
+        ?.updated_at,
+    });
+    expect(repository.transitionPromotion('support', promotionId, 'rolled_back').isErr()).toBe(
+      true,
+    );
+    expect(db.prepare(`SELECT rollback_id FROM behavior_promotion_rollbacks`).all()).toEqual([]);
+    expect(
+      repository
+        .rollbackActivation({
+          persona: 'support',
+          activationId: 'activation-1',
+          rollbackId: 'rollback-1',
+          reason: 'operator-rejected',
+        })
+        .isOk(),
+    ).toBe(true);
+    expect(repository.transitionPromotion('support', promotionId, 'reopened').isOk()).toBe(true);
+    expect(repository.transitionPromotion('support', promotionId, 'approved').isErr()).toBe(true);
+    expect(repository.expireCandidate('support', candidateId).isOk()).toBe(true);
+
+    expect(repository.findPromotionsByPersona('support')._unsafeUnwrap()).toMatchObject([
+      { promotion_id: promotionId, status: 'reopened' },
+    ]);
+    expect(
+      db.prepare(`SELECT status FROM behavior_candidates WHERE candidate_id = ?`).get(candidateId),
+    ).toEqual({
+      status: 'expired',
+    });
+    expect(
+      db.prepare(`SELECT rollback_id, reason FROM behavior_promotion_rollbacks`).all(),
+    ).toEqual([{ rollback_id: 'rollback-1', reason: 'operator-rejected' }]);
+  });
+
+  it('rejects direct SQL changes to activation and rollback provenance rows', () => {
+    createActivePromotion({
+      candidateId: 'immutable-candidate',
+      promotionId: 'immutable-promotion',
+      activationId: 'immutable-activation',
+      promptArtifactId: 'immutable-prompt',
+      reloadId: 'immutable-reload',
+    });
+    const activationBefore = db
+      .prepare(
+        `SELECT activation_id, persona, promotion_id, prompt_artifact_id, reload_id, activated_at
+         FROM behavior_promotion_activations
+         WHERE activation_id = 'immutable-activation'`,
+      )
+      .get() as Record<string, unknown>;
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE behavior_promotion_activations
+           SET reload_id = 'immutable-reload-mutated', activated_at = activated_at + 1
+           WHERE activation_id = 'immutable-activation'`,
+        )
+        .run(),
+    ).toThrow(/immutable/);
+    expect(
+      db
+        .prepare(
+          `SELECT activation_id, persona, promotion_id, prompt_artifact_id, reload_id, activated_at
+           FROM behavior_promotion_activations
+           WHERE activation_id = 'immutable-activation'`,
+        )
+        .get(),
+    ).toEqual(activationBefore);
+    expect(() =>
+      db
+        .prepare(
+          `DELETE FROM behavior_promotion_activations
+           WHERE activation_id = 'immutable-activation'`,
+        )
+        .run(),
+    ).toThrow(/append-only/);
+    expect(
+      db
+        .prepare(
+          `SELECT p.status AS promotion_status, a.activation_id, a.persona, a.promotion_id,
+                  a.prompt_artifact_id, a.reload_id, a.activated_at
+           FROM behavior_promotions p
+           JOIN behavior_promotion_activations a
+             ON a.persona = p.persona
+            AND a.promotion_id = p.promotion_id
+           WHERE a.activation_id = 'immutable-activation'`,
+        )
+        .get(),
+    ).toEqual({ promotion_status: 'active', ...activationBefore });
+
+    expect(
+      repository
+        .rollbackActivation({
+          persona: 'support',
+          activationId: 'immutable-activation',
+          rollbackId: 'immutable-rollback',
+          reason: 'operator-rejected',
+        })
+        .isOk(),
+    ).toBe(true);
+    const rollbackBefore = db
+      .prepare(
+        `SELECT rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+         FROM behavior_promotion_rollbacks
+         WHERE rollback_id = 'immutable-rollback'`,
+      )
+      .get() as Record<string, unknown>;
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE behavior_promotion_rollbacks
+           SET reason = 'operator-corrected', rolled_back_at = rolled_back_at + 1
+           WHERE rollback_id = 'immutable-rollback'`,
+        )
+        .run(),
+    ).toThrow(/immutable/);
+    expect(
+      db
+        .prepare(
+          `SELECT rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+           FROM behavior_promotion_rollbacks
+           WHERE rollback_id = 'immutable-rollback'`,
+        )
+        .get(),
+    ).toEqual(rollbackBefore);
+    expect(() =>
+      db
+        .prepare(
+          `DELETE FROM behavior_promotion_rollbacks
+           WHERE rollback_id = 'immutable-rollback'`,
+        )
+        .run(),
+    ).toThrow(/append-only/);
+    expect(
+      db
+        .prepare(
+          `SELECT p.status AS promotion_status, r.rollback_id, r.persona, r.activation_id,
+                  r.promotion_id, r.reason, r.rolled_back_at
+           FROM behavior_promotions p
+           JOIN behavior_promotion_rollbacks r
+             ON r.persona = p.persona
+            AND r.promotion_id = p.promotion_id
+           WHERE r.rollback_id = 'immutable-rollback'`,
+        )
+        .get(),
+    ).toEqual({ promotion_status: 'rolled_back', ...rollbackBefore });
+  });
+
+  it('rolls back rollback provenance when promotion update does not affect an active row', () => {
+    createActivePromotion({
+      candidateId: 'rollback-atomic-candidate',
+      promotionId: 'rollback-atomic-promotion',
+      activationId: 'rollback-atomic-activation',
+      promptArtifactId: 'rollback-atomic-prompt',
+      reloadId: 'rollback-atomic-reload',
+    });
+    db.prepare(`DROP TRIGGER behavior_promotions_guard_transitions`).run();
+    db.prepare(
+      `UPDATE behavior_promotions
+       SET status = 'reopened', updated_at = updated_at + 1
+       WHERE promotion_id = 'rollback-atomic-promotion'`,
+    ).run();
+    db.prepare(`DROP TRIGGER behavior_promotion_rollbacks_guard_active_lineage`).run();
+
+    const result = repository.rollbackActivation({
+      persona: 'support',
+      activationId: 'rollback-atomic-activation',
+      rollbackId: 'rollback-atomic-second',
+      reason: 'operator-rejected',
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(
+      db
+        .prepare(
+          `SELECT rollback_id FROM behavior_promotion_rollbacks
+           WHERE rollback_id = 'rollback-atomic-second'`,
+        )
+        .get(),
+    ).toBeUndefined();
+  });
+
+  it('rejects rollback rows unless the referenced activation promotion is active', () => {
+    const [firstEvidence, secondEvidence] = recordDistinctEvidence();
+    const candidateId = 'rollback-active-candidate';
+    expect(
+      repository
+        .createCandidate(
+          candidate({
+            candidateId,
+            status: 'ready',
+            createdFromEvidenceIds: [firstEvidence.evidenceId, secondEvidence.evidenceId],
+          }),
+        )
+        .isOk(),
+    ).toBe(true);
+    expect(
+      repository
+        .createPromotion(promotion(candidateId, { promotionId: 'rollback-active-promotion' }))
+        .isOk(),
+    ).toBe(true);
+    for (const status of ['evaluating', 'approved', 'activating'] as const) {
+      expect(repository.transitionPromotion('support', 'rollback-active-promotion', status).isOk())
+        .toBe(true);
+    }
+    db.prepare(
+      `INSERT INTO behavior_promotion_activations (
+        activation_id, persona, promotion_id, prompt_artifact_id, reload_id, activated_at
+      ) VALUES (
+        'rollback-active-activation', 'support', 'rollback-active-promotion',
+        'rollback-active-prompt', 'rollback-active-reload', 1
+      )`,
+    ).run();
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_promotion_rollbacks (
+            rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+          ) VALUES (
+            'rollback-inactive-direct', 'support', 'rollback-active-activation',
+            'rollback-active-promotion', 'operator-rejected', 2
+          )`,
+        )
+        .run(),
+    ).toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT rollback_id FROM behavior_promotion_rollbacks
+           WHERE rollback_id = 'rollback-inactive-direct'`,
+        )
+        .get(),
+    ).toBeUndefined();
+
+    expect(
+      repository
+        .activatePromotion({
+          persona: 'support',
+          promotionId: 'rollback-active-promotion',
+          activationId: 'rollback-active-second-activation',
+          promptArtifactId: 'rollback-active-second-prompt',
+          reloadId: 'rollback-active-second-reload',
+        })
+        .isOk(),
+    ).toBe(true);
+    const activePromotion = db
+      .prepare(
+        `SELECT updated_at FROM behavior_promotions
+         WHERE promotion_id = 'rollback-active-promotion'`,
+      )
+      .get() as { updated_at: number };
+    const rollbackAt = activePromotion.updated_at + 1;
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_promotion_rollbacks (
+            rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+          ) VALUES (
+            'rollback-active-direct', 'support', 'rollback-active-activation',
+            'rollback-active-promotion', 'operator-rejected', ?
+          )`,
+        )
+        .run(rollbackAt),
+    ).not.toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT rollback_id FROM behavior_promotion_rollbacks
+           WHERE rollback_id = 'rollback-active-direct'`,
+        )
+        .get(),
+    ).toEqual({ rollback_id: 'rollback-active-direct' });
+  });
+
+  it('rejects rollback rows after the referenced activation promotion is rolled back', () => {
+    const [firstEvidence, secondEvidence] = recordDistinctEvidence();
+    const candidateId = 'rollback-after-candidate';
+    expect(
+      repository
+        .createCandidate(
+          candidate({
+            candidateId,
+            status: 'ready',
+            createdFromEvidenceIds: [firstEvidence.evidenceId, secondEvidence.evidenceId],
+          }),
+        )
+        .isOk(),
+    ).toBe(true);
+    expect(
+      repository
+        .createPromotion(promotion(candidateId, { promotionId: 'rollback-after-promotion' }))
+        .isOk(),
+    ).toBe(true);
+    for (const status of ['evaluating', 'approved', 'activating'] as const) {
+      expect(repository.transitionPromotion('support', 'rollback-after-promotion', status).isOk())
+        .toBe(true);
+    }
+    const activatingPromotion = db
+      .prepare(
+        `SELECT updated_at FROM behavior_promotions
+         WHERE promotion_id = 'rollback-after-promotion'`,
+      )
+      .get() as { updated_at: number };
+    const activeAt = activatingPromotion.updated_at + 1;
+    db.prepare(
+      `INSERT INTO behavior_promotion_activations (
+        activation_id, persona, promotion_id, prompt_artifact_id, reload_id, activated_at
+      ) VALUES (
+        'rollback-after-activation-a', 'support', 'rollback-after-promotion',
+        'rollback-after-prompt-a', 'rollback-after-reload-a', ?
+      )`,
+    ).run(activeAt);
+    db.prepare(
+      `INSERT INTO behavior_promotion_activations (
+        activation_id, persona, promotion_id, prompt_artifact_id, reload_id, activated_at
+      ) VALUES (
+        'rollback-after-activation-b', 'support', 'rollback-after-promotion',
+        'rollback-after-prompt-b', 'rollback-after-reload-b', ?
+      )`,
+    ).run(activeAt);
+    db.prepare(
+      `UPDATE behavior_promotions
+       SET status = 'active', updated_at = ?
+       WHERE promotion_id = 'rollback-after-promotion'`,
+    ).run(activeAt);
+    const activePromotion = db
+      .prepare(
+        `SELECT updated_at FROM behavior_promotions
+         WHERE promotion_id = 'rollback-after-promotion'`,
+      )
+      .get() as { updated_at: number };
+    const rollbackAt = activePromotion.updated_at + 1;
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_promotion_rollbacks (
+            rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+          ) VALUES (
+            'rollback-after-direct', 'support', 'rollback-after-activation-a',
+            'rollback-after-promotion', 'operator-rejected', ?
+          )`,
+        )
+        .run(rollbackAt),
+    ).not.toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT rollback_id FROM behavior_promotion_rollbacks
+           WHERE rollback_id = 'rollback-after-direct'`,
+        )
+        .get(),
+    ).toEqual({ rollback_id: 'rollback-after-direct' });
+    expect(
+      db
+        .prepare(
+          `UPDATE behavior_promotions
+           SET status = 'rolled_back', updated_at = ?
+           WHERE promotion_id = 'rollback-after-promotion'`,
+        )
+        .run(rollbackAt).changes,
+    ).toBe(1);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_promotion_rollbacks (
+            rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+          ) VALUES (
+            'rollback-inactive-direct', 'support', 'rollback-after-activation-b',
+            'rollback-after-promotion', 'operator-rejected', 2
+          )`,
+        )
+        .run(),
+    ).toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT rollback_id FROM behavior_promotion_rollbacks
+           WHERE rollback_id = 'rollback-inactive-direct'`,
+        )
+        .get(),
+    ).toBeUndefined();
+  });
+
+  it('rejects rollback rows that cross-link an activation to a different promotion', () => {
+    const [firstEvidenceA, firstEvidenceB] = recordDistinctEvidence();
+    const firstCandidateId = 'rollback-lineage-candidate-a';
+    expect(
+      repository
+        .createCandidate(
+          candidate({
+            candidateId: firstCandidateId,
+            status: 'ready',
+            createdFromEvidenceIds: [firstEvidenceA.evidenceId, firstEvidenceB.evidenceId],
+          }),
+        )
+        .isOk(),
+    ).toBe(true);
+    const firstPromotionId = repository
+      .createPromotion(promotion(firstCandidateId, { promotionId: 'rollback-lineage-promotion-a' }))
+      ._unsafeUnwrap().promotion_id;
+    expect(repository.transitionPromotion('support', firstPromotionId, 'evaluating').isOk()).toBe(
+      true,
+    );
+    expect(repository.transitionPromotion('support', firstPromotionId, 'approved').isOk()).toBe(
+      true,
+    );
+    expect(repository.transitionPromotion('support', firstPromotionId, 'activating').isOk()).toBe(
+      true,
+    );
+    expect(
+      repository
+        .activatePromotion({
+          persona: 'support',
+          promotionId: firstPromotionId,
+          activationId: 'rollback-lineage-activation-a',
+          promptArtifactId: 'rollback-lineage-prompt-a',
+          reloadId: 'rollback-lineage-reload-a',
+        })
+        .isOk(),
+    ).toBe(true);
+
+    const [secondEvidenceA, secondEvidenceB] = recordDistinctEvidence();
+    const secondCandidateId = 'rollback-lineage-candidate-b';
+    expect(
+      repository
+        .createCandidate(
+          candidate({
+            candidateId: secondCandidateId,
+            status: 'ready',
+            createdFromEvidenceIds: [secondEvidenceA.evidenceId, secondEvidenceB.evidenceId],
+          }),
+        )
+        .isOk(),
+    ).toBe(true);
+    const secondPromotionId = repository
+      .createPromotion(
+        promotion(secondCandidateId, { promotionId: 'rollback-lineage-promotion-b' }),
+      )
+      ._unsafeUnwrap().promotion_id;
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO behavior_promotion_rollbacks (
+            rollback_id, persona, activation_id, promotion_id, reason, rolled_back_at
+          ) VALUES (
+            'rollback-lineage-mismatch', 'support', 'rollback-lineage-activation-a',
+            ?, 'operator-rejected', 1
+          )`,
+        )
+        .run(secondPromotionId),
+    ).toThrow();
+    expect(
+      db
+        .prepare(
+          `SELECT rollback_id FROM behavior_promotion_rollbacks
+           WHERE rollback_id = 'rollback-lineage-mismatch'`,
+        )
+        .get(),
+    ).toBeUndefined();
+  });
+
+  it('seeds the monotonic write clock from persisted behavior ledger timestamps', () => {
+    const futureTs = Date.now() + 60_000;
+    db.prepare(
+      `INSERT INTO behavior_candidates (
+        candidate_id, persona, kind, status, summary, proposed_behavior, confidence,
+        created_at, updated_at
+      ) VALUES (
+        'future-candidate', 'support', 'style', 'collecting',
+        'Future timestamp fixture.', 'Prefer concise responses.', 0.5, ?, ?
+      )`,
+    ).run(futureTs, futureTs);
+
+    BaseRepository.__resetMonotonicClockForTests();
+    BaseRepository.seedMonotonicClockFromDb(db);
+    const afterRestart = new BehaviorSignalRepository(db);
+
+    const transitioned = afterRestart.transitionCandidate('support', 'future-candidate', 'rejected');
+    expect(transitioned.isOk()).toBe(true);
+    expect(transitioned._unsafeUnwrap().updated_at).toBeGreaterThan(futureTs);
+  });
+});

--- a/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
+++ b/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
@@ -863,8 +863,8 @@ describe('lifecycle event persistence', () => {
         import.meta.dirname,
         '../../../../../src/core/database/migrations',
       );
-      expect(runMigrations(legacyDb, currentMigrations)._unsafeUnwrap()).toBe(3);
-      expect(legacyDb.pragma('user_version', { simple: true })).toBe(17);
+      expect(runMigrations(legacyDb, currentMigrations)._unsafeUnwrap()).toBe(4);
+      expect(legacyDb.pragma('user_version', { simple: true })).toBe(18);
       const upgradedDeliveries = new LifecycleDeliveryRepository(legacyDb, () => upgradeLeaseNow);
       const terminal = upgradedDeliveries
         .fail(


### PR DESCRIPTION
## Summary
- add behavior ledger migration for evidence, candidates, promotions, activations, and rollbacks
- add BehaviorSignalRepository and lifecycle behavior types
- enforce append-only provenance and direct-SQL transition guards with focused tests

## Verification
- npx vitest run tests/unit/core/database/repositories/behavior-signal-repository.test.ts tests/unit/core/database/migrations/runner.test.ts
- npx eslint src/core/database/repositories/behavior-signal-repository.ts src/core/database/repositories/base-repository.ts src/core/database/repositories/index.ts src/lifecycle/behavior tests/unit/core/database/repositories/behavior-signal-repository.test.ts tests/unit/core/database/migrations/runner.test.ts
- npm run build
- git diff --check

## Review
- GPT-5.5/xhigh review: PASS, no Critical/High/Medium blockers