### PR TITLE
feat(lifecycle): publish run tool outbound events

### DIFF
--- a/src/core/database/repositories/message-repository.ts
+++ b/src/core/database/repositories/message-repository.ts
@@ -40,6 +40,7 @@ export class MessageRepository extends BaseRepository {
   private readonly findLatestByThreadStmt: Database.Statement;
   private readonly findLatestByThreadSinceStmt: Database.Statement;
   private readonly findByIdempotencyKeyStmt: Database.Statement;
+  private readonly deleteByIdempotencyKeyStmt: Database.Statement;
 
   constructor(db: Database.Database) {
     super(db);
@@ -82,6 +83,10 @@ export class MessageRepository extends BaseRepository {
 
     this.findByIdempotencyKeyStmt = db.prepare(`
       SELECT * FROM messages WHERE idempotency_key = ?
+    `);
+
+    this.deleteByIdempotencyKeyStmt = db.prepare(`
+      DELETE FROM messages WHERE idempotency_key = ?
     `);
   }
 
@@ -206,5 +211,27 @@ export class MessageRepository extends BaseRepository {
    */
   existsByIdempotencyKey(key: string): boolean {
     return this.findByIdempotencyKeyStmt.get(key) !== undefined;
+  }
+
+  /**
+   * Deletes a message reservation by idempotency key.
+   *
+   * This is intentionally narrow: outbound final delivery reserves an
+   * idempotency key before external send so post-send finalization retries do
+   * not duplicate delivery, but a known send failure must make that key
+   * retryable again.
+   */
+  deleteByIdempotencyKey(key: string): Result<number, DbError> {
+    try {
+      const result = this.deleteByIdempotencyKeyStmt.run(key);
+      return ok(result.changes);
+    } catch (cause) {
+      return err(
+        new DbError(
+          `Failed to delete message by idempotency key: ${String(cause)}`,
+          cause instanceof Error ? cause : undefined,
+        ),
+      );
+    }
   }
 }

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -18,7 +18,13 @@ import {
 import { getProviderAffinityResetAt } from '../threads/thread-metadata.js';
 import { readScheduleOriginExternalId } from './schedule-thread-utils.js';
 import { buildTimeContext } from '../core/time-context.js';
+import type { ReasoningEffort } from '../core/config/config-types.js';
 import { formatToolCall } from './tool-name-formatter.js';
+import {
+  buildLifecycleContentPreview,
+  resolveLifecycleOutboundContent,
+} from '../lifecycle/outbound-content-preview.js';
+import type { ChannelConnector } from '../channels/channel-types.js';
 import type {
   AgentUsage,
   ContextUsage,
@@ -26,11 +32,23 @@ import type {
   CanonicalMcpSdkServer,
   CanonicalMcpServer,
 } from '../providers/provider-types.js';
+import type { LifecycleEventEnvelope } from '../lifecycle/contracts/index.js';
+import type { TransactionContext } from '../lifecycle/transaction-context.js';
 import type { StartedObservationHandle } from '../observability/langfuse/observability-types.js';
 import { generateBridgeSecret, TALOND_BRIDGE_SECRET_ENV } from '../tools/host-tools-bridge-auth.js';
 
 /** Default maximum time (ms) a provider query (SDK or CLI) may run before being aborted. */
 const DEFAULT_QUERY_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+interface OutboundDeliveryIdentity {
+  readonly messageId: string;
+  readonly idempotencyKey: string;
+}
+
+interface PendingNoIdProviderToolObservation {
+  readonly observation: StartedObservationHandle;
+  readonly toolCallId: string;
+}
 
 class AgentQueryAttemptError extends Error {
   constructor(
@@ -112,7 +130,7 @@ export class AgentRunner {
       loadedPersona.config.queryTimeoutMinutes !== undefined
         ? loadedPersona.config.queryTimeoutMinutes * 60 * 1000
         : this.queryTimeoutMs;
-    const model = loadedPersona.config.model;
+    let model = loadedPersona.config.model;
     const reasoningEffort = loadedPersona.config.reasoningEffort;
 
     const threadResult = this.ctx.repos.thread.findById(item.threadId);
@@ -146,11 +164,77 @@ export class AgentRunner {
         : [affinityProviderName, personaProviderName, configuredDefaultProvider]
     ).filter((name): name is string => typeof name === 'string' && name.length > 0);
 
-    const providerEntry = this.ctx.providerRegistry.getDefault(preferredProviderOrder);
+    let providerEntry = this.ctx.providerRegistry.getDefault(preferredProviderOrder);
     if (!providerEntry) {
       this.failA2ATask(a2aTaskId, 'NO_PROVIDER', 'No enabled agent runner provider is configured');
       return err(new Error('No enabled agent runner provider is configured'));
     }
+
+    const runId = uuidv4();
+    const runInterception = this.interceptRunBeforeExecute({
+      runId,
+      threadId: item.threadId,
+      personaName,
+      provider: providerEntry.provider.name,
+      model,
+      queueItemId: item.id,
+      itemType: item.type,
+    });
+    if (runInterception.isErr()) {
+      const finalized = this.insertAndFinalizePreExecutionFailedRun(
+        runId,
+        {
+          threadId: item.threadId,
+          personaId,
+          queueItemId: item.id,
+          provider: providerEntry.provider.name,
+          model,
+          reasoningEffort,
+          error: runInterception.error.message,
+        },
+        personaName,
+      );
+      if (finalized.isErr()) {
+        this.ctx.logger.error(
+          { runId, err: finalized.error.message },
+          'agent-runner: failed to finalize blocked run',
+        );
+      }
+      this.failA2ATask(a2aTaskId, 'RUN_BLOCKED', runInterception.error.message);
+      return err(runInterception.error);
+    }
+    const lifecycleRunContextAdditions = runInterception.value.contextAdditions;
+    if (runInterception.value.provider !== providerEntry.provider.name) {
+      const transformedProvider = this.ctx.providerRegistry.get(runInterception.value.provider);
+      if (!transformedProvider) {
+        const error = new Error(
+          `Lifecycle run interceptor selected unavailable provider "${runInterception.value.provider}"`,
+        );
+        const finalized = this.insertAndFinalizePreExecutionFailedRun(
+          runId,
+          {
+            threadId: item.threadId,
+            personaId,
+            queueItemId: item.id,
+            provider: runInterception.value.provider,
+            model: runInterception.value.model,
+            reasoningEffort,
+            error: error.message,
+          },
+          personaName,
+        );
+        if (finalized.isErr()) {
+          this.ctx.logger.error(
+            { runId, err: finalized.error.message },
+            'agent-runner: failed to finalize unavailable transformed provider run',
+          );
+        }
+        this.failA2ATask(a2aTaskId, 'NO_PROVIDER', error.message);
+        return err(error);
+      }
+      providerEntry = transformedProvider;
+    }
+    model = runInterception.value.model;
 
     const strategy = providerEntry.provider.createExecutionStrategy();
     const sessionProviderName = providerEntry.provider.name;
@@ -223,10 +307,9 @@ export class AgentRunner {
       }
     }
 
-    const runId = uuidv4();
     const now = Date.now();
 
-    const runInsert = this.ctx.repos.run.insert({
+    const runInput = {
       id: runId,
       thread_id: item.threadId,
       persona_id: personaId,
@@ -246,7 +329,29 @@ export class AgentRunner {
       error: null,
       started_at: now,
       ended_at: null,
-    });
+    } as const;
+
+    const runInsert = this.ctx.lifecycleRuntime
+      ? this.ctx.lifecycleRuntime.transaction((transaction) => {
+          const inserted = this.ctx.repos.run.insert(runInput);
+          if (inserted.isErr()) return err(inserted.error);
+          const published = this.publishRunEvent(
+            'run.started.v1',
+            {
+              runId,
+              threadId: item.threadId,
+              personaId,
+              queueItemId: item.id,
+              provider: providerEntry.provider.name,
+              model,
+              status: 'running',
+            },
+            personaName,
+            transaction,
+          );
+          return published.isErr() ? err(published.error) : ok(inserted.value);
+        })
+      : this.ctx.repos.run.insert(runInput);
 
     if (runInsert.isErr()) {
       // Mark A2A task as failed — run record creation failed, so the task cannot proceed.
@@ -283,7 +388,7 @@ export class AgentRunner {
       bridgeSecret,
     });
 
-    const runInput = {
+    const observedRunInput = {
       content,
       itemType: item.type,
       persona: personaName,
@@ -303,7 +408,7 @@ export class AgentRunner {
         {
           type: 'agent',
           name: 'foreground-run',
-          input: runInput,
+          input: observedRunInput,
           metadata: runMetadata,
           trace: {
             sessionId: item.threadId,
@@ -313,7 +418,7 @@ export class AgentRunner {
               `itemType:${item.type}`,
               `provider:${providerEntry.provider.name}`,
             ],
-            input: runInput,
+            input: observedRunInput,
             metadata: runMetadata,
           },
         },
@@ -513,8 +618,17 @@ export class AgentRunner {
               externalId &&
               item.payload.type !== 'schedule'
             ) {
-              const waitingResult = await connector.send(externalId, {
-                body: 'Thinking...',
+              const waitingResult = await this.sendLifecycleOutboundMessage({
+                content: 'Thinking...',
+                connector,
+                externalId,
+                runId,
+                threadId: item.threadId,
+                personaName,
+                channelName,
+                itemOrigin: 'run',
+                itemType: 'message',
+                messageId: `outbound:${item.id}:waiting`,
               });
               if (waitingResult.isErr()) {
                 this.ctx.logger.debug(
@@ -543,6 +657,11 @@ export class AgentRunner {
                 channelContext,
                 timeContext,
               ];
+              if (lifecycleRunContextAdditions) {
+                systemPromptParts.push(
+                  `Lifecycle Context Additions:\n${JSON.stringify(lifecycleRunContextAdditions)}`,
+                );
+              }
               if (!resumeSessionId) {
                 const previous = await getPreviousContext();
                 if (previous.text) {
@@ -700,7 +819,7 @@ export class AgentRunner {
                   const pendingProviderToolTasks: Array<Promise<void>> = [];
                   // FIFO queue for tool events that lack a toolUseId (e.g. claude-code tool_use/tool_result
                   // streaming events). Events are sequential so FIFO order correctly pairs starts with ends.
-                  const pendingNoIdToolObservations: StartedObservationHandle[] = [];
+                  const pendingNoIdToolObservations: PendingNoIdProviderToolObservation[] = [];
 
                   // Materialize dynamic auth (OAuth bearers) on HTTP MCP
                   // entries before handing them to the provider. Providers
@@ -781,14 +900,33 @@ export class AgentRunner {
                           ) {
                             // Flush preceding text first, then show tool description (issue #102 + #108).
                             if (outputText) {
-                              const flushResult = await connector.send(externalId, {
-                                body: outputText,
+                              const originalOutputText = outputText;
+                              const flushIdentity = this.runOutboundDeliveryIdentity(
+                                item.id,
+                                `stream:${streamOutboundMessageIndex++}`,
+                              );
+                              const flushResult = await this.sendLifecycleOutboundMessage({
+                                content: outputText,
+                                connector,
+                                externalId,
+                                runId,
+                                threadId: item.threadId,
+                                personaName,
+                                channelName,
+                                itemOrigin: 'run',
+                                itemType: 'message',
+                                messageId: flushIdentity.messageId,
+                                idempotencyKey: flushIdentity.idempotencyKey,
                               });
                               if (flushResult.isErr()) {
                                 throw new Error(
                                   `channel send failed: ${flushResult.error.message}`,
                                 );
                               }
+                              fullOutputText = fullOutputText.endsWith(originalOutputText)
+                                ? `${fullOutputText.slice(0, -originalOutputText.length)}${flushResult.value.content}`
+                                : fullOutputText;
+                              hasReservedIntermediateTextOutbound = true;
                               outputText = '';
                               fullOutputText += '\n\n';
                             }
@@ -801,8 +939,22 @@ export class AgentRunner {
                                 event.messageType === 'mcp_tool_use' && event.serverName
                                   ? `mcp__${event.serverName}__${event.tool ?? ''}`
                                   : (event.tool ?? '');
-                              const toolCallResult = await connector.send(externalId, {
-                                body: formatToolCall(toolCallId),
+                              const toolNoticeIdentity = this.runOutboundDeliveryIdentity(
+                                item.id,
+                                `tool:${streamOutboundMessageIndex++}`,
+                              );
+                              const toolCallResult = await this.sendLifecycleOutboundMessage({
+                                content: formatToolCall(toolCallId),
+                                connector,
+                                externalId,
+                                runId,
+                                threadId: item.threadId,
+                                personaName,
+                                channelName,
+                                itemOrigin: 'run',
+                                itemType: 'message',
+                                messageId: toolNoticeIdentity.messageId,
+                                idempotencyKey: toolNoticeIdentity.idempotencyKey,
                               });
                               if (toolCallResult.isErr()) {
                                 this.ctx.logger.warn(
@@ -818,6 +970,7 @@ export class AgentRunner {
                               runId,
                               threadId: item.threadId,
                               provider: providerEntry.provider.name,
+                              persona: personaName,
                             },
                             activeProviderToolObservations,
                             ignoredProviderToolUseIds,
@@ -929,6 +1082,10 @@ export class AgentRunner {
 
             let outputText = '';
             let fullOutputText = '';
+            const finalOutboundIdentity = this.runOutboundDeliveryIdentity(item.id);
+            let finalOutboundReservationHandled = false;
+            let streamOutboundMessageIndex = 0;
+            let hasReservedIntermediateTextOutbound = false;
             let resultSessionId: string | undefined;
             let usage: AgentUsage = {
               inputTokens: 0,
@@ -1044,35 +1201,61 @@ export class AgentRunner {
             } else if (connector !== undefined && externalId && outputText) {
               // Send remaining text (final block). Intermediate blocks were flushed
               // during the stream when tool_use events were encountered (issue #102).
-              const sendResult = await connector.send(externalId, {
-                body: outputText,
+              const sendResult = await this.sendLifecycleOutboundMessage({
+                content: outputText,
+                persistedContent: fullOutputText,
+                connector,
+                externalId,
+                runId,
+                threadId: item.threadId,
+                personaName,
+                channelName,
+                itemOrigin: 'run',
+                itemType: 'message',
+                messageId: finalOutboundIdentity.messageId,
+                idempotencyKey: finalOutboundIdentity.idempotencyKey,
+                ...(hasReservedIntermediateTextOutbound
+                  ? { reservationContent: outputText }
+                  : {}),
               });
               if (sendResult.isErr()) {
                 throw new Error(`channel send failed: ${sendResult.error.message}`);
               }
+              outputText = sendResult.value.content;
+              fullOutputText = sendResult.value.fullContent;
+              finalOutboundReservationHandled = true;
             }
 
-            // Persist the outbound message BEFORE context rotation so that a fast
-            // user reply cannot be inserted ahead of the assistant turn in the DB.
-            // The message is stored immediately after delivery (issue #164).
-            if (!isA2ATask) {
-              this.ctx.repos.message.insert({
-                id: uuidv4(),
+            // When streamed text was already flushed as physical outbound rows
+            // and the provider emits no final text segment, do not synthesize a
+            // final transcript row containing the previously flushed content.
+            if (
+              !isA2ATask &&
+              !finalOutboundReservationHandled &&
+              !hasReservedIntermediateTextOutbound
+            ) {
+              const persistedOutbound = this.ctx.repos.message.insert({
+                id: finalOutboundIdentity.messageId,
                 thread_id: item.threadId,
                 direction: 'outbound',
                 content: JSON.stringify({ body: fullOutputText }),
-                idempotency_key: `outbound:${runId}`,
+                idempotency_key: finalOutboundIdentity.idempotencyKey,
                 provider_id: null,
                 run_id: runId,
               });
+              if (persistedOutbound.isErr()) {
+                throw new Error(
+                  `failed to persist outbound message: ${persistedOutbound.error.message}`,
+                );
+              }
             }
 
             // Check if context needs rotation (rolling window).
-            // Runs AFTER connector.send() and message.insert() so the user receives
-            // their response immediately — context rotation may invoke a summarizer
-            // LLM call that takes 5-15 s. The queue item stays in-flight (claimed)
-            // until run() returns, so the next item for this thread cannot be
-            // picked up until rotation completes, preserving per-thread ordering.
+            // Runs AFTER connector.send() and the final outbound reservation so the
+            // user receives their response immediately — context rotation may invoke
+            // a summarizer LLM call that takes 5-15 s. The queue item stays in-flight
+            // (claimed) until run() returns, so the next item for this thread cannot
+            // be picked up until rotation completes, preserving per-thread ordering.
             // (issue #164)
             if (this.ctx.contextRoller && enabledContextManagement) {
               // Gate rotation on per-step usage when the provider reports
@@ -1201,17 +1384,40 @@ export class AgentRunner {
               },
             });
 
-            this.ctx.repos.run.updateStatus(runId, 'completed', {
-              ended_at: Date.now(),
-            });
+            const finalized = this.finalizeRunWithLifecycle(
+              runId,
+              'completed',
+              {
+                threadId: item.threadId,
+                personaId,
+                queueItemId: item.id,
+                provider: providerEntry.provider.name,
+                model,
+              },
+              personaName,
+              { ended_at: Date.now() },
+            );
+            if (finalized.isErr()) {
+              throw new Error(`failed to finalize completed run: ${finalized.error.message}`);
+            }
             runFinalized = true;
           } catch (cause) {
             if (typingInterval) clearInterval(typingInterval);
             const error = this.toError(cause);
-            this.ctx.repos.run.updateStatus(runId, 'failed', {
-              ended_at: Date.now(),
-              error: error.message,
-            });
+            const finalized = this.finalizeRunWithLifecycle(
+              runId,
+              'failed',
+              {
+                threadId: item.threadId,
+                personaId,
+                queueItemId: item.id,
+                provider: providerEntry.provider.name,
+                model,
+                error: error.message,
+              },
+              personaName,
+              { ended_at: Date.now(), error: error.message },
+            );
             // Mark A2A task as failed on agent execution error.
             if (isA2ATask && a2aTaskId) {
               this.ctx.repos.a2aTask
@@ -1223,6 +1429,11 @@ export class AgentRunner {
                   );
                 });
             }
+            if (finalized.isErr()) {
+              throw new Error(
+                `${error.message}; additionally failed to finalize failed run: ${finalized.error.message}`,
+              );
+            }
             runFinalized = true;
             throw error;
           }
@@ -1233,15 +1444,495 @@ export class AgentRunner {
     } catch (cause) {
       const error = this.toError(cause);
       if (!runFinalized) {
-        this.ctx.repos.run.updateStatus(runId, 'failed', {
-          ended_at: Date.now(),
-          error: error.message,
-        });
+        const finalized = this.finalizeRunWithLifecycle(
+          runId,
+          'failed',
+          {
+            threadId: item.threadId,
+            personaId,
+            queueItemId: item.id,
+            provider: providerEntry.provider.name,
+            model,
+            error: error.message,
+          },
+          personaName,
+          { ended_at: Date.now(), error: error.message },
+        );
+        if (finalized.isErr()) {
+          return err(
+            new Error(
+              `${error.message}; additionally failed to finalize failed run: ${finalized.error.message}`,
+            ),
+          );
+        }
       }
       return err(error);
     } finally {
       this.ctx.hostToolsBridge.unregisterRunAuthentication?.(runId);
     }
+  }
+
+  private interceptRunBeforeExecute(input: {
+    runId: string;
+    threadId: string;
+    personaName: string;
+    provider: string;
+    model: string;
+    queueItemId: string;
+    itemType: string;
+  }): Result<
+    { provider: string; model: string; contextAdditions?: Record<string, unknown> },
+    Error
+  > {
+    if (!this.ctx.lifecycleRuntime) {
+      return ok({ provider: input.provider, model: input.model });
+    }
+
+    const interception = this.ctx.lifecycleRuntime.intercept(
+      {
+        persona: input.personaName,
+        hook: 'run.before_execute',
+        itemOrigin: 'run',
+        itemType: 'run',
+      },
+      {
+        version: 'v1',
+        interceptionId: uuidv4(),
+        hook: 'run.before_execute',
+        context: this.lifecycleContext('run', input.runId, input.queueItemId, 'run'),
+        input: {
+          runId: input.runId,
+          provider: input.provider,
+          model: input.model,
+          persona: input.personaName,
+        },
+      },
+    );
+    if (interception.isErr()) {
+      return err(new Error(`Lifecycle run interception failed: ${interception.error.message}`));
+    }
+    if (interception.value.outcome !== 'allow') {
+      return err(new Error(`Lifecycle run policy blocked execution: ${interception.value.reason}`));
+    }
+
+    const runInput = interception.value.input.input as {
+      provider: string;
+      model: string;
+      contextAdditions?: Record<string, unknown>;
+    };
+    return ok({
+      provider: runInput.provider,
+      model: runInput.model,
+      ...(runInput.contextAdditions ? { contextAdditions: runInput.contextAdditions } : {}),
+    });
+  }
+
+  private runOutboundDeliveryIdentity(
+    queueItemId: string,
+    segment: string = 'final',
+  ): OutboundDeliveryIdentity {
+    const key = segment === 'final' ? `outbound:${queueItemId}` : `outbound:${queueItemId}:${segment}`;
+    return {
+      messageId: key,
+      idempotencyKey: key,
+    };
+  }
+
+  private async sendLifecycleOutboundMessage(input: {
+    content: string;
+    persistedContent?: string;
+    connector: ChannelConnector;
+    externalId: string;
+    runId: string;
+    threadId: string;
+    personaName: string;
+    channelName?: string;
+    itemOrigin: 'run' | 'tool';
+    itemType: 'message';
+    messageId: string;
+    idempotencyKey?: string;
+    reservationContent?: string;
+  }): Promise<Result<{ content: string; fullContent: string; skipped: boolean }, Error>> {
+    const originalContent = input.content;
+    let content = input.content;
+    let fullContent = input.persistedContent ?? input.content;
+    let idempotentReservationInserted = false;
+
+    if (this.ctx.lifecycleRuntime) {
+      const lifecycleContent = buildLifecycleContentPreview(content);
+      const interception = this.ctx.lifecycleRuntime.intercept(
+        {
+          persona: input.personaName,
+          hook: 'message.before_send',
+          itemOrigin: input.itemOrigin,
+          itemType: input.itemType,
+          ...(input.channelName ? { channel: input.channelName } : {}),
+          messageSource: 'outbound',
+        },
+        {
+          version: 'v1',
+          interceptionId: uuidv4(),
+          hook: 'message.before_send',
+          context: this.lifecycleContext('message', input.messageId, input.runId, input.itemOrigin),
+          input: {
+            messageId: input.messageId,
+            content: lifecycleContent.content,
+            source: 'outbound',
+            recipientId: input.externalId,
+            ...(input.channelName ? { channel: input.channelName } : {}),
+            persona: input.personaName,
+          },
+        },
+      );
+      if (interception.isErr()) {
+        return err(new Error(`Lifecycle outbound interception failed: ${interception.error.message}`));
+      }
+      if (interception.value.outcome !== 'allow') {
+        return err(new Error(`Lifecycle outbound policy blocked delivery: ${interception.value.reason}`));
+      }
+      const resolvedContent = resolveLifecycleOutboundContent({
+        originalContent: content,
+        preview: lifecycleContent,
+        interceptedContent: (interception.value.input.input as { content: string }).content,
+      });
+      if (resolvedContent.isErr()) {
+        return err(resolvedContent.error);
+      }
+      content = resolvedContent.value;
+    }
+
+    fullContent = input.persistedContent
+      ? input.persistedContent.endsWith(originalContent)
+        ? `${input.persistedContent.slice(0, -originalContent.length)}${content}`
+        : content
+      : content;
+
+    if (input.idempotencyKey) {
+      const reservationContent = input.reservationContent ?? fullContent;
+      const reserved = this.ctx.repos.message.insertIfAbsent({
+        id: input.messageId,
+        thread_id: input.threadId,
+        direction: 'outbound',
+        content: JSON.stringify({ body: reservationContent }),
+        idempotency_key: input.idempotencyKey,
+        provider_id: null,
+        run_id: input.runId,
+      });
+      if (reserved.isErr()) {
+        return err(
+          new Error(`failed to reserve outbound delivery: ${reserved.error.message}`),
+        );
+      }
+      if (!reserved.value.inserted) {
+        this.ctx.logger.info(
+          { runId: input.runId, messageId: input.messageId },
+          'agent-runner: skipping already reserved outbound delivery',
+        );
+        return ok({ content, fullContent, skipped: true });
+      }
+      idempotentReservationInserted = true;
+    }
+
+    const sendResult = await input.connector.send(input.externalId, { body: content });
+    if (sendResult.isErr()) {
+      if (input.idempotencyKey && idempotentReservationInserted) {
+        const cleared = this.ctx.repos.message.deleteByIdempotencyKey(input.idempotencyKey);
+        if (cleared.isErr()) {
+          return err(
+            new Error(
+              `channel send failed: ${sendResult.error.message}; failed to clear outbound delivery reservation: ${cleared.error.message}`,
+            ),
+          );
+        }
+      }
+      this.publishMessageSendEvent('message.send_failed.v1', input, content, {
+        status: 'failed',
+        errorLength: sendResult.error.message.length,
+      });
+      return err(new Error(sendResult.error.message));
+    }
+
+    this.publishMessageSendEvent('message.sent.v1', input, content, { status: 'sent' });
+    return ok({ content, fullContent, skipped: false });
+  }
+
+  private publishMessageSendEvent(
+    type: 'message.sent.v1' | 'message.send_failed.v1',
+    input: {
+      runId: string;
+      threadId: string;
+      personaName: string;
+      channelName?: string;
+      itemOrigin: 'run' | 'tool';
+      itemType: 'message';
+      messageId: string;
+      externalId: string;
+    },
+    content: string,
+    metadata: Record<string, string | number | boolean | null>,
+  ): void {
+    if (!this.ctx.lifecycleRuntime) return;
+    const publication = this.ctx.lifecycleRuntime.publish({
+      event: this.lifecycleEvent(
+        type,
+        'message',
+        input.messageId,
+        input.runId,
+        input.itemOrigin,
+        [
+          { type: 'message', id: input.messageId },
+          { type: 'thread', id: input.threadId },
+          { type: 'run', id: input.runId },
+        ],
+        {
+          direction: 'outbound',
+          source: input.itemOrigin,
+          contentLength: content.length,
+          ...metadata,
+        },
+      ),
+      persona: input.personaName,
+      itemOrigin: input.itemOrigin,
+      itemType: input.itemType,
+      ...(input.channelName ? { channel: input.channelName } : {}),
+      messageSource: 'outbound',
+    });
+    if (publication.isErr()) {
+      this.ctx.logger.error(
+        { err: publication.error.message, runId: input.runId, messageId: input.messageId, type },
+        'agent-runner: failed to publish outbound lifecycle event',
+      );
+    }
+  }
+
+  private finalizeRunWithLifecycle(
+    runId: string,
+    status: 'completed' | 'failed',
+    eventInput: {
+      threadId: string;
+      personaId: string;
+      queueItemId: string;
+      provider: string;
+      model: string;
+      error?: string;
+    },
+    personaName: string,
+    timestamps: { ended_at: number; error?: string },
+  ): Result<void, Error> {
+    if (!this.ctx.lifecycleRuntime) {
+      const updated = this.ctx.repos.run.updateStatus(runId, status, timestamps);
+      return updated.isErr() ? err(new Error(updated.error.message)) : ok(undefined);
+    }
+    const result = this.ctx.lifecycleRuntime.transaction((transaction) => {
+      const updated = this.ctx.repos.run.updateStatus(runId, status, timestamps);
+      if (updated.isErr()) return err(updated.error);
+      const published = this.publishRunEvent(
+        status === 'completed' ? 'run.completed.v1' : 'run.failed.v1',
+        {
+          runId,
+          threadId: eventInput.threadId,
+          personaId: eventInput.personaId,
+          queueItemId: eventInput.queueItemId,
+          provider: eventInput.provider,
+          model: eventInput.model,
+          status,
+          ...(eventInput.error ? { errorLength: eventInput.error.length } : {}),
+        },
+        personaName,
+        transaction,
+      );
+      return published.isErr() ? err(published.error) : ok(undefined);
+    });
+    if (result.isErr()) {
+      this.ctx.logger.error(
+        { err: result.error.message, runId, status },
+        'agent-runner: failed to finalize run lifecycle event',
+      );
+    }
+    return result.isErr() ? err(new Error(result.error.message)) : ok(undefined);
+  }
+
+  private insertAndFinalizePreExecutionFailedRun(
+    runId: string,
+    input: {
+      threadId: string;
+      personaId: string;
+      queueItemId: string;
+      provider: string;
+      model: string;
+      reasoningEffort?: ReasoningEffort | null;
+      error: string;
+    },
+    personaName: string,
+  ): Result<void, Error> {
+    const inserted = this.ctx.repos.run.insert({
+      id: runId,
+      thread_id: input.threadId,
+      persona_id: input.personaId,
+      provider_name: input.provider,
+      model_name: input.model,
+      reasoning_effort: input.reasoningEffort ?? null,
+      sandbox_id: null,
+      session_id: null,
+      status: 'running',
+      parent_run_id: null,
+      queue_item_id: input.queueItemId,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      cost_usd: 0,
+      error: null,
+      started_at: Date.now(),
+      ended_at: null,
+    });
+    if (inserted.isErr()) {
+      return err(new Error(inserted.error.message));
+    }
+    return this.finalizeRunWithLifecycle(
+      runId,
+      'failed',
+      {
+        threadId: input.threadId,
+        personaId: input.personaId,
+        queueItemId: input.queueItemId,
+        provider: input.provider,
+        model: input.model,
+        error: input.error,
+      },
+      personaName,
+      { ended_at: Date.now(), error: input.error },
+    );
+  }
+
+  private publishRunEvent(
+    type: 'run.started.v1' | 'run.completed.v1' | 'run.failed.v1',
+    input: {
+      runId: string;
+      threadId: string;
+      personaId: string;
+      queueItemId: string;
+      provider: string;
+      model: string;
+      status: string;
+      errorLength?: number;
+    },
+    personaName: string,
+    transaction: TransactionContext,
+  ): Result<void, Error> {
+    if (!this.ctx.lifecycleRuntime) return ok(undefined);
+    const publication = this.ctx.lifecycleRuntime.publish(
+      {
+        event: this.lifecycleEvent(
+          type,
+          'run',
+          input.runId,
+          input.queueItemId,
+          'run',
+          [
+            { type: 'run', id: input.runId },
+            { type: 'thread', id: input.threadId },
+            { type: 'persona', id: input.personaId },
+            { type: 'queue_item', id: input.queueItemId },
+          ],
+          {
+            provider: input.provider,
+            model: input.model,
+            status: input.status,
+            ...(input.errorLength !== undefined ? { errorLength: input.errorLength } : {}),
+          },
+        ),
+        persona: personaName,
+        itemOrigin: 'run',
+        itemType: 'run',
+      },
+      transaction,
+    );
+    return publication.isErr() ? err(new Error(publication.error.message)) : ok(undefined);
+  }
+
+  private publishProviderToolLifecycleEvent(
+    type: 'provider.tool.started.v1' | 'provider.tool.completed.v1',
+    metadata: {
+      runId: string;
+      threadId: string;
+      provider: string;
+      persona: string;
+    },
+    event: {
+      messageType: string;
+      tool?: string;
+      toolUseId?: string;
+      isError?: boolean;
+      serverName?: string;
+    },
+    toolCallIdOverride?: string,
+  ): void {
+    if (!this.ctx.lifecycleRuntime) return;
+    const toolCallId = toolCallIdOverride ?? event.toolUseId ?? uuidv4();
+    const publication = this.ctx.lifecycleRuntime.publish({
+      event: this.lifecycleEvent(
+        type,
+        'tool_call',
+        toolCallId,
+        metadata.runId,
+        'run',
+        [
+          { type: 'tool_call', id: toolCallId },
+          { type: 'run', id: metadata.runId },
+          { type: 'thread', id: metadata.threadId },
+        ],
+        {
+          provider: metadata.provider,
+          toolName: event.tool ?? event.messageType,
+          messageType: event.messageType,
+          ...(event.serverName ? { serverName: event.serverName } : {}),
+          status: type === 'provider.tool.started.v1' ? 'started' : event.isError ? 'error' : 'completed',
+        },
+      ),
+      persona: metadata.persona,
+      itemOrigin: 'run',
+      itemType: 'tool_call',
+    });
+    if (publication.isErr()) {
+      this.ctx.logger.error(
+        { err: publication.error.message, runId: metadata.runId, type },
+        'agent-runner: failed to publish provider tool lifecycle event',
+      );
+    }
+  }
+
+  private lifecycleContext(
+    aggregateType: string,
+    aggregateId: string,
+    correlationId: string,
+    source: string,
+  ): LifecycleEventEnvelope['context'] {
+    return {
+      aggregate: { type: aggregateType, id: aggregateId },
+      correlationId,
+      recursion: { depth: 0, maxDepth: 8 },
+      provenance: { source, sourceEventIds: [], sourceReferences: [] },
+    };
+  }
+
+  private lifecycleEvent(
+    type: LifecycleEventEnvelope['type'],
+    aggregateType: string,
+    aggregateId: string,
+    correlationId: string,
+    source: string,
+    references: LifecycleEventEnvelope['payload']['references'],
+    metadata: LifecycleEventEnvelope['payload']['metadata'],
+  ): LifecycleEventEnvelope {
+    return {
+      version: 'v1',
+      type,
+      eventId: uuidv4(),
+      occurredAt: new Date().toISOString(),
+      context: this.lifecycleContext(aggregateType, aggregateId, correlationId, source),
+      payload: { references, metadata },
+    };
   }
 
   private toError(cause: unknown): Error {
@@ -1254,11 +1945,12 @@ export class AgentRunner {
       runId: string;
       threadId: string;
       provider: string;
+      persona: string;
     },
     activeProviderToolObservations: Map<string, StartedObservationHandle>,
     ignoredProviderToolUseIds: Set<string>,
     pendingProviderToolTasks: Array<Promise<void>>,
-    pendingNoIdToolObservations: StartedObservationHandle[],
+    pendingNoIdToolObservations: PendingNoIdProviderToolObservation[],
     event: {
       messageType: string;
       tool?: string;
@@ -1285,6 +1977,7 @@ export class AgentRunner {
     }
 
     if (this.isProviderToolStartEvent(event.messageType) && event.toolUseId) {
+      this.publishProviderToolLifecycleEvent('provider.tool.started.v1', metadata, event);
       const observation = this.ctx.observability.startWithTraceparent(traceparent, {
         type: 'tool',
         name: this.getProviderToolObservationName(event),
@@ -1302,6 +1995,7 @@ export class AgentRunner {
     }
 
     if (this.isProviderToolResultEvent(event.messageType) && event.toolUseId) {
+      this.publishProviderToolLifecycleEvent('provider.tool.completed.v1', metadata, event);
       const observation = activeProviderToolObservations.get(event.toolUseId);
       if (!observation) {
         return;
@@ -1319,14 +2013,20 @@ export class AgentRunner {
 
     // Handle result events for tools that had no toolUseId — match by FIFO order.
     if (this.isProviderToolResultEvent(event.messageType) && !event.toolUseId) {
-      const observation = pendingNoIdToolObservations.shift();
-      if (observation) {
-        observation.update({
+      const pending = pendingNoIdToolObservations.shift();
+      this.publishProviderToolLifecycleEvent(
+        'provider.tool.completed.v1',
+        metadata,
+        event,
+        pending?.toolCallId,
+      );
+      if (pending) {
+        pending.observation.update({
           output: event.output,
           level: event.isError ? 'ERROR' : undefined,
           statusMessage: event.isError ? 'Tool call returned an error' : undefined,
         });
-        observation.end();
+        pending.observation.end();
       }
       return;
     }
@@ -1337,6 +2037,13 @@ export class AgentRunner {
 
     // Start events without toolUseId: track with FIFO queue so we can end them when the
     // matching result event arrives. This avoids the zero-latency observation problem.
+    const noIdToolCallId = uuidv4();
+    this.publishProviderToolLifecycleEvent(
+      'provider.tool.started.v1',
+      metadata,
+      event,
+      noIdToolCallId,
+    );
     const noIdObservation = this.ctx.observability.startWithTraceparent(traceparent, {
       type: 'tool',
       name: this.getProviderToolObservationName(event),
@@ -1348,12 +2055,15 @@ export class AgentRunner {
         serverName: event.serverName ?? null,
       },
     });
-    pendingNoIdToolObservations.push(noIdObservation);
+    pendingNoIdToolObservations.push({
+      observation: noIdObservation,
+      toolCallId: noIdToolCallId,
+    });
   }
 
   private finishProviderToolObservations(
     activeProviderToolObservations: Map<string, StartedObservationHandle>,
-    pendingNoIdToolObservations: StartedObservationHandle[],
+    pendingNoIdToolObservations: PendingNoIdProviderToolObservation[],
     update?: {
       level?: 'ERROR';
       statusMessage?: string;
@@ -1368,11 +2078,11 @@ export class AgentRunner {
     activeProviderToolObservations.clear();
 
     // End any unmatched no-id observations (e.g. on error path where result never arrived)
-    for (const observation of pendingNoIdToolObservations) {
+    for (const pending of pendingNoIdToolObservations) {
       if (update) {
-        observation.update(update);
+        pending.observation.update(update);
       }
-      observation.end();
+      pending.observation.end();
     }
     pendingNoIdToolObservations.splice(0);
   }

--- a/src/lifecycle/outbound-content-preview.ts
+++ b/src/lifecycle/outbound-content-preview.ts
@@ -1,0 +1,53 @@
+import { err, ok, type Result } from 'neverthrow';
+
+import { MAX_LIFECYCLE_CONTENT_LENGTH } from './contracts/event-contract.js';
+
+export interface LifecycleContentPreview {
+  readonly content: string;
+  readonly originalLength: number;
+  readonly truncated: boolean;
+}
+
+export function buildLifecycleContentPreview(content: string): LifecycleContentPreview {
+  if (content.length <= MAX_LIFECYCLE_CONTENT_LENGTH) {
+    return { content, originalLength: content.length, truncated: false };
+  }
+
+  const marker = `\n\n[Lifecycle preview truncated: original content length ${content.length} chars]\n\n`;
+  if (marker.length >= MAX_LIFECYCLE_CONTENT_LENGTH) {
+    return {
+      content: content.slice(0, MAX_LIFECYCLE_CONTENT_LENGTH),
+      originalLength: content.length,
+      truncated: true,
+    };
+  }
+
+  const contentBudget = MAX_LIFECYCLE_CONTENT_LENGTH - marker.length;
+  const headLength = Math.ceil(contentBudget / 2);
+  const tailLength = contentBudget - headLength;
+  return {
+    content: `${content.slice(0, headLength)}${marker}${content.slice(content.length - tailLength)}`,
+    originalLength: content.length,
+    truncated: true,
+  };
+}
+
+export function resolveLifecycleOutboundContent(input: {
+  readonly originalContent: string;
+  readonly preview: LifecycleContentPreview;
+  readonly interceptedContent: string;
+}): Result<string, Error> {
+  if (!input.preview.truncated) {
+    return ok(input.interceptedContent);
+  }
+
+  if (input.interceptedContent !== input.preview.content) {
+    return err(
+      new Error(
+        'Lifecycle outbound content transform rejected because interceptor received a truncated preview',
+      ),
+    );
+  }
+
+  return ok(input.originalContent);
+}

--- a/src/tools/host-tools-bridge.ts
+++ b/src/tools/host-tools-bridge.ts
@@ -7,9 +7,11 @@
  */
 
 import { unlinkSync, existsSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { dirname, join, resolve } from 'node:path';
 import net from 'node:net';
 import type Database from 'better-sqlite3';
+import { err, ok } from 'neverthrow';
 import type { DaemonContext } from '../daemon/daemon-context.js';
 import type { ToolCallResult } from './tool-types.js';
 import type { ToolExecutionContext } from './host-tools/channel-send.js';
@@ -34,6 +36,7 @@ import {
   ensureOwnerOnlyDirSync,
   ensureOwnerOnlyFile,
 } from '../core/fs/private-paths.js';
+import type { LifecycleEventEnvelope } from '../lifecycle/contracts/index.js';
 
 /** NDJSON request shape from MCP server. */
 interface BridgeRequest {
@@ -50,6 +53,14 @@ interface BridgeResponse {
   result?: ToolCallResult;
   error?: string;
 }
+
+type LifecycleBridgeJson =
+  | string
+  | number
+  | boolean
+  | null
+  | LifecycleBridgeJson[]
+  | { [key: string]: LifecycleBridgeJson };
 
 /** Tool name mapping from MCP (underscores) to handler (dots). Derived from HOST_TOOL_REGISTRY. */
 const TOOL_NAME_MAP = Object.fromEntries(MCP_TO_INTERNAL);
@@ -91,6 +102,8 @@ export class HostToolsBridge {
     this.channelHandler = new ChannelSendHandler({
       channelRegistry: ctx.channelRegistry,
       threadRepository: ctx.repos.thread,
+      personaRepository: ctx.repos.persona,
+      lifecycleRuntime: ctx.lifecycleRuntime ?? undefined,
       logger: ctx.logger,
     });
 
@@ -360,12 +373,56 @@ export class HostToolsBridge {
             return toolResult;
           }
 
+          const lifecyclePreparation = this.prepareLifecycleToolExecution(
+            normalizedTool,
+            args,
+            context,
+          );
+          if (lifecyclePreparation.status === 'error') {
+            const toolResult: ToolCallResult = {
+              requestId: context.requestId ?? 'unknown',
+              tool: normalizedTool,
+              status: 'error',
+              error: lifecyclePreparation.error,
+            };
+            toolObservation.update({
+              output: toolResult,
+              level: 'ERROR',
+              statusMessage: toolResult.error,
+            });
+            return toolResult;
+          }
+
+          const effectiveArgs = lifecyclePreparation.args;
+          const started = this.publishToolLifecycleEvent(
+            'provider.tool.started.v1',
+            normalizedTool,
+            effectiveArgs,
+            context,
+            lifecyclePreparation.personaName,
+            { status: 'started' },
+          );
+          if (started.isErr()) {
+            const toolResult: ToolCallResult = {
+              requestId: context.requestId ?? 'unknown',
+              tool: normalizedTool,
+              status: 'error',
+              error: `Failed to publish tool start lifecycle event: ${started.error.message}`,
+            };
+            toolObservation.update({
+              output: toolResult,
+              level: 'ERROR',
+              statusMessage: toolResult.error,
+            });
+            return toolResult;
+          }
+
           let timeoutId: ReturnType<typeof setTimeout> | undefined;
-          const requestTimeoutMs = getHostToolRequestTimeoutMs(normalizedTool, args);
+          const requestTimeoutMs = getHostToolRequestTimeoutMs(normalizedTool, effectiveArgs);
 
           try {
             const toolResult = await Promise.race([
-              this.dispatch(normalizedTool, args, context),
+              this.dispatch(normalizedTool, effectiveArgs, context),
               new Promise<never>((_, reject) => {
                 timeoutId = setTimeout(() => {
                   this.ctx.logger.warn(
@@ -383,9 +440,33 @@ export class HostToolsBridge {
               statusMessage: toolResult.status === 'error' ? toolResult.error : undefined,
             });
 
+            this.publishToolLifecycleEvent(
+              'provider.tool.completed.v1',
+              normalizedTool,
+              effectiveArgs,
+              context,
+              lifecyclePreparation.personaName,
+              {
+                status: toolResult.status,
+                hasError: toolResult.status === 'error',
+              },
+            );
+
             return toolResult;
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
+            this.publishToolLifecycleEvent(
+              'provider.tool.completed.v1',
+              normalizedTool,
+              effectiveArgs,
+              context,
+              lifecyclePreparation.personaName,
+              {
+                status: 'error',
+                hasError: true,
+                errorLength: message.length,
+              },
+            );
             toolObservation.update({
               level: 'ERROR',
               statusMessage: message,
@@ -534,6 +615,140 @@ export class HostToolsBridge {
       );
       return { allow: [], requireApproval: [] };
     }
+  }
+
+  private resolvePersonaName(personaId: string): string | null {
+    const personaRowResult = this.ctx.repos.persona.findById(personaId);
+    if (personaRowResult.isErr() || personaRowResult.value === null) {
+      return null;
+    }
+    return personaRowResult.value.name;
+  }
+
+  private prepareLifecycleToolExecution(
+    tool: string,
+    args: Record<string, unknown>,
+    context: ToolExecutionContext,
+  ):
+    | { status: 'ready'; args: Record<string, unknown>; personaName: string }
+    | { status: 'error'; error: string } {
+    if (!this.ctx.lifecycleRuntime) {
+      return { status: 'ready', args, personaName: context.personaId };
+    }
+
+    const personaName = this.resolvePersonaName(context.personaId);
+    if (!personaName) {
+      return {
+        status: 'error',
+        error: `Failed to resolve lifecycle persona for tool call: ${context.personaId}`,
+      };
+    }
+
+    const toolCallId = context.requestId ?? randomUUID();
+    const interception = this.ctx.lifecycleRuntime.intercept(
+      {
+        persona: personaName,
+        hook: 'tool.before_execute',
+        itemOrigin: 'tool',
+        itemType: 'tool_call',
+      },
+      {
+        version: 'v1',
+        interceptionId: randomUUID(),
+        hook: 'tool.before_execute',
+        context: this.lifecycleContext('tool_call', toolCallId, context.runId, 'tool'),
+        input: {
+          toolCallId,
+          toolName: tool,
+          arguments: args as Record<string, LifecycleBridgeJson>,
+        },
+      },
+    );
+    if (interception.isErr()) {
+      return {
+        status: 'error',
+        error: `Lifecycle tool interception failed: ${interception.error.message}`,
+      };
+    }
+    if (interception.value.outcome !== 'allow') {
+      return {
+        status: 'error',
+        error: `Lifecycle tool policy blocked execution: ${interception.value.reason}`,
+      };
+    }
+    return {
+      status: 'ready',
+      args: (interception.value.input.input as { arguments: Record<string, unknown> }).arguments,
+      personaName,
+    };
+  }
+
+  private publishToolLifecycleEvent(
+    type: 'provider.tool.started.v1' | 'provider.tool.completed.v1',
+    tool: string,
+    args: Record<string, unknown>,
+    context: ToolExecutionContext,
+    personaName: string,
+    metadata: Record<string, string | number | boolean | null>,
+  ): import('neverthrow').Result<void, Error> {
+    if (!this.ctx.lifecycleRuntime) return ok(undefined);
+    const toolCallId = context.requestId ?? randomUUID();
+    const publication = this.ctx.lifecycleRuntime.publish({
+      event: this.lifecycleEvent(
+        type,
+        'tool_call',
+        toolCallId,
+        context.runId,
+        'tool',
+        [
+          { type: 'tool_call', id: toolCallId },
+          { type: 'run', id: context.runId },
+          { type: 'thread', id: context.threadId },
+        ],
+        {
+          toolName: tool,
+          argumentKeys: Object.keys(args).length,
+          ...metadata,
+        },
+      ),
+      persona: personaName,
+      itemOrigin: 'tool',
+      itemType: 'tool_call',
+    });
+    return publication.isErr() ? err(new Error(publication.error.message)) : ok(undefined);
+  }
+
+  private lifecycleContext(
+    aggregateType: string,
+    aggregateId: string,
+    correlationId: string,
+    source: string,
+  ): LifecycleEventEnvelope['context'] {
+    return {
+      aggregate: { type: aggregateType, id: aggregateId },
+      correlationId,
+      recursion: { depth: 0, maxDepth: 8 },
+      provenance: { source, sourceEventIds: [], sourceReferences: [] },
+    };
+  }
+
+  private lifecycleEvent(
+    type: LifecycleEventEnvelope['type'],
+    aggregateType: string,
+    aggregateId: string,
+    correlationId: string,
+    source: string,
+    references: LifecycleEventEnvelope['payload']['references'],
+    metadata: LifecycleEventEnvelope['payload']['metadata'],
+  ): LifecycleEventEnvelope {
+    return {
+      version: 'v1',
+      type,
+      eventId: randomUUID(),
+      occurredAt: new Date().toISOString(),
+      context: this.lifecycleContext(aggregateType, aggregateId, correlationId, source),
+      payload: { references, metadata },
+    };
   }
 
   private async dispatch(

--- a/src/tools/host-tools/channel-send.ts
+++ b/src/tools/host-tools/channel-send.ts
@@ -7,10 +7,18 @@
  */
 
 import type pino from 'pino';
+import { v4 as uuidv4 } from 'uuid';
 import type { ToolManifest, ToolCallResult } from '../tool-types.js';
 import type { ChannelRegistry } from '../../channels/channel-registry.js';
 import type { ThreadRepository } from '../../core/database/repositories/thread-repository.js';
+import type { PersonaRepository } from '../../core/database/repositories/persona-repository.js';
 import { ToolError } from '../../core/errors/error-types.js';
+import type { LifecycleRuntime } from '../../lifecycle/lifecycle-runtime.js';
+import type { LifecycleEventEnvelope } from '../../lifecycle/contracts/index.js';
+import {
+  buildLifecycleContentPreview,
+  resolveLifecycleOutboundContent,
+} from '../../lifecycle/outbound-content-preview.js';
 
 /**
  * Returns the origin chat's external_id recorded in a dedicated schedule
@@ -82,6 +90,8 @@ export class ChannelSendHandler {
     private readonly deps: {
       channelRegistry: ChannelRegistry;
       threadRepository: ThreadRepository;
+      personaRepository?: PersonaRepository;
+      lifecycleRuntime?: LifecycleRuntime;
       logger: pino.Logger;
     },
   ) {}
@@ -154,13 +164,37 @@ export class ChannelSendHandler {
     const externalThreadId =
       readOriginExternalId(threadResult.value.metadata) ?? threadResult.value.external_id;
 
-    const result = await connector.send(externalThreadId, output);
+    const lifecycle = this.prepareLifecycleSend({
+      context,
+      channelId,
+      content,
+      externalThreadId,
+    });
+    if (lifecycle.status === 'error') {
+      return { requestId, tool: 'channel.send', status: 'error', error: lifecycle.error };
+    }
+
+    const sendContent = lifecycle.content;
+    const sendOutput = {
+      ...output,
+      body: sendContent,
+    };
+
+    const result = await connector.send(externalThreadId, sendOutput);
 
     if (result.isErr()) {
       const msg = `channel.send: failed to send message — ${result.error.message}`;
       this.deps.logger.error({ requestId, channelId, err: result.error }, msg);
+      this.publishLifecycleSendEvent('message.send_failed.v1', lifecycle, sendContent, {
+        status: 'failed',
+        errorLength: result.error.message.length,
+      });
       return { requestId, tool: 'channel.send', status: 'error', error: msg };
     }
+
+    this.publishLifecycleSendEvent('message.sent.v1', lifecycle, sendContent, {
+      status: 'sent',
+    });
 
     this.deps.logger.info(
       { requestId, channelId, threadId: context.threadId },
@@ -172,6 +206,181 @@ export class ChannelSendHandler {
       tool: 'channel.send',
       status: 'success',
       result: { channelId, sent: true },
+    };
+  }
+
+  private prepareLifecycleSend(input: {
+    context: ToolExecutionContext;
+    channelId: string;
+    content: string;
+    externalThreadId: string;
+  }):
+    | {
+        status: 'ready';
+        content: string;
+        messageId: string;
+        personaName: string;
+        channelId: string;
+        context: ToolExecutionContext;
+      }
+    | { status: 'error'; error: string } {
+    if (!this.deps.lifecycleRuntime) {
+      return {
+        status: 'ready',
+        content: input.content,
+        messageId: uuidv4(),
+        personaName: input.context.personaId,
+        channelId: input.channelId,
+        context: input.context,
+      };
+    }
+    const persona = this.deps.personaRepository?.findById(input.context.personaId);
+    if (!persona || persona.isErr() || persona.value === null) {
+      return {
+        status: 'error',
+        error: `channel.send: failed to resolve lifecycle persona for ${input.context.personaId}`,
+      };
+    }
+    const messageId = uuidv4();
+    const lifecycleContent = buildLifecycleContentPreview(input.content);
+    const interception = this.deps.lifecycleRuntime.intercept(
+      {
+        persona: persona.value.name,
+        hook: 'message.before_send',
+        itemOrigin: 'tool',
+        itemType: 'message',
+        channel: input.channelId,
+        messageSource: 'outbound',
+      },
+      {
+        version: 'v1',
+        interceptionId: uuidv4(),
+        hook: 'message.before_send',
+        context: this.lifecycleContext('message', messageId, input.context.runId, 'tool'),
+        input: {
+          messageId,
+          content: lifecycleContent.content,
+          source: 'outbound',
+          recipientId: input.externalThreadId,
+          channel: input.channelId,
+          persona: persona.value.name,
+        },
+      },
+    );
+    if (interception.isErr()) {
+      return {
+        status: 'error',
+        error: `channel.send: lifecycle before_send failed — ${interception.error.message}`,
+      };
+    }
+    if (interception.value.outcome !== 'allow') {
+      return {
+        status: 'error',
+        error: `channel.send: lifecycle before_send blocked delivery — ${interception.value.reason}`,
+      };
+    }
+    const content = resolveLifecycleOutboundContent({
+      originalContent: input.content,
+      preview: lifecycleContent,
+      interceptedContent: (interception.value.input.input as { content: string }).content,
+    });
+    if (content.isErr()) {
+      return {
+        status: 'error',
+        error: `channel.send: ${content.error.message}`,
+      };
+    }
+    return {
+      status: 'ready',
+      content: content.value,
+      messageId,
+      personaName: persona.value.name,
+      channelId: input.channelId,
+      context: input.context,
+    };
+  }
+
+  private publishLifecycleSendEvent(
+    type: 'message.sent.v1' | 'message.send_failed.v1',
+    lifecycle: {
+      status: 'ready';
+      content: string;
+      messageId: string;
+      personaName: string;
+      channelId: string;
+      context: ToolExecutionContext;
+    },
+    content: string,
+    metadata: Record<string, string | number | boolean | null>,
+  ): void {
+    if (!this.deps.lifecycleRuntime) return;
+    const publication = this.deps.lifecycleRuntime.publish({
+      event: this.lifecycleEvent(
+        type,
+        'message',
+        lifecycle.messageId,
+        lifecycle.context.runId,
+        'tool',
+        [
+          { type: 'message', id: lifecycle.messageId },
+          { type: 'thread', id: lifecycle.context.threadId },
+          { type: 'run', id: lifecycle.context.runId },
+        ],
+        {
+          direction: 'outbound',
+          source: 'tool',
+          contentLength: content.length,
+          ...metadata,
+        },
+      ),
+      persona: lifecycle.personaName,
+      itemOrigin: 'tool',
+      itemType: 'message',
+      channel: lifecycle.channelId,
+      messageSource: 'outbound',
+    });
+    if (publication.isErr()) {
+      this.deps.logger.error(
+        {
+          requestId: lifecycle.context.requestId ?? 'unknown',
+          err: publication.error.message,
+          type,
+        },
+        'channel.send: failed to publish lifecycle send event',
+      );
+    }
+  }
+
+  private lifecycleContext(
+    aggregateType: string,
+    aggregateId: string,
+    correlationId: string,
+    source: string,
+  ): LifecycleEventEnvelope['context'] {
+    return {
+      aggregate: { type: aggregateType, id: aggregateId },
+      correlationId,
+      recursion: { depth: 0, maxDepth: 8 },
+      provenance: { source, sourceEventIds: [], sourceReferences: [] },
+    };
+  }
+
+  private lifecycleEvent(
+    type: LifecycleEventEnvelope['type'],
+    aggregateType: string,
+    aggregateId: string,
+    correlationId: string,
+    source: string,
+    references: LifecycleEventEnvelope['payload']['references'],
+    metadata: LifecycleEventEnvelope['payload']['metadata'],
+  ): LifecycleEventEnvelope {
+    return {
+      version: 'v1',
+      type,
+      eventId: uuidv4(),
+      occurredAt: new Date().toISOString(),
+      context: this.lifecycleContext(aggregateType, aggregateId, correlationId, source),
+      payload: { references, metadata },
     };
   }
 }

--- a/tests/unit/daemon/agent-runner.test.ts
+++ b/tests/unit/daemon/agent-runner.test.ts
@@ -54,6 +54,11 @@ import type {
   ObservationHandle,
   StartedObservationHandle,
 } from '../../../src/observability/langfuse/observability-types.js';
+import {
+  LifecycleInterceptorEnvelopeSchema,
+  type LifecycleInterceptorEnvelope,
+} from '../../../src/lifecycle/contracts/index.js';
+import { MAX_LIFECYCLE_CONTENT_LENGTH } from '../../../src/lifecycle/contracts/event-contract.js';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -166,6 +171,17 @@ function makeMockContext(): DaemonContext {
       audit: {} as any,
       message: {
         insert: vi.fn().mockReturnValue(ok({})),
+        insertIfAbsent: vi.fn((input) =>
+          ok({
+            message: {
+              ...input,
+              created_at: Date.now(),
+            },
+            inserted: true,
+          }),
+        ),
+        existsByIdempotencyKey: vi.fn().mockReturnValue(false),
+        deleteByIdempotencyKey: vi.fn().mockReturnValue(ok(1)),
       } as any,
       run: {
         insert: vi.fn().mockReturnValue(ok({})),
@@ -243,6 +259,8 @@ function makeMockContext(): DaemonContext {
     } as any,
     hostToolsBridge: {
       path: '/tmp/test-data/host-tools.sock',
+      registerRunAuthentication: vi.fn(),
+      unregisterRunAuthentication: vi.fn(),
     } as any,
     providerRegistry: new ProviderRegistry(
       {
@@ -253,7 +271,26 @@ function makeMockContext(): DaemonContext {
       },
     ),
     backgroundAgentManager: null,
+    lifecycleRuntime: null,
     logger: mockLogger as any,
+  };
+}
+
+function allowInterception(input: LifecycleInterceptorEnvelope) {
+  return ok({
+    outcome: 'allow' as const,
+    input,
+    signals: [],
+  });
+}
+
+function makeLifecycleRuntime() {
+  return {
+    intercept: vi.fn((_invocation, input: LifecycleInterceptorEnvelope) => allowInterception(input)),
+    publish: vi.fn(() => ok({})),
+    transaction: vi.fn((callback: (transaction: unknown) => ReturnType<typeof ok>) =>
+      callback({}),
+    ),
   };
 }
 
@@ -277,6 +314,24 @@ async function* makeAgentStream(overrides: Record<string, unknown> = {}) {
     usage: { input_tokens: 100, output_tokens: 50 },
     is_error: false,
     ...overrides,
+  };
+}
+
+async function* makeAgentStreamWithText(text: string) {
+  yield {
+    type: 'assistant',
+    message: {
+      content: [{ text }],
+    },
+  };
+  yield {
+    type: 'result',
+    subtype: 'success',
+    result: text,
+    session_id: 'session-abc-123',
+    total_cost_usd: 0.005,
+    usage: { input_tokens: 100, output_tokens: 50 },
+    is_error: false,
   };
 }
 
@@ -535,7 +590,7 @@ describe('AgentRunner', () => {
 
       await runner.run(item);
 
-      expect(ctx.repos.message.insert).toHaveBeenCalledWith(
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledWith(
         expect.objectContaining({
           thread_id: 'thread-001',
           direction: 'outbound',
@@ -553,6 +608,587 @@ describe('AgentRunner', () => {
         expect.any(String),
         'completed',
         expect.objectContaining({ ended_at: expect.any(Number) }),
+      );
+    });
+
+    it('publishes run started and completed lifecycle events when lifecycle is enabled', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      runner = new AgentRunner(ctx);
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: 'run.started.v1',
+            context: expect.objectContaining({
+              aggregate: expect.objectContaining({ type: 'run' }),
+              correlationId: 'qi-001',
+            }),
+            payload: expect.objectContaining({
+              metadata: expect.not.objectContaining({
+                content: expect.anything(),
+              }),
+            }),
+          }),
+          persona: 'TestBot',
+          itemOrigin: 'run',
+          itemType: 'run',
+        }),
+        expect.anything(),
+      );
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'run.completed.v1' }),
+          persona: 'TestBot',
+          itemOrigin: 'run',
+          itemType: 'run',
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('returns an error and marks the run failed when completed lifecycle finalization fails', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      lifecycleRuntime.publish.mockImplementation((publication: { event: { type: string } }) =>
+        publication.event.type === 'run.completed.v1'
+          ? err(new Error('publish completed failed'))
+          : ok({}),
+      );
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      runner = new AgentRunner(ctx);
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().message).toContain('failed to finalize completed run');
+      expect(ctx.repos.run.updateStatus).toHaveBeenCalledWith(
+        expect.any(String),
+        'failed',
+        expect.objectContaining({
+          error: expect.stringContaining('failed to finalize completed run'),
+        }),
+      );
+    });
+
+    it('applies run.before_execute transforms before invoking the provider', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      lifecycleRuntime.intercept.mockImplementation((_invocation, input: LifecycleInterceptorEnvelope) => {
+        if (input.hook !== 'run.before_execute') return allowInterception(input);
+        return ok({
+          outcome: 'allow' as const,
+          input: {
+            ...input,
+            input: {
+              ...input.input,
+              model: 'claude-opus-4-20250514',
+              contextAdditions: { reviewer: 'lifecycle' },
+            },
+          },
+          signals: [],
+        });
+      });
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      runner = new AgentRunner(ctx);
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      const queryCall = mockQuery.mock.calls[0]![0] as {
+        options: { model: string; systemPrompt: string };
+      };
+      expect(queryCall.options.model).toBe('claude-opus-4-20250514');
+      expect(queryCall.options.systemPrompt).toContain('"reviewer":"lifecycle"');
+    });
+
+    it('does not invoke the provider when run.before_execute denies execution', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      lifecycleRuntime.intercept.mockImplementation((_invocation, input: LifecycleInterceptorEnvelope) => {
+        if (input.hook !== 'run.before_execute') return allowInterception(input);
+        return ok({
+          outcome: 'deny' as const,
+          reason: 'policy blocked run',
+          input,
+          signals: [],
+        });
+      });
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      runner = new AgentRunner(ctx);
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().message).toContain('policy blocked run');
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(ctx.repos.run.updateStatus).toHaveBeenCalledWith(
+        expect.any(String),
+        'failed',
+        expect.objectContaining({ error: expect.stringContaining('policy blocked run') }),
+      );
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'run.failed.v1' }),
+          persona: 'TestBot',
+          itemOrigin: 'run',
+          itemType: 'run',
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('records a failed run when run.before_execute selects an unavailable provider', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      lifecycleRuntime.intercept.mockImplementation((_invocation, input: LifecycleInterceptorEnvelope) => {
+        if (input.hook !== 'run.before_execute') return allowInterception(input);
+        return ok({
+          outcome: 'allow' as const,
+          input: {
+            ...input,
+            input: {
+              ...input.input,
+              provider: 'missing-provider',
+            },
+          },
+          signals: [],
+        });
+      });
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      runner = new AgentRunner(ctx);
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'Lifecycle run interceptor selected unavailable provider "missing-provider"',
+      );
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(ctx.repos.run.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider_name: 'missing-provider',
+          status: 'running',
+        }),
+      );
+      expect(ctx.repos.run.updateStatus).toHaveBeenCalledWith(
+        expect.any(String),
+        'failed',
+        expect.objectContaining({
+          error: 'Lifecycle run interceptor selected unavailable provider "missing-provider"',
+        }),
+      );
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'run.failed.v1' }),
+          persona: 'TestBot',
+          itemOrigin: 'run',
+          itemType: 'run',
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('runs message.before_send before final outbound delivery and publishes sent', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      lifecycleRuntime.intercept.mockImplementation((_invocation, input: LifecycleInterceptorEnvelope) => {
+        if (input.hook !== 'message.before_send') return allowInterception(input);
+        return ok({
+          outcome: 'allow' as const,
+          input: {
+            ...input,
+            input: {
+              ...input.input,
+              content: 'Transformed outbound',
+            },
+          },
+          signals: [],
+        });
+      });
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      runner = new AgentRunner(ctx);
+      const connector = ctx.channelRegistry.get('test-channel')!;
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      expect(connector.send).toHaveBeenCalledWith('ext-001', { body: 'Transformed outbound' });
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'outbound:qi-001',
+          content: JSON.stringify({ body: 'Transformed outbound' }),
+          idempotency_key: 'outbound:qi-001',
+        }),
+      );
+      const insertCall = vi.mocked(ctx.repos.message.insertIfAbsent).mock.calls[0]![0] as { id: string };
+      const sentPublication = lifecycleRuntime.publish.mock.calls
+        .map(([publication]) => publication as { event: { type: string; payload: { references: unknown[] } } })
+        .find((publication) => publication.event.type === 'message.sent.v1');
+      expect(sentPublication?.event.payload.references).toContainEqual({
+        type: 'message',
+        id: insertCall.id,
+      });
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'message.sent.v1' }),
+          persona: 'TestBot',
+          itemOrigin: 'run',
+          itemType: 'message',
+          messageSource: 'outbound',
+        }),
+      );
+    });
+
+    it('bounds lifecycle input but delivers original over-limit final outbound when unchanged', async () => {
+      const longContent = 'L'.repeat(MAX_LIFECYCLE_CONTENT_LENGTH + 1024);
+      mockQuery.mockReturnValue(makeAgentStreamWithText(longContent));
+      const lifecycleRuntime = makeLifecycleRuntime();
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      runner = new AgentRunner(ctx);
+      const connector = ctx.channelRegistry.get('test-channel')!;
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      const beforeSendCall = lifecycleRuntime.intercept.mock.calls.find(
+        ([invocation, input]) =>
+          invocation.hook === 'message.before_send' &&
+          (input as LifecycleInterceptorEnvelope).input.messageId === 'outbound:qi-001',
+      );
+      expect(beforeSendCall).toBeDefined();
+      const lifecycleInput = beforeSendCall![1] as LifecycleInterceptorEnvelope;
+      expect(LifecycleInterceptorEnvelopeSchema.safeParse(lifecycleInput).success).toBe(true);
+      expect(lifecycleInput.input.content.length).toBeLessThanOrEqual(
+        MAX_LIFECYCLE_CONTENT_LENGTH,
+      );
+      expect(lifecycleInput.input.content).not.toBe(longContent);
+      expect(connector.send).toHaveBeenCalledWith('ext-001', { body: longContent });
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: JSON.stringify({ body: longContent }),
+        }),
+      );
+    });
+
+    it('reserves final outbound delivery before sending to protect retries after post-send failures', async () => {
+      const callOrder: string[] = [];
+      vi.mocked(ctx.repos.message.insertIfAbsent).mockImplementation((input) => {
+        callOrder.push('reserve');
+        return ok({
+          message: {
+            ...input,
+            created_at: Date.now(),
+          },
+          inserted: true,
+        } as any);
+      });
+      const connector = ctx.channelRegistry.get('test-channel')!;
+      vi.mocked(connector.send).mockImplementation(async () => {
+        callOrder.push('send');
+        return ok(undefined);
+      });
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'outbound:qi-001',
+          idempotency_key: 'outbound:qi-001',
+          content: JSON.stringify({ body: 'Hello from the agent!' }),
+        }),
+      );
+      expect(callOrder).toEqual(expect.arrayContaining(['reserve', 'send']));
+      expect(callOrder.indexOf('reserve')).toBeLessThan(callOrder.indexOf('send'));
+    });
+
+    it('does not resend final outbound on retry after a post-send finalization failure', async () => {
+      mockQuery.mockImplementation(() => makeAgentStream());
+      let reserveAttempt = 0;
+      vi.mocked(ctx.repos.message.insertIfAbsent).mockImplementation((input) => {
+        reserveAttempt += 1;
+        return ok({
+          message: {
+            ...input,
+            created_at: Date.now(),
+          },
+          inserted: reserveAttempt === 1,
+        } as any);
+      });
+      let completedStatusAttempt = 0;
+      vi.mocked(ctx.repos.run.updateStatus).mockImplementation((_runId, status) => {
+        if (status === 'completed') {
+          completedStatusAttempt += 1;
+          if (completedStatusAttempt === 1) {
+            return err(new Error('post-send finalization failed')) as any;
+          }
+        }
+        return ok({} as any);
+      });
+      const connector = ctx.channelRegistry.get('test-channel')!;
+
+      const first = await runner.run(makeQueueItem());
+      const second = await runner.run(makeQueueItem());
+
+      expect(first.isErr()).toBe(true);
+      expect(first._unsafeUnwrapErr().message).toContain('post-send finalization failed');
+      expect(second.isOk()).toBe(true);
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledTimes(2);
+      expect(connector.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not resend intermediate outbound text on retry after a post-send finalization failure', async () => {
+      async function* textToolTextStream() {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              { text: 'Before tool.' },
+              { type: 'tool_use', id: 'tu-001', name: 'memory_access', input: {} },
+            ],
+          },
+        };
+        yield {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'tu-001', content: 'ok' }],
+          },
+        };
+        yield {
+          type: 'assistant',
+          message: { content: [{ text: 'After tool.' }] },
+        };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: '',
+          session_id: 'session-abc-123',
+          total_cost_usd: 0.001,
+          usage: { input_tokens: 100, output_tokens: 50 },
+          is_error: false,
+        };
+      }
+
+      mockQuery.mockImplementation(() => textToolTextStream());
+      const reservedKeys = new Set<string>();
+      vi.mocked(ctx.repos.message.insertIfAbsent).mockImplementation((input) => {
+        const inserted = !reservedKeys.has(input.idempotency_key);
+        if (inserted) {
+          reservedKeys.add(input.idempotency_key);
+        }
+        return ok({
+          message: {
+            ...input,
+            created_at: Date.now(),
+          },
+          inserted,
+        } as any);
+      });
+      let completedStatusAttempt = 0;
+      vi.mocked(ctx.repos.run.updateStatus).mockImplementation((_runId, status) => {
+        if (status === 'completed') {
+          completedStatusAttempt += 1;
+          if (completedStatusAttempt === 1) {
+            return err(new Error('post-send finalization failed')) as any;
+          }
+        }
+        return ok({} as any);
+      });
+      const connector = ctx.channelRegistry.get('test-channel')!;
+
+      const first = await runner.run(makeQueueItem());
+      const second = await runner.run(makeQueueItem());
+
+      expect(first.isErr()).toBe(true);
+      expect(first._unsafeUnwrapErr().message).toContain('post-send finalization failed');
+      expect(second.isOk()).toBe(true);
+      const sentBodies = vi
+        .mocked(connector.send)
+        .mock.calls.map(([, body]) => (body as { body: string }).body);
+      expect(sentBodies).toEqual(['Before tool.', 'After tool.']);
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotency_key: 'outbound:qi-001:stream:0' }),
+      );
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotency_key: 'outbound:qi-001' }),
+      );
+    });
+
+    it('does not persist a synthetic final transcript row when stream ends after flushed text', async () => {
+      async function* textToolOnlyStream() {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              { text: 'Before tool.' },
+              { type: 'tool_use', id: 'tu-001', name: 'memory_access', input: {} },
+            ],
+          },
+        };
+        yield {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'tu-001', content: 'ok' }],
+          },
+        };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: '',
+          session_id: 'session-abc-123',
+          total_cost_usd: 0.001,
+          usage: { input_tokens: 100, output_tokens: 50 },
+          is_error: false,
+        };
+      }
+
+      mockQuery.mockImplementation(() => textToolOnlyStream());
+      const connector = ctx.channelRegistry.get('test-channel')!;
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      expect(
+        vi.mocked(connector.send).mock.calls.map(([, body]) => (body as { body: string }).body),
+      ).toEqual(['Before tool.']);
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledTimes(1);
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: JSON.stringify({ body: 'Before tool.' }),
+          idempotency_key: 'outbound:qi-001:stream:0',
+        }),
+      );
+      expect(ctx.repos.message.insert).not.toHaveBeenCalled();
+    });
+
+    it('clears final outbound reservation and sends again on retry after connector send failure', async () => {
+      mockQuery.mockImplementation(() => makeAgentStream());
+      const reservedKeys = new Set<string>();
+      vi.mocked(ctx.repos.message.insertIfAbsent).mockImplementation((input) => {
+        const inserted = !reservedKeys.has(input.idempotency_key);
+        if (inserted) {
+          reservedKeys.add(input.idempotency_key);
+        }
+        return ok({
+          message: {
+            ...input,
+            created_at: Date.now(),
+          },
+          inserted,
+        } as any);
+      });
+      vi.mocked(ctx.repos.message.deleteByIdempotencyKey).mockImplementation((key) => {
+        const deleted = reservedKeys.delete(key);
+        return ok(deleted ? 1 : 0);
+      });
+      const connector = ctx.channelRegistry.get('test-channel')!;
+      vi.mocked(connector.send)
+        .mockResolvedValueOnce(err(new Error('transport down')))
+        .mockResolvedValueOnce(ok(undefined));
+
+      const first = await runner.run(makeQueueItem());
+      const second = await runner.run(makeQueueItem());
+
+      expect(first.isErr()).toBe(true);
+      expect(first._unsafeUnwrapErr().message).toContain('transport down');
+      expect(second.isOk()).toBe(true);
+      expect(ctx.repos.message.deleteByIdempotencyKey).toHaveBeenCalledWith('outbound:qi-001');
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledTimes(2);
+      expect(connector.send).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips final outbound connector delivery when the stable outbound reservation exists', async () => {
+      vi.mocked(ctx.repos.message.insertIfAbsent).mockImplementation((input) =>
+        ok({
+          message: {
+            ...input,
+            created_at: Date.now(),
+          },
+          inserted: false,
+        } as any),
+      );
+      const connector = ctx.channelRegistry.get('test-channel')!;
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotency_key: 'outbound:qi-001' }),
+      );
+      expect(connector.send).not.toHaveBeenCalled();
+      expect(ctx.repos.message.insert).not.toHaveBeenCalled();
+      expect(ctx.repos.run.updateStatus).toHaveBeenCalledWith(
+        expect.any(String),
+        'completed',
+        expect.objectContaining({ ended_at: expect.any(Number) }),
+      );
+    });
+
+    it('routes CLI waiting notifications through outbound lifecycle hooks', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      const cliRun = vi.fn().mockResolvedValue({
+        output: 'CLI output',
+        sessionId: undefined,
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+        },
+        isError: false,
+      });
+      ctx.providerRegistry = {
+        getDefault: vi.fn().mockReturnValue({
+          type: 'legacy-cli',
+          provider: {
+            name: 'legacy-cli',
+            createExecutionStrategy: () => ({
+              type: 'cli' as const,
+              supportsSessionResumption: false as const,
+              run: cliRun,
+            }),
+            prepareBackgroundInvocation: vi.fn(),
+            parseBackgroundResult: vi.fn(),
+            estimateContextUsage: vi.fn().mockReturnValue({
+              inputTokens: 10,
+              metrics: { input_tokens: 10 },
+            }),
+          },
+          config: makeAgentRunnerProviderConfig({
+            command: 'legacy-cli',
+            contextWindowTokens: 1_000_000,
+          }),
+        }),
+      } as any;
+      runner = new AgentRunner(ctx);
+      const connector = ctx.channelRegistry.get('test-channel')!;
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      expect(connector.send).toHaveBeenCalledWith('ext-001', { body: 'Thinking...' });
+      expect(lifecycleRuntime.intercept).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hook: 'message.before_send',
+          itemOrigin: 'run',
+          itemType: 'message',
+          messageSource: 'outbound',
+        }),
+        expect.objectContaining({
+          hook: 'message.before_send',
+          input: expect.objectContaining({
+            messageId: 'outbound:qi-001:waiting',
+            content: 'Thinking...',
+          }),
+        }),
+      );
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: 'message.sent.v1',
+            context: expect.objectContaining({
+              aggregate: expect.objectContaining({ id: 'outbound:qi-001:waiting' }),
+            }),
+          }),
+        }),
       );
     });
 
@@ -884,7 +1520,7 @@ describe('AgentRunner', () => {
       expect(connector.send).toHaveBeenNthCalledWith(1, 'ext-001', {
         body: 'Gemini result',
       });
-      expect(ctx.repos.message.insert).toHaveBeenCalledTimes(1);
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledTimes(1);
       expect(ctx.contextRoller.checkAndRotate).toHaveBeenCalledWith(
         'thread-001',
         'persona-001',
@@ -1215,12 +1851,18 @@ describe('AgentRunner', () => {
         expect(callOrder.indexOf('send')).toBeLessThan(callOrder.indexOf('rotate'));
       });
 
-      it('persists outbound message before running context rotation for SDK providers', async () => {
+      it('reserves outbound message before running context rotation for SDK providers', async () => {
         const callOrder: string[] = [];
 
-        vi.mocked(ctx.repos.message.insert).mockImplementation(() => {
-          callOrder.push('message.insert');
-          return ok({} as any);
+        vi.mocked(ctx.repos.message.insertIfAbsent).mockImplementation((input) => {
+          callOrder.push('message.reserve');
+          return ok({
+            message: {
+              ...input,
+              created_at: Date.now(),
+            },
+            inserted: true,
+          } as any);
         });
 
         ctx.contextRoller = {
@@ -1244,7 +1886,7 @@ describe('AgentRunner', () => {
 
         expect(result.isOk()).toBe(true);
         expect(callOrder).toContain('rotate'); // sanity: rotation was triggered
-        expect(callOrder.indexOf('message.insert')).toBeLessThan(callOrder.indexOf('rotate'));
+        expect(callOrder.indexOf('message.reserve')).toBeLessThan(callOrder.indexOf('rotate'));
       });
 
       it('sends response to channel before context rotation for CLI providers', async () => {
@@ -3249,6 +3891,117 @@ describe('AgentRunner', () => {
       expect(ctx.observability.observeWithTraceparent).not.toHaveBeenCalled();
     });
 
+    it('publishes no-toolUseId provider tool lifecycle start and completion with the same tool_call id', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      runner = new AgentRunner(ctx);
+
+      async function* streamWithNoIdToolResult() {
+        yield { type: 'tool_use', tool: 'Read', subtype: undefined };
+        yield {
+          type: 'tool_result',
+          tool: 'Read',
+          subtype: 'success',
+          content: 'file contents',
+        };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: 'Done reading.',
+          session_id: 'session-xyz',
+          total_cost_usd: 0.01,
+          usage: { input_tokens: 200, output_tokens: 100 },
+          is_error: false,
+        };
+      }
+
+      mockQuery.mockReturnValue(streamWithNoIdToolResult());
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      const toolEvents = lifecycleRuntime.publish.mock.calls
+        .map(([publication]) => (publication as { event: any }).event)
+        .filter((event) =>
+          ['provider.tool.started.v1', 'provider.tool.completed.v1'].includes(event.type),
+        );
+      expect(toolEvents).toHaveLength(2);
+      const [started, completed] = toolEvents as [
+        { context: { aggregate: { id: string } }; payload: { references: unknown[] } },
+        { context: { aggregate: { id: string } }; payload: { references: unknown[] } },
+      ];
+      expect(started.context.aggregate.id).toEqual(expect.any(String));
+      expect(completed.context.aggregate.id).toBe(started.context.aggregate.id);
+      expect(started.payload.references).toContainEqual({
+        type: 'tool_call',
+        id: started.context.aggregate.id,
+      });
+      expect(completed.payload.references).toContainEqual({
+        type: 'tool_call',
+        id: started.context.aggregate.id,
+      });
+    });
+
+    it('publishes provider tool lifecycle events with the provider supplied toolUseId', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      ctx.lifecycleRuntime = lifecycleRuntime as any;
+      runner = new AgentRunner(ctx);
+
+      async function* streamWithProviderToolUseId() {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_001',
+                name: 'Read',
+                input: { file_path: 'README.md' },
+              },
+            ],
+          },
+        };
+        yield {
+          type: 'user',
+          message: {
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'toolu_001',
+                content: 'README contents',
+                is_error: false,
+              },
+            ],
+          },
+        };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: 'Done reading.',
+          session_id: 'session-xyz',
+          total_cost_usd: 0.01,
+          usage: { input_tokens: 200, output_tokens: 100 },
+          is_error: false,
+        };
+      }
+
+      mockQuery.mockReturnValue(streamWithProviderToolUseId());
+
+      const result = await runner.run(makeQueueItem());
+
+      expect(result.isOk()).toBe(true);
+      const toolEvents = lifecycleRuntime.publish.mock.calls
+        .map(([publication]) => (publication as { event: any }).event)
+        .filter((event) =>
+          ['provider.tool.started.v1', 'provider.tool.completed.v1'].includes(event.type),
+        );
+      expect(toolEvents).toHaveLength(2);
+      for (const event of toolEvents) {
+        expect(event.context.aggregate).toEqual({ type: 'tool_call', id: 'toolu_001' });
+        expect(event.payload.references).toContainEqual({ type: 'tool_call', id: 'toolu_001' });
+      }
+    });
+
     it('skips duplicate provider tool observations for internal host-tools MCP calls', async () => {
       ctx.observability.startWithTraceparent = vi.fn(() => makeStartedObservationHandle(null));
 
@@ -3597,13 +4350,22 @@ describe('AgentRunner', () => {
       expect(sendCalls[0]![1]).toEqual({ body: 'Before tool.' });
       expect(sendCalls[1]![1]).toEqual({ body: 'After tool.' });
 
-      // Verify DB persistence stores the full transcript with block separators
-      expect(ctx.repos.message.insert).toHaveBeenCalledTimes(1);
-      const insertCall = vi.mocked(ctx.repos.message.insert).mock.calls[0]![0] as {
-        content: string;
-      };
-      const persisted = JSON.parse(insertCall.content);
-      expect(persisted.body).toBe('Before tool.\n\nAfter tool.');
+      // Verify DB persistence stores the physical outbound messages with stable delivery keys.
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledTimes(2);
+      const persisted = vi.mocked(ctx.repos.message.insertIfAbsent).mock.calls.map(([input]) => {
+        const row = input as {
+          content: string;
+          idempotency_key: string;
+        };
+        return {
+          body: (JSON.parse(row.content) as { body: string }).body,
+          idempotencyKey: row.idempotency_key,
+        };
+      });
+      expect(persisted).toEqual([
+        { body: 'Before tool.', idempotencyKey: 'outbound:qi-001:stream:0' },
+        { body: 'After tool.', idempotencyKey: 'outbound:qi-001' },
+      ]);
     });
 
     it('sends three separate messages for text → tool → text → tool → text', async () => {
@@ -3667,13 +4429,23 @@ describe('AgentRunner', () => {
       expect(sendCalls[1]![1]).toEqual({ body: 'Block 2.' });
       expect(sendCalls[2]![1]).toEqual({ body: 'Block 3.' });
 
-      // Verify DB persistence stores the full transcript with block separators
-      expect(ctx.repos.message.insert).toHaveBeenCalledTimes(1);
-      const insertCall = vi.mocked(ctx.repos.message.insert).mock.calls[0]![0] as {
-        content: string;
-      };
-      const persisted = JSON.parse(insertCall.content);
-      expect(persisted.body).toBe('Block 1.\n\nBlock 2.\n\nBlock 3.');
+      // Verify DB persistence stores the physical outbound messages with stable delivery keys.
+      expect(ctx.repos.message.insertIfAbsent).toHaveBeenCalledTimes(3);
+      const persisted = vi.mocked(ctx.repos.message.insertIfAbsent).mock.calls.map(([input]) => {
+        const row = input as {
+          content: string;
+          idempotency_key: string;
+        };
+        return {
+          body: (JSON.parse(row.content) as { body: string }).body,
+          idempotencyKey: row.idempotency_key,
+        };
+      });
+      expect(persisted).toEqual([
+        { body: 'Block 1.', idempotencyKey: 'outbound:qi-001:stream:0' },
+        { body: 'Block 2.', idempotencyKey: 'outbound:qi-001:stream:1' },
+        { body: 'Block 3.', idempotencyKey: 'outbound:qi-001' },
+      ]);
     });
 
     it('concatenates consecutive text events with no tool between them into a single message', async () => {

--- a/tests/unit/tools/host-tools-bridge.test.ts
+++ b/tests/unit/tools/host-tools-bridge.test.ts
@@ -12,6 +12,7 @@ import type { DaemonContext } from '../../../src/daemon/daemon-context.js';
 import type { ScheduleRepository } from '../../../src/core/database/repositories/schedule-repository.js';
 import type { ChannelRegistry } from '../../../src/channels/channel-registry.js';
 import { ok } from 'neverthrow';
+import type { LifecycleInterceptorEnvelope } from '../../../src/lifecycle/contracts/index.js';
 
 // Mock createDatabase so it doesn't try to open a real file for the readonly connection.
 // Returns an err() result so the bridge falls back to the main ctx.db connection.
@@ -91,6 +92,14 @@ describe('HostToolsBridge', () => {
       bridgeSecret: validBridgeSecret,
     });
   };
+
+  const makeLifecycleRuntime = () => ({
+    intercept: vi.fn((_invocation, input: LifecycleInterceptorEnvelope) =>
+      ok({ outcome: 'allow' as const, input, signals: [] }),
+    ),
+    publish: vi.fn(() => ok({})),
+    transaction: vi.fn(),
+  });
 
   beforeEach(async () => {
     tempDir = join('/tmp', `host-tools-bridge-test-${randomUUID()}`);
@@ -215,6 +224,7 @@ describe('HostToolsBridge', () => {
         cancel: vi.fn().mockReturnValue(ok(false)),
         getResult: vi.fn().mockReturnValue(ok(null)),
       } as any,
+      lifecycleRuntime: null,
       executionEnvManager: {
         create: vi.fn().mockResolvedValue(ok({
           id: 'env-1',
@@ -627,6 +637,99 @@ describe('HostToolsBridge', () => {
         }),
         expect.any(Function),
       );
+    });
+
+    it('runs tool.before_execute, dispatches transformed arguments, and publishes tool lifecycle events', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      lifecycleRuntime.intercept.mockImplementation((_invocation, input: LifecycleInterceptorEnvelope) => {
+        if (input.hook !== 'tool.before_execute') {
+          return ok({ outcome: 'allow' as const, input, signals: [] });
+        }
+        return ok({
+          outcome: 'allow' as const,
+          input: {
+            ...input,
+            input: {
+              ...input.input,
+              arguments: { action: 'list' },
+            },
+          },
+          signals: [],
+        });
+      });
+      mockCtx.lifecycleRuntime = lifecycleRuntime as any;
+      bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
+      const dispatch = vi
+        .spyOn(bridge as any, 'dispatch')
+        .mockResolvedValue({ requestId: 'req-001', tool: 'schedule.manage', status: 'success', result: { ok: true } });
+
+      const socket = { write: vi.fn() } as unknown as ReturnType<typeof createConnection>;
+      await (bridge as any).handleRequest(
+        JSON.stringify({
+          id: 'req-001',
+          tool: 'schedule_manage',
+          args: { action: 'create', cronExpr: '0 9 * * *' },
+          bridgeSecret: validBridgeSecret,
+          context: {
+            runId: 'run-001',
+            threadId: 'thread-001',
+            personaId: 'persona-001',
+            requestId: 'req-001',
+          },
+        }),
+        socket,
+      );
+
+      expect(dispatch).toHaveBeenCalledWith(
+        'schedule.manage',
+        { action: 'list' },
+        expect.objectContaining({ runId: 'run-001' }),
+      );
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'provider.tool.started.v1' }),
+          persona: 'test',
+          itemOrigin: 'tool',
+          itemType: 'tool_call',
+        }),
+      );
+      expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'provider.tool.completed.v1' }),
+          persona: 'test',
+          itemOrigin: 'tool',
+          itemType: 'tool_call',
+        }),
+      );
+    });
+
+    it('keeps default-deny capability rejection authoritative before lifecycle interception', async () => {
+      const lifecycleRuntime = makeLifecycleRuntime();
+      mockCtx.lifecycleRuntime = lifecycleRuntime as any;
+      bridge = new HostToolsBridge(mockCtx);
+      registerActiveRunAuth();
+
+      const socket = { write: vi.fn() } as unknown as ReturnType<typeof createConnection>;
+      await (bridge as any).handleRequest(
+        JSON.stringify({
+          id: 'req-001',
+          tool: 'unknown_tool',
+          args: {},
+          bridgeSecret: validBridgeSecret,
+          context: {
+            runId: 'run-001',
+            threadId: 'thread-001',
+            personaId: 'persona-001',
+            requestId: 'req-001',
+          },
+        }),
+        socket,
+      );
+
+      expect(lifecycleRuntime.intercept).not.toHaveBeenCalled();
+      expect(lifecycleRuntime.publish).not.toHaveBeenCalled();
+      expect((socket.write as any).mock.calls[0]?.[0]).toContain('not allowed');
     });
 
     it('dispatches skill.load before capability checks for persona-owned skills', async () => {

--- a/tests/unit/tools/host-tools/channel-send.test.ts
+++ b/tests/unit/tools/host-tools/channel-send.test.ts
@@ -17,6 +17,11 @@ import type { ChannelSendArgs, ToolExecutionContext } from '../../../../src/tool
 import { ChannelError } from '../../../../src/core/errors/error-types.js';
 import type { ChannelRegistry } from '../../../../src/channels/channel-registry.js';
 import type { ChannelConnector } from '../../../../src/channels/channel-types.js';
+import {
+  LifecycleInterceptorEnvelopeSchema,
+  type LifecycleInterceptorEnvelope,
+} from '../../../../src/lifecycle/contracts/index.js';
+import { MAX_LIFECYCLE_CONTENT_LENGTH } from '../../../../src/lifecycle/contracts/event-contract.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -80,6 +85,21 @@ function makeRegistry(connector?: ChannelConnector): ChannelRegistry {
     startAll: vi.fn(),
     stopAll: vi.fn(),
   } as unknown as ChannelRegistry;
+}
+
+function makePersonaRepo() {
+  return {
+    findById: vi.fn().mockReturnValue(ok({ id: 'persona-001', name: 'assistant' })),
+  } as any;
+}
+
+function makeLifecycleRuntime() {
+  return {
+    intercept: vi.fn((_invocation, input: LifecycleInterceptorEnvelope) =>
+      ok({ outcome: 'allow' as const, input, signals: [] }),
+    ),
+    publish: vi.fn(() => ok({})),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -151,6 +171,170 @@ describe('ChannelSendHandler — success', () => {
     const result = await handler.execute(makeArgs(), context);
 
     expect(result.requestId).toBe('unknown');
+  });
+
+  it('runs message.before_send before delivery and publishes message.sent on success', async () => {
+    const lifecycleRuntime = makeLifecycleRuntime();
+    lifecycleRuntime.intercept.mockImplementation((_invocation, input: LifecycleInterceptorEnvelope) =>
+      ok({
+        outcome: 'allow' as const,
+        input: {
+          ...input,
+          input: {
+            ...input.input,
+            content: 'Lifecycle transformed',
+          },
+        },
+        signals: [],
+      }),
+    );
+    const connector = makeConnector(ok(undefined));
+    const registry = makeRegistry(connector);
+    const handler = new ChannelSendHandler({
+      channelRegistry: registry,
+      threadRepository: makeThreadRepo(),
+      personaRepository: makePersonaRepo(),
+      lifecycleRuntime: lifecycleRuntime as any,
+      logger: makeLogger(),
+    } as any);
+
+    const result = await handler.execute(makeArgs(), makeContext());
+
+    expect(result.status).toBe('success');
+    expect(connector.send).toHaveBeenCalledWith(
+      'ext-001',
+      expect.objectContaining({ body: 'Lifecycle transformed' }),
+    );
+    expect(lifecycleRuntime.intercept).toHaveBeenCalledWith(
+      expect.objectContaining({
+        persona: 'assistant',
+        hook: 'message.before_send',
+        itemOrigin: 'tool',
+        itemType: 'message',
+        messageSource: 'outbound',
+      }),
+      expect.objectContaining({
+        hook: 'message.before_send',
+        input: expect.objectContaining({
+          content: 'Hello from persona!',
+          recipientId: 'ext-001',
+        }),
+      }),
+    );
+    expect(lifecycleRuntime.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({ type: 'message.sent.v1' }),
+        persona: 'assistant',
+        itemOrigin: 'tool',
+        itemType: 'message',
+        messageSource: 'outbound',
+      }),
+    );
+  });
+
+  it('returns an error without sending when message.before_send denies delivery', async () => {
+    const lifecycleRuntime = makeLifecycleRuntime();
+    lifecycleRuntime.intercept.mockReturnValue(
+      ok({
+        outcome: 'deny' as const,
+        reason: 'blocked outbound',
+        input: {
+          version: 'v1',
+          interceptionId: 'interception-001',
+          hook: 'message.before_send',
+          context: {
+            aggregate: { type: 'message', id: 'message-001' },
+            correlationId: 'run-001',
+            recursion: { depth: 0, maxDepth: 8 },
+            provenance: { source: 'tool', sourceEventIds: [], sourceReferences: [] },
+          },
+          input: {
+            messageId: 'message-001',
+            content: 'Hello from persona!',
+            source: 'outbound',
+            recipientId: 'ext-001',
+          },
+        } as LifecycleInterceptorEnvelope,
+        signals: [],
+      }),
+    );
+    const connector = makeConnector(ok(undefined));
+    const registry = makeRegistry(connector);
+    const handler = new ChannelSendHandler({
+      channelRegistry: registry,
+      threadRepository: makeThreadRepo(),
+      personaRepository: makePersonaRepo(),
+      lifecycleRuntime: lifecycleRuntime as any,
+      logger: makeLogger(),
+    } as any);
+
+    const result = await handler.execute(makeArgs(), makeContext());
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('blocked outbound');
+    expect(connector.send).not.toHaveBeenCalled();
+    expect(lifecycleRuntime.publish).not.toHaveBeenCalled();
+  });
+
+  it('bounds lifecycle input but sends original over-limit content when unchanged', async () => {
+    const longContent = 'C'.repeat(MAX_LIFECYCLE_CONTENT_LENGTH + 1024);
+    const lifecycleRuntime = makeLifecycleRuntime();
+    const connector = makeConnector(ok(undefined));
+    const registry = makeRegistry(connector);
+    const handler = new ChannelSendHandler({
+      channelRegistry: registry,
+      threadRepository: makeThreadRepo(),
+      personaRepository: makePersonaRepo(),
+      lifecycleRuntime: lifecycleRuntime as any,
+      logger: makeLogger(),
+    } as any);
+
+    const result = await handler.execute(makeArgs({ content: longContent }), makeContext());
+
+    expect(result.status).toBe('success');
+    const lifecycleInput = lifecycleRuntime.intercept.mock.calls[0]![1] as LifecycleInterceptorEnvelope;
+    expect(LifecycleInterceptorEnvelopeSchema.safeParse(lifecycleInput).success).toBe(true);
+    expect(lifecycleInput.input.content.length).toBeLessThanOrEqual(
+      MAX_LIFECYCLE_CONTENT_LENGTH,
+    );
+    expect(lifecycleInput.input.content).not.toBe(longContent);
+    expect(connector.send).toHaveBeenCalledWith(
+      'ext-001',
+      expect.objectContaining({ body: longContent }),
+    );
+  });
+
+  it('rejects content transforms when before_send only saw a truncated preview', async () => {
+    const longContent = 'T'.repeat(MAX_LIFECYCLE_CONTENT_LENGTH + 1024);
+    const lifecycleRuntime = makeLifecycleRuntime();
+    lifecycleRuntime.intercept.mockImplementation((_invocation, input: LifecycleInterceptorEnvelope) =>
+      ok({
+        outcome: 'allow' as const,
+        input: {
+          ...input,
+          input: {
+            ...input.input,
+            content: 'Unsafe transform from truncated preview',
+          },
+        },
+        signals: [],
+      }),
+    );
+    const connector = makeConnector(ok(undefined));
+    const registry = makeRegistry(connector);
+    const handler = new ChannelSendHandler({
+      channelRegistry: registry,
+      threadRepository: makeThreadRepo(),
+      personaRepository: makePersonaRepo(),
+      lifecycleRuntime: lifecycleRuntime as any,
+      logger: makeLogger(),
+    } as any);
+
+    const result = await handler.execute(makeArgs({ content: longContent }), makeContext());
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('truncated preview');
+    expect(connector.send).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- publish run lifecycle started/completed/failed events around agent execution
- route run.before_execute, tool.before_execute, and outbound message.before_send hooks through run/tool/channel-send paths
- reserve outbound delivery IDs before sends so retries do not duplicate final or streamed messages
- persist physical streamed outbound segments with stable idempotency keys and cover no-final-text stream retry edge cases

## Verification
- `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npx vitest run tests/unit/daemon/agent-runner.test.ts tests/unit/tools/host-tools-bridge.test.ts tests/unit/tools/host-tools/channel-send.test.ts tests/unit/core/database/repositories/message-repository.test.ts` — 4 files / 164 tests passed
- `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npx eslint src/daemon/agent-runner.ts src/tools/host-tools-bridge.ts src/tools/host-tools/channel-send.ts src/core/database/repositories/message-repository.ts tests/unit/daemon/agent-runner.test.ts tests/unit/tools/host-tools-bridge.test.ts tests/unit/tools/host-tools/channel-send.test.ts tests/unit/core/database/repositories/message-repository.test.ts` — exited 0; repo ignore-pattern warnings for test files only
- `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run build`
- `git diff --check`

## Review gate
- GPT-5.5/xhigh full review initially found one Medium blocker: no-final-text streamed runs could duplicate already-flushed outbound text in the transcript.
- Remediated with a guard plus regression test.
- GPT-5.5/xhigh post-remediation review: PASS — no Critical/High/Medium blockers.

## Notes
- Full `npm test` was not run per repo instruction to ask before running the full suite.