### PR TITLE
feat(lifecycle): add retention and replay admin primitives

### DIFF
--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/TICKET-002-durable-event-runtime/in-progress/TASK-014-lifecycle-retention-reload-replay.md
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/TICKET-002-durable-event-runtime/in-progress/TASK-014-lifecycle-retention-reload-replay.md
@@ -18,10 +18,10 @@ assigned_model_class: codexHigh
 review_model_class: reviewGate
 branch: task/TASK-014-lifecycle-retention-reload-replay
 worker_worktree: /Users/ivo.toby/workspace/talon/.worktrees/WAVE-007-lifecycle-retention-reload-replay
-worktree_status: allocated_pending_creation
+worktree_status: pre_commit_review_passed
 pr: null
-current_gate: activation_checkpoint_pending
-branch_freshness: pending_activation_checkpoint
+current_gate: pre_commit_review_passed
+branch_freshness: task_branch_current_before_commit
 verification:
   - "npx vitest run tests/unit/lifecycle/retention-service.test.ts tests/unit/lifecycle/lifecycle-admin-service.test.ts tests/unit/daemon/reload.test.ts"
   - "npm run build"
@@ -174,9 +174,57 @@ Refactor only the new/touched boundary after green; do not broaden scope or chan
 
 ## Verification Evidence
 
-- Not run yet.
+- `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npx vitest run tests/unit/lifecycle/retention-service.test.ts tests/unit/lifecycle/lifecycle-admin-service.test.ts tests/unit/daemon/reload.test.ts` passed: 35 tests / 3 files.
+- Adjacent lifecycle persistence/migration coverage also passed: `tests/unit/core/database/repositories/lifecycle-event-repository.test.ts` and `tests/unit/core/database/migrations/runner.test.ts`, 79 total tests across 5 files with the required suite.
+- Remediation targeted suite passed after GPT-5.5/xhigh findings were addressed: `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npx vitest run tests/unit/lifecycle/retention-service.test.ts tests/unit/lifecycle/lifecycle-admin-service.test.ts tests/unit/core/database/migrations/runner.test.ts tests/unit/core/database/repositories/lifecycle-event-repository.test.ts tests/unit/core/config/config-schema.test.ts tests/unit/daemon/reload.test.ts` passed: 187 tests / 6 files.
+- `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run build` passed.
+- `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run lint` still fails on pre-existing unrelated repo-wide lint errors in WhatsApp/CLI/context/subagent/provider/tool files; no TASK-014-owned lint errors remain.
+- Task-owned source ESLint passed for `src/core/database/lifecycle-sql-functions.ts`, `src/lifecycle/retention-service.ts`, `src/lifecycle/lifecycle-admin-service.ts`, `src/lifecycle/contracts/subscription-contract.ts`, `src/lifecycle/contracts/index.ts`, `src/core/database/repositories/lifecycle-event-repository.ts`, and `src/core/database/repositories/lifecycle-delivery-repository.ts`.
+- Touched-file Prettier check passed.
+- `git diff --check` passed.
+- Remediation for direct SQL replay of tombstoned deliveries passed:
+  `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npx vitest run tests/unit/core/database/repositories/lifecycle-event-repository.test.ts` passed: 32 tests / 1 file.
+- Migration-level replay bypass regression coverage passed:
+  `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npx vitest run tests/unit/core/database/migrations/runner.test.ts` passed: 12 tests / 1 file.
+- TASK-014 focused remediation suite passed:
+  `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npx vitest run tests/unit/lifecycle/retention-service.test.ts tests/unit/lifecycle/lifecycle-admin-service.test.ts tests/unit/core/database/migrations/runner.test.ts tests/unit/core/database/repositories/lifecycle-event-repository.test.ts tests/unit/core/config/config-schema.test.ts tests/unit/daemon/reload.test.ts` passed: 188 tests / 6 files.
+- `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run build` passed.
+- Scoped ESLint passed:
+  `env PATH=/Users/ivo.toby/.local/share/mise/installs/node/24.15.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npx eslint src/core/database/repositories/lifecycle-delivery-repository.ts`.
+- `git diff --check` passed after remediation.
+- Blocking-review remediation for system-owned tombstone authority passed:
+  `npx vitest run tests/unit/core/database/repositories/lifecycle-event-repository.test.ts tests/unit/core/database/migrations/runner.test.ts tests/unit/lifecycle/retention-service.test.ts tests/unit/lifecycle/lifecycle-admin-service.test.ts` passed: 57 tests / 4 files.
+- `npm run build` passed after system-owned tombstone remediation.
+- Scoped ESLint passed for remediation-touched source:
+  `npx eslint src/core/database/repositories/lifecycle-event-repository.ts src/core/database/repositories/lifecycle-delivery-repository.ts`.
+- `git diff --check` passed after system-owned tombstone remediation.
+- Fresh full-diff GPT-5.5/xhigh review gate passed in Codex session
+  `019f9c80-79e8-7770-bcf4-8ef4f8d2a5fb`: 0 Critical / 0 High /
+  0 Medium / 0 Low. Reviewer re-ran the six-file focused suite
+  (`190 tests`), `npm run build`, `git diff --check`, and scoped ESLint.
 
 ## Review Feedback
+
+### GPT-5.5/xhigh Blocking Finding
+
+- Resolved: migration 019 no longer permits unauthorised terminal-to-pending
+  replay updates. The trigger now requires repository authorization for replay,
+  and the repository `reopen()` path enters that authorization scope only after
+  eligibility checks reject retention-compacted event tombstones,
+  privacy-deleted event tombstones, handler-disabled deliveries, and
+  privacy-deleted deliveries.
+- Resolved: retention compaction no longer treats caller-owned payload metadata
+  named `lifecycleRetention` as authoritative. Migration 019 adds a
+  system-owned `retention_tombstone_reason` column, repository tombstone writes
+  set it under SQLite authorization, and compaction skips only rows with that
+  system marker. Focused coverage verifies an eligible completed event with
+  caller metadata `lifecycleRetention` is still compacted.
+- Resolved: replay eligibility no longer infers non-replayable tombstone state
+  solely from handler-writable `last_error.code`. Migration 019 adds a
+  system-owned `terminal_tombstone_reason` column for handler-disable/privacy
+  delivery tombstones; repository replay blocks real delivery tombstones and
+  event retention/privacy tombstones, while ordinary dead-letter failures using
+  diagnostic codes `privacy-deleted` or `handler-disabled` reopen normally.
 
 ### P1
 
@@ -190,6 +238,19 @@ Refactor only the new/touched boundary after green; do not broaden scope or chan
 
 - None.
 
+### Fresh Full-Diff Review
+
+- Passed: GPT-5.5/xhigh review in Codex session
+  `019f9c80-79e8-7770-bcf4-8ef4f8d2a5fb` found 0 Critical, 0 High,
+  0 Medium, and 0 Low findings after reviewing tracked and untracked TASK-014
+  files. All prior blockers were explicitly confirmed resolved.
+
 ## Completion Notes
 
-- None yet.
+- GPT-5.5/xhigh remediation tightened thread tombstone SQL to require `aggregate_type = 'thread'`, blocked replay of canonical retention/privacy tombstones and handler-disabled/privacy-deleted delivery tombstones, and preserved replay for ordinary terminal handler failures.
+- GPT-5.5/xhigh blocking-review remediation made event and delivery tombstone
+  authority system-owned via migration 019 columns, preserving replay for
+  ordinary handler diagnostics that use tombstone-like strings and preserving
+  blocked replay for real retention/privacy/disablement tombstones.
+- Migration 019 now requires a repository-controlled SQLite authorization function for canonical event tombstones and privacy/disablement terminal delivery tombstones; direct SQL regression coverage was added.
+- TASK-014 now exposes validated `lifecycle.retention.completedAuditWindowMs` config and documents the service-level retention/privacy primitives. Operator CLI invocation remains scoped to downstream TASK-016.

--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/shared-context/resources/task-findings.md
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/shared-context/resources/task-findings.md
@@ -213,6 +213,22 @@ behavior provenance, and after-commit telemetry boundaries.
   invalid W3C `ff` versions. Langfuse observations are parent-linked only when
   valid trace context exists; interceptor/retry/signal-handoff paths may remain
   audit/metric evidence instead of trace-nested spans.
+- Source: TASK-014 / worker proposal, pending PR. Migration 019 keeps lifecycle
+  event and delivery identities immutable while adding two guarded mutation
+  paths only: canonical event payload/provenance tombstones for retention or
+  privacy deletion, and terminal delivery invalidation for handler disablement
+  or privacy deletion. Completed/no-subscriber events compact after the audit
+  window; pending, failed, claimed, and dead-letter events retain operational
+  detail unless privacy deletion explicitly tombstones them. Exact replay
+  continues to reuse the existing `(event_id, handler_id)` delivery row.
+  GPT-5.5/xhigh remediation tightened thread tombstoning to
+  `aggregate_type = 'thread'` plus explicit thread references, rejects replay
+  of canonical retention/privacy tombstones and handler-disabled/privacy-deleted
+  terminal deliveries while preserving ordinary terminal-failure replay, and
+  requires repository-controlled SQLite authorization for direct retention,
+  privacy, and disablement tombstone updates. TASK-014 exposes validated
+  `lifecycle.retention.completedAuditWindowMs`; operator CLI invocation remains
+  downstream TASK-016 scope.
 - WAVE-006 evidence passed three GitHub PR gates (#269/#270/#271), task-level
   GPT-5.5/xhigh reviews with no remaining Critical/High/Medium findings, and
   integrated epic verification: 19 targeted files / 647 tests, `npm run build`,

--- a/README.md
+++ b/README.md
@@ -2507,6 +2507,28 @@ When using Anthropic API keys, Talon records token usage from Claude runtime res
 
 Per-persona budget limits and a `talonctl usage` report command are planned (TASK-047).
 
+## Lifecycle Retention
+
+Lifecycle events are durable by default. When lifecycle retention is invoked by
+operator/admin wiring, completed events and events with no subscribers can have
+their payload/provenance detail compacted after the configured audit window.
+Pending, failed, claimed, dead-letter, privacy-deleted, and handler-disabled
+deliveries keep their operational safety semantics; exact replay remains
+limited to ordinary terminal handler failures.
+
+```yaml
+lifecycle:
+  enabled: true
+  handlers: []
+  retention:
+    completedAuditWindowMs: 2592000000 # 30 days
+```
+
+Thread/persona privacy deletion uses the same retention service to tombstone
+matching lifecycle event detail and dead-letter outstanding matching deliveries.
+Operator CLI commands for invoking these primitives are owned by the lifecycle
+operator CLI workstream.
+
 ---
 
 ## Observability with Langfuse

--- a/config/talond.example.yaml
+++ b/config/talond.example.yaml
@@ -145,6 +145,16 @@ queue:
   backoffMaxMs: 60000
   concurrencyLimit: 5
 
+# Durable lifecycle event handling. Retention compaction rewrites completed
+# lifecycle event payload/provenance detail after the audit window; pending,
+# failed, claimed, dead-letter, and privacy-deleted rows keep their safety
+# semantics.
+# lifecycle:
+#   enabled: false
+#   handlers: []
+#   retention:
+#     completedAuditWindowMs: 2592000000 # 30 days
+
 agentRunner:
   defaultProvider: claude-code
   providers:

--- a/src/core/database/lifecycle-sql-functions.ts
+++ b/src/core/database/lifecycle-sql-functions.ts
@@ -8,6 +8,7 @@ import {
 } from './repositories/lifecycle-persistence-validation.js';
 
 const identifier = /^[a-z][a-z0-9]*(?:[-_.][a-z0-9]+)*$/;
+const retentionMutationAuthorizationDepth = new WeakMap<Database.Database, number>();
 
 function text(value: unknown, units: number, bytes: number): value is string {
   return (
@@ -311,6 +312,23 @@ function validPersona(value: unknown): boolean {
   );
 }
 
+export function withLifecycleRetentionMutationAuthorization<T>(
+  db: Database.Database,
+  operation: () => T,
+): T {
+  const previous = retentionMutationAuthorizationDepth.get(db) ?? 0;
+  retentionMutationAuthorizationDepth.set(db, previous + 1);
+  try {
+    return operation();
+  } finally {
+    if (previous === 0) {
+      retentionMutationAuthorizationDepth.delete(db);
+    } else {
+      retentionMutationAuthorizationDepth.set(db, previous);
+    }
+  }
+}
+
 /** Registers validators before migrations and on normal application connections. */
 export function registerLifecycleSqlFunctions(db: Database.Database): void {
   db.function(
@@ -350,5 +368,8 @@ export function registerLifecycleSqlFunctions(db: Database.Database): void {
   );
   db.function('lifecycle_persona_valid', { deterministic: true }, (value: unknown): number =>
     validPersona(value) ? 1 : 0,
+  );
+  db.function('lifecycle_retention_mutation_authorized', (): number =>
+    (retentionMutationAuthorizationDepth.get(db) ?? 0) > 0 ? 1 : 0,
   );
 }

--- a/src/core/database/migrations/019-lifecycle-retention.sql
+++ b/src/core/database/migrations/019-lifecycle-retention.sql
@@ -1,0 +1,172 @@
+-- Migration 019: lifecycle retention, privacy tombstoning, and disablement transitions.
+--
+-- Event and delivery identities remain immutable. This migration adds only the
+-- guarded update paths needed to remove retained payload/detail data and to
+-- invalidate pending handler work during privacy deletion or operator
+-- disablement.
+
+DROP TRIGGER lifecycle_events_reject_updates;
+DROP TRIGGER lifecycle_event_deliveries_guard_transitions;
+
+ALTER TABLE lifecycle_events
+ADD COLUMN retention_tombstone_reason TEXT
+  CHECK (
+    retention_tombstone_reason IS NULL
+    OR retention_tombstone_reason IN ('retention-compacted', 'privacy-deleted')
+  );
+
+ALTER TABLE lifecycle_event_deliveries
+ADD COLUMN terminal_tombstone_reason TEXT
+  CHECK (
+    terminal_tombstone_reason IS NULL
+    OR terminal_tombstone_reason IN ('handler-disabled', 'privacy-deleted')
+  );
+
+CREATE TRIGGER lifecycle_events_guard_initial_retention_tombstone
+BEFORE INSERT ON lifecycle_events
+FOR EACH ROW
+WHEN NEW.retention_tombstone_reason IS NOT NULL
+BEGIN
+  SELECT RAISE(ABORT, 'lifecycle event tombstones are system-owned');
+END;
+
+CREATE TRIGGER lifecycle_event_deliveries_guard_initial_terminal_tombstone
+BEFORE INSERT ON lifecycle_event_deliveries
+FOR EACH ROW
+WHEN NEW.terminal_tombstone_reason IS NOT NULL
+BEGIN
+  SELECT RAISE(ABORT, 'lifecycle delivery tombstones are system-owned');
+END;
+
+CREATE TRIGGER lifecycle_events_guard_retention_updates
+BEFORE UPDATE ON lifecycle_events
+FOR EACH ROW
+WHEN NOT (
+  NEW.event_sequence IS OLD.event_sequence
+  AND NEW.event_id IS OLD.event_id
+  AND NEW.version IS OLD.version
+  AND NEW.type IS OLD.type
+  AND NEW.aggregate_type IS OLD.aggregate_type
+  AND NEW.aggregate_id IS OLD.aggregate_id
+  AND NEW.correlation_id IS OLD.correlation_id
+  AND (
+    (NEW.causation_id IS NULL AND OLD.causation_id IS NULL)
+    OR NEW.causation_id IS OLD.causation_id
+  )
+  AND NEW.recursion_depth IS OLD.recursion_depth
+  AND NEW.recursion_max_depth IS OLD.recursion_max_depth
+  AND NEW.occurred_at IS OLD.occurred_at
+  AND NEW.created_at IS OLD.created_at
+  AND (
+    (
+      NEW.payload IS OLD.payload
+      AND NEW.provenance IS OLD.provenance
+      AND NEW.retention_tombstone_reason IS OLD.retention_tombstone_reason
+    )
+    OR (
+      lifecycle_retention_mutation_authorized() = 1
+      AND
+      NEW.payload IN (
+        '{"references":[],"metadata":{"lifecycleRetention":"retention-compacted"}}',
+        '{"references":[],"metadata":{"lifecycleRetention":"privacy-deleted"}}'
+      )
+      AND NEW.provenance IS '{"source":"retention-service","sourceEventIds":[],"sourceReferences":[]}'
+      AND NEW.retention_tombstone_reason IN ('retention-compacted', 'privacy-deleted')
+      AND json_extract(NEW.payload, '$.metadata.lifecycleRetention') IS NEW.retention_tombstone_reason
+      AND (
+        OLD.retention_tombstone_reason IS NULL
+        OR NEW.retention_tombstone_reason IS 'privacy-deleted'
+      )
+    )
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid lifecycle event retention update');
+END;
+
+CREATE TRIGGER lifecycle_event_deliveries_guard_transitions
+BEFORE UPDATE ON lifecycle_event_deliveries
+FOR EACH ROW
+WHEN NOT (
+  NEW.event_id IS OLD.event_id
+  AND NEW.handler_id IS OLD.handler_id
+  AND NEW.persona IS OLD.persona
+  AND NEW.priority IS OLD.priority
+  AND NEW.handler_identity IS OLD.handler_identity
+  AND NEW.failure_policy IS OLD.failure_policy
+  AND NEW.max_attempts IS OLD.max_attempts
+  AND NEW.created_at IS OLD.created_at
+  AND (
+    (
+      OLD.status IN ('pending', 'failed')
+      AND NEW.status = 'claimed'
+      AND NEW.attempts IS OLD.attempts
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NOT NULL
+      AND NEW.claim_expires_at IS NOT NULL
+      AND NEW.last_error IS NULL
+      AND NEW.terminal_tombstone_reason IS OLD.terminal_tombstone_reason
+      AND NEW.completed_at IS OLD.completed_at
+    )
+    OR
+    (
+      OLD.status = 'claimed'
+      AND NEW.status = 'completed'
+      AND NEW.attempts IS OLD.attempts
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IS NULL
+      AND NEW.terminal_tombstone_reason IS OLD.terminal_tombstone_reason
+      AND NEW.completed_at IS NOT NULL
+    )
+    OR
+    (
+      OLD.status = 'claimed'
+      AND NEW.status IN ('failed', 'dead_letter')
+      AND NEW.attempts = OLD.attempts + 1
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IS NOT NULL
+      AND NEW.terminal_tombstone_reason IS OLD.terminal_tombstone_reason
+      AND NEW.completed_at IS OLD.completed_at
+    )
+    OR
+    (
+      OLD.status IN ('completed', 'dead_letter')
+      AND NEW.status = 'pending'
+      AND lifecycle_retention_mutation_authorized() = 1
+      AND OLD.terminal_tombstone_reason IS NULL
+      AND NEW.attempts = 0
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IS NULL
+      AND NEW.terminal_tombstone_reason IS NULL
+      AND NEW.completed_at IS NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM lifecycle_events target_event
+        WHERE target_event.event_id = OLD.event_id
+          AND target_event.retention_tombstone_reason IS NOT NULL
+      )
+    )
+    OR
+    (
+      OLD.status IN ('pending', 'failed', 'claimed')
+      AND NEW.status = 'dead_letter'
+      AND lifecycle_retention_mutation_authorized() = 1
+      AND NEW.attempts BETWEEN 1 AND OLD.max_attempts
+      AND NEW.next_retry_at IS NULL
+      AND NEW.claim_token IS NULL
+      AND NEW.claim_expires_at IS NULL
+      AND NEW.last_error IN ('{"code":"handler-disabled"}', '{"code":"privacy-deleted"}')
+      AND NEW.terminal_tombstone_reason IN ('handler-disabled', 'privacy-deleted')
+      AND json_extract(NEW.last_error, '$.code') IS NEW.terminal_tombstone_reason
+      AND NEW.completed_at IS OLD.completed_at
+    )
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid lifecycle delivery update');
+END;

--- a/src/core/database/repositories/index.ts
+++ b/src/core/database/repositories/index.ts
@@ -73,6 +73,7 @@ export { ExecutionEnvCheckpointRepository } from './execution-env-checkpoint-rep
 export type {
   LifecycleEventRow,
   LifecycleEventFanoutResult,
+  LifecycleEventRetentionResult,
 } from './lifecycle-event-repository.js';
 export { LifecycleEventRepository } from './lifecycle-event-repository.js';
 
@@ -84,6 +85,7 @@ export type {
   ClaimLifecycleDeliveryOptions,
   LifecycleDeliveryClock,
   LifecycleFailureDiagnostic,
+  LifecycleDeliveryRetentionResult,
 } from './lifecycle-delivery-repository.js';
 export {
   LifecycleDeliveryRepository,

--- a/src/core/database/repositories/lifecycle-delivery-repository.ts
+++ b/src/core/database/repositories/lifecycle-delivery-repository.ts
@@ -26,6 +26,7 @@ import {
   validIdentity,
   validPayload,
   validProvenance,
+  withLifecycleRetentionMutationAuthorization,
 } from '../lifecycle-sql-functions.js';
 import { BaseRepository } from './base-repository.js';
 import {
@@ -72,6 +73,7 @@ export interface LifecycleDeliveryRow {
   claim_token: string | null;
   claim_expires_at: number | null;
   last_error: string | null;
+  terminal_tombstone_reason: 'handler-disabled' | 'privacy-deleted' | null;
   completed_at: number | null;
   created_at: number;
   updated_at: number;
@@ -96,6 +98,10 @@ export interface LifecycleDeliveryRepositoryOptions {
   readonly leaseClock?: LifecycleDeliveryClock;
   readonly auditLogger?: Pick<AuditLogger, 'logLifecycleReplay'>;
   readonly metrics?: Pick<LifecycleMetricsRecorder, 'increment'>;
+}
+
+export interface LifecycleDeliveryRetentionResult {
+  disabledDeliveries: number;
 }
 
 /** Persisted failure diagnostics intentionally carry only a stable, non-secret code. */
@@ -135,6 +141,9 @@ export class LifecycleDeliveryRepository extends BaseRepository {
   private readonly canReopenStmt: Database.Statement;
   private readonly reopenStmt: Database.Statement;
   private readonly findEventStmt: Database.Statement;
+  private readonly disableHandlerStmt: Database.Statement;
+  private readonly tombstoneThreadDeliveriesStmt: Database.Statement;
+  private readonly tombstonePersonaDeliveriesStmt: Database.Statement;
   private readonly leaseClock: LifecycleDeliveryClock;
   private readonly auditLogger?: Pick<AuditLogger, 'logLifecycleReplay'>;
   private readonly metrics?: Pick<LifecycleMetricsRecorder, 'increment'>;
@@ -229,12 +238,14 @@ export class LifecycleDeliveryRepository extends BaseRepository {
     this.canReopenStmt = db.prepare(`
       SELECT 1
       FROM lifecycle_event_deliveries target_delivery
+      JOIN lifecycle_events target_event ON target_event.event_id = target_delivery.event_id
       WHERE target_delivery.event_id = @event_id AND target_delivery.handler_id = @handler_id
         AND target_delivery.status IN ('completed', 'dead_letter')
+        AND target_delivery.terminal_tombstone_reason IS NULL
+        AND target_event.retention_tombstone_reason IS NULL
         AND NOT EXISTS (
           SELECT 1
           FROM lifecycle_event_deliveries later_delivery
-          JOIN lifecycle_events target_event ON target_event.event_id = target_delivery.event_id
           JOIN lifecycle_events later_event ON later_event.event_id = later_delivery.event_id
           WHERE later_delivery.handler_id = target_delivery.handler_id
             AND later_event.aggregate_type = target_event.aggregate_type
@@ -248,9 +259,16 @@ export class LifecycleDeliveryRepository extends BaseRepository {
       UPDATE lifecycle_event_deliveries
       SET status = 'pending', attempts = 0, next_retry_at = NULL,
           claim_token = NULL, claim_expires_at = NULL, last_error = NULL,
-          completed_at = NULL, updated_at = @write_now
+          terminal_tombstone_reason = NULL, completed_at = NULL, updated_at = @write_now
       WHERE event_id = @event_id AND handler_id = @handler_id
         AND status IN ('completed', 'dead_letter')
+        AND terminal_tombstone_reason IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM lifecycle_events target_event
+          WHERE target_event.event_id = lifecycle_event_deliveries.event_id
+            AND target_event.retention_tombstone_reason IS NOT NULL
+        )
         AND NOT EXISTS (
           SELECT 1
           FROM lifecycle_event_deliveries later_delivery
@@ -266,6 +284,64 @@ export class LifecycleDeliveryRepository extends BaseRepository {
       RETURNING *
     `);
     this.findEventStmt = db.prepare(`SELECT * FROM lifecycle_events WHERE event_id = ?`);
+    this.disableHandlerStmt = db.prepare(`
+      UPDATE lifecycle_event_deliveries
+      SET status = 'dead_letter',
+          attempts = CASE WHEN attempts < 1 THEN 1 ELSE attempts END,
+          next_retry_at = NULL,
+          claim_token = NULL,
+          claim_expires_at = NULL,
+          last_error = '{"code":"handler-disabled"}',
+          terminal_tombstone_reason = 'handler-disabled',
+          completed_at = NULL,
+          updated_at = @write_now
+      WHERE handler_id = @handler_id
+        AND status IN ('pending', 'failed', 'claimed')
+    `);
+    this.tombstoneThreadDeliveriesStmt = db.prepare(`
+      UPDATE lifecycle_event_deliveries
+      SET status = 'dead_letter',
+          attempts = CASE WHEN attempts < 1 THEN 1 ELSE attempts END,
+          next_retry_at = NULL,
+          claim_token = NULL,
+          claim_expires_at = NULL,
+          last_error = '{"code":"privacy-deleted"}',
+          terminal_tombstone_reason = 'privacy-deleted',
+          completed_at = NULL,
+          updated_at = @write_now
+      WHERE status IN ('pending', 'failed', 'claimed')
+        AND event_id IN (
+          SELECT e.event_id
+          FROM lifecycle_events e
+          WHERE (e.aggregate_type = 'thread' AND e.aggregate_id = @thread_id)
+            OR EXISTS (
+              SELECT 1
+              FROM json_each(e.payload, '$.references') reference
+              WHERE json_extract(reference.value, '$.type') = 'thread'
+                AND json_extract(reference.value, '$.id') = @thread_id
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM json_each(e.provenance, '$.sourceReferences') reference
+              WHERE json_extract(reference.value, '$.type') = 'thread'
+                AND json_extract(reference.value, '$.id') = @thread_id
+            )
+        )
+    `);
+    this.tombstonePersonaDeliveriesStmt = db.prepare(`
+      UPDATE lifecycle_event_deliveries
+      SET status = 'dead_letter',
+          attempts = CASE WHEN attempts < 1 THEN 1 ELSE attempts END,
+          next_retry_at = NULL,
+          claim_token = NULL,
+          claim_expires_at = NULL,
+          last_error = '{"code":"privacy-deleted"}',
+          terminal_tombstone_reason = 'privacy-deleted',
+          completed_at = NULL,
+          updated_at = @write_now
+      WHERE persona = @persona
+        AND status IN ('pending', 'failed', 'claimed')
+    `);
   }
 
   /**
@@ -437,12 +513,14 @@ export class LifecycleDeliveryRepository extends BaseRepository {
           lease_now: leaseNow,
           write_now: writeNow,
         });
-        const row = this.reopenStmt.get({
-          event_id: eventId,
-          handler_id: handlerId,
-          lease_now: leaseNow,
-          write_now: writeNow,
-        }) as LifecycleDeliveryRow | undefined;
+        const row = withLifecycleRetentionMutationAuthorization(this.db, () =>
+          this.reopenStmt.get({
+            event_id: eventId,
+            handler_id: handlerId,
+            lease_now: leaseNow,
+            write_now: writeNow,
+          }),
+        ) as LifecycleDeliveryRow | undefined;
         if (!row) {
           // The eligibility check and state transition share one SQLite
           // transaction. If they diverge, roll back expiry recovery too.
@@ -520,6 +598,64 @@ export class LifecycleDeliveryRepository extends BaseRepository {
       return ok(row ? this.validateDeliveryRow(row) : null);
     } catch (cause) {
       return err(toDbError('find lifecycle delivery by key', cause));
+    }
+  }
+
+  /** Terminally disables outstanding work for one stable handler identity. */
+  disableHandler(handlerId: string): Result<LifecycleDeliveryRetentionResult, DbError> {
+    try {
+      if (!this.isIdentifier(handlerId)) {
+        return err(new DbError('Failed to disable lifecycle handler: invalid handler id'));
+      }
+      const info = withLifecycleRetentionMutationAuthorization(this.db, () =>
+        this.disableHandlerStmt.run({
+          handler_id: handlerId,
+          write_now: this.now(),
+        }),
+      );
+      return ok({ disabledDeliveries: info.changes });
+    } catch (cause) {
+      return err(toDbError('disable lifecycle handler', cause));
+    }
+  }
+
+  /** Dead-letters outstanding delivery detail for a privacy-deleted thread. */
+  tombstoneThread(threadId: string): Result<LifecycleDeliveryRetentionResult, DbError> {
+    try {
+      if (!this.isRuntimeId(threadId)) {
+        return err(
+          new DbError('Failed to tombstone lifecycle thread deliveries: invalid thread id'),
+        );
+      }
+      const info = withLifecycleRetentionMutationAuthorization(this.db, () =>
+        this.tombstoneThreadDeliveriesStmt.run({
+          thread_id: threadId,
+          write_now: this.now(),
+        }),
+      );
+      return ok({ disabledDeliveries: info.changes });
+    } catch (cause) {
+      return err(toDbError('tombstone lifecycle thread deliveries', cause));
+    }
+  }
+
+  /** Dead-letters outstanding delivery detail for a privacy-deleted persona. */
+  tombstonePersona(persona: string): Result<LifecycleDeliveryRetentionResult, DbError> {
+    try {
+      if (!this.isBoundedPersona(persona)) {
+        return err(
+          new DbError('Failed to tombstone lifecycle persona deliveries: invalid persona'),
+        );
+      }
+      const info = withLifecycleRetentionMutationAuthorization(this.db, () =>
+        this.tombstonePersonaDeliveriesStmt.run({
+          persona,
+          write_now: this.now(),
+        }),
+      );
+      return ok({ disabledDeliveries: info.changes });
+    } catch (cause) {
+      return err(toDbError('tombstone lifecycle persona deliveries', cause));
     }
   }
 
@@ -646,6 +782,7 @@ export class LifecycleDeliveryRepository extends BaseRepository {
       !this.isNullableTimestamp(row.completed_at) ||
       !Number.isSafeInteger(row.created_at) ||
       !Number.isSafeInteger(row.updated_at) ||
+      !this.hasValidTerminalTombstone(row, diagnostic) ||
       !this.hasValidStatusFields(row, diagnostic)
     ) {
       throw new Error('invalid persisted lifecycle delivery row');
@@ -762,6 +899,20 @@ export class LifecycleDeliveryRepository extends BaseRepository {
 
   private isNullableTimestamp(value: unknown): boolean {
     return value === null || Number.isSafeInteger(value);
+  }
+
+  private hasValidTerminalTombstone(
+    row: LifecycleDeliveryRow,
+    diagnostic: LifecycleFailureDiagnostic | null,
+  ): boolean {
+    if (row.terminal_tombstone_reason === null) return true;
+    if (
+      row.terminal_tombstone_reason !== 'handler-disabled' &&
+      row.terminal_tombstone_reason !== 'privacy-deleted'
+    ) {
+      return false;
+    }
+    return row.status === 'dead_letter' && diagnostic?.code === row.terminal_tombstone_reason;
   }
 
   private hasValidStatusFields(

--- a/src/core/database/repositories/lifecycle-event-repository.ts
+++ b/src/core/database/repositories/lifecycle-event-repository.ts
@@ -17,6 +17,7 @@ import {
   validIdentity,
   validPayload,
   validProvenance,
+  withLifecycleRetentionMutationAuthorization,
 } from '../lifecycle-sql-functions.js';
 import { BaseRepository } from './base-repository.js';
 import {
@@ -46,6 +47,7 @@ export interface LifecycleEventRow {
   recursion_max_depth: number;
   provenance: string;
   payload: string;
+  retention_tombstone_reason: 'retention-compacted' | 'privacy-deleted' | null;
   occurred_at: string;
   created_at: number;
 }
@@ -54,6 +56,11 @@ export interface LifecycleEventRow {
 export interface LifecycleEventFanoutResult {
   event: LifecycleEventRow;
   deliveries: LifecycleDeliveryRow[];
+}
+
+/** Counts for lifecycle event payload/provenance tombstoning operations. */
+export interface LifecycleEventRetentionResult {
+  compactedEvents: number;
 }
 
 function toDbError(operation: string, cause: unknown): DbError {
@@ -74,6 +81,9 @@ export class LifecycleEventRepository extends BaseRepository {
   private readonly countStmt: Database.Statement;
   private readonly insertDeliveryStmt: Database.Statement;
   private readonly findDeliveriesByEventStmt: Database.Statement;
+  private readonly compactCompletedStmt: Database.Statement;
+  private readonly tombstoneThreadStmt: Database.Statement;
+  private readonly tombstonePersonaStmt: Database.Statement;
 
   constructor(db: Database.Database) {
     super(db);
@@ -107,6 +117,73 @@ export class LifecycleEventRepository extends BaseRepository {
     `);
     this.findDeliveriesByEventStmt = db.prepare(`
       SELECT * FROM lifecycle_event_deliveries WHERE event_id = ? ORDER BY priority DESC, created_at ASC
+    `);
+    this.compactCompletedStmt = db.prepare(`
+      UPDATE lifecycle_events
+      SET payload = @payload,
+          provenance = @provenance,
+          retention_tombstone_reason = @retention_tombstone_reason
+      WHERE retention_tombstone_reason IS NULL
+        AND (
+          (
+            NOT EXISTS (
+              SELECT 1 FROM lifecycle_event_deliveries d
+              WHERE d.event_id = lifecycle_events.event_id
+            )
+            AND created_at <= @cutoff
+          )
+          OR (
+            EXISTS (
+              SELECT 1 FROM lifecycle_event_deliveries d
+              WHERE d.event_id = lifecycle_events.event_id
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM lifecycle_event_deliveries d
+              WHERE d.event_id = lifecycle_events.event_id
+                AND d.status <> 'completed'
+            )
+            AND (
+              SELECT MAX(d.completed_at)
+              FROM lifecycle_event_deliveries d
+              WHERE d.event_id = lifecycle_events.event_id
+            ) <= @cutoff
+          )
+        )
+    `);
+    this.tombstoneThreadStmt = db.prepare(`
+      UPDATE lifecycle_events
+      SET payload = @payload,
+          provenance = @provenance,
+          retention_tombstone_reason = @retention_tombstone_reason
+      WHERE retention_tombstone_reason IS NOT 'privacy-deleted'
+        AND (
+          (aggregate_type = 'thread' AND aggregate_id = @thread_id)
+          OR EXISTS (
+            SELECT 1
+            FROM json_each(lifecycle_events.payload, '$.references') reference
+            WHERE json_extract(reference.value, '$.type') = 'thread'
+              AND json_extract(reference.value, '$.id') = @thread_id
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM json_each(lifecycle_events.provenance, '$.sourceReferences') reference
+            WHERE json_extract(reference.value, '$.type') = 'thread'
+              AND json_extract(reference.value, '$.id') = @thread_id
+          )
+        )
+    `);
+    this.tombstonePersonaStmt = db.prepare(`
+      UPDATE lifecycle_events
+      SET payload = @payload,
+          provenance = @provenance,
+          retention_tombstone_reason = @retention_tombstone_reason
+      WHERE retention_tombstone_reason IS NOT 'privacy-deleted'
+        AND EXISTS (
+          SELECT 1
+          FROM lifecycle_event_deliveries d
+          WHERE d.event_id = lifecycle_events.event_id
+            AND d.persona = @persona
+        )
     `);
   }
 
@@ -215,6 +292,64 @@ export class LifecycleEventRepository extends BaseRepository {
       return ok((this.countStmt.get() as { count: number }).count);
     } catch (cause) {
       return err(toDbError('count lifecycle events', cause));
+    }
+  }
+
+  /**
+   * Replaces completed event payload/provenance detail after the configured
+   * audit window. Pending, failed, claimed, and dead-letter deliveries keep
+   * their original event detail for operational recovery.
+   */
+  compactCompletedBefore(cutoff: number): Result<LifecycleEventRetentionResult, DbError> {
+    try {
+      if (!Number.isSafeInteger(cutoff)) {
+        return err(new DbError('Failed to compact lifecycle events: invalid cutoff'));
+      }
+      const info = withLifecycleRetentionMutationAuthorization(this.db, () =>
+        this.compactCompletedStmt.run({
+          cutoff,
+          ...this.tombstone('retention-compacted'),
+        }),
+      );
+      return ok({ compactedEvents: info.changes });
+    } catch (cause) {
+      return err(toDbError('compact lifecycle events', cause));
+    }
+  }
+
+  /** Tombstones lifecycle event detail associated with a privacy-deleted thread. */
+  tombstoneThread(threadId: string): Result<LifecycleEventRetentionResult, DbError> {
+    try {
+      if (!this.isRuntimeId(threadId)) {
+        return err(new DbError('Failed to tombstone lifecycle thread events: invalid thread id'));
+      }
+      const info = withLifecycleRetentionMutationAuthorization(this.db, () =>
+        this.tombstoneThreadStmt.run({
+          thread_id: threadId,
+          ...this.tombstone('privacy-deleted'),
+        }),
+      );
+      return ok({ compactedEvents: info.changes });
+    } catch (cause) {
+      return err(toDbError('tombstone lifecycle thread events', cause));
+    }
+  }
+
+  /** Tombstones lifecycle event detail associated with a privacy-deleted persona. */
+  tombstonePersona(persona: string): Result<LifecycleEventRetentionResult, DbError> {
+    try {
+      if (!this.isBoundedPersona(persona)) {
+        return err(new DbError('Failed to tombstone lifecycle persona events: invalid persona'));
+      }
+      const info = withLifecycleRetentionMutationAuthorization(this.db, () =>
+        this.tombstonePersonaStmt.run({
+          persona,
+          ...this.tombstone('privacy-deleted'),
+        }),
+      );
+      return ok({ compactedEvents: info.changes });
+    } catch (cause) {
+      return err(toDbError('tombstone lifecycle persona events', cause));
     }
   }
 
@@ -355,7 +490,8 @@ export class LifecycleEventRepository extends BaseRepository {
       !snapshot ||
       !Number.isSafeInteger(row.event_sequence) ||
       row.event_sequence < 1 ||
-      !Number.isSafeInteger(row.created_at)
+      !Number.isSafeInteger(row.created_at) ||
+      !this.hasValidRetentionTombstone(row)
     ) {
       throw new Error('invalid persisted lifecycle event row');
     }
@@ -480,5 +616,49 @@ export class LifecycleEventRepository extends BaseRepository {
       ) &&
       this.parses(LifecycleFilterOwnerNameSchema, value)
     );
+  }
+
+  private hasValidRetentionTombstone(row: LifecycleEventRow): boolean {
+    if (row.retention_tombstone_reason === null) return true;
+    if (
+      row.retention_tombstone_reason !== 'retention-compacted' &&
+      row.retention_tombstone_reason !== 'privacy-deleted'
+    ) {
+      return false;
+    }
+    return (
+      row.payload ===
+        JSON.stringify({
+          references: [],
+          metadata: { lifecycleRetention: row.retention_tombstone_reason },
+        }) &&
+      row.provenance ===
+        JSON.stringify({
+          source: 'retention-service',
+          sourceEventIds: [],
+          sourceReferences: [],
+        })
+    );
+  }
+
+  private tombstone(reason: 'privacy-deleted' | 'retention-compacted'): {
+    payload: string;
+    provenance: string;
+    retention_tombstone_reason: string;
+  } {
+    return {
+      payload: JSON.stringify({
+        references: [],
+        metadata: {
+          lifecycleRetention: reason,
+        },
+      }),
+      provenance: JSON.stringify({
+        source: 'retention-service',
+        sourceEventIds: [],
+        sourceReferences: [],
+      }),
+      retention_tombstone_reason: reason,
+    };
   }
 }

--- a/src/lifecycle/contracts/index.ts
+++ b/src/lifecycle/contracts/index.ts
@@ -96,6 +96,7 @@ export {
 } from './signal-contract.js';
 export {
   LifecycleConfigSchema,
+  LifecycleRetentionConfigSchema,
   LifecycleEventSubscriptionContractSchema,
   LifecycleInterceptorSubscriptionContractSchema,
   LifecycleSubscriptionContractSchema,
@@ -103,6 +104,7 @@ export {
   PersonaLifecycleConfigSchema,
   PersonaLifecycleSubscriptionSchema,
   type LifecycleConfig,
+  type LifecycleRetentionConfig,
   type LifecycleSubscriptionContract,
   type PersonaLifecycleConfig,
   type PersonaLifecycleSubscription,

--- a/src/lifecycle/contracts/subscription-contract.ts
+++ b/src/lifecycle/contracts/subscription-contract.ts
@@ -64,14 +64,28 @@ export const PersonaLifecycleConfigSchema = z
   })
   .strict();
 
+export const LifecycleRetentionConfigSchema = z
+  .object({
+    completedAuditWindowMs: z
+      .number()
+      .int()
+      .min(0)
+      .default(30 * 24 * 60 * 60 * 1000),
+  })
+  .strict();
+
 export const LifecycleConfigSchema = z
   .object({
     enabled: z.boolean().default(false),
     handlers: z.array(LifecycleHandlerContractSchema).max(MAX_LIFECYCLE_ATTACHMENTS).default([]),
+    retention: LifecycleRetentionConfigSchema.default(() =>
+      LifecycleRetentionConfigSchema.parse({}),
+    ),
   })
   .strict();
 
 export type LifecycleSubscriptionContract = z.infer<typeof LifecycleSubscriptionContractSchema>;
 export type PersonaLifecycleSubscription = z.infer<typeof PersonaLifecycleSubscriptionSchema>;
 export type PersonaLifecycleConfig = z.infer<typeof PersonaLifecycleConfigSchema>;
+export type LifecycleRetentionConfig = z.infer<typeof LifecycleRetentionConfigSchema>;
 export type LifecycleConfig = z.infer<typeof LifecycleConfigSchema>;

--- a/src/lifecycle/lifecycle-admin-service.ts
+++ b/src/lifecycle/lifecycle-admin-service.ts
@@ -1,0 +1,65 @@
+/** Operator-facing lifecycle administration primitives. */
+
+import { err, ok, type Result } from 'neverthrow';
+import type { AuditLogger } from '../core/logging/audit-logger.js';
+import { DbError, LifecycleError } from '../core/errors/index.js';
+import type {
+  LifecycleDeliveryRepository,
+  LifecycleDeliveryRow,
+} from '../core/database/repositories/index.js';
+import { LifecycleIdentifierSchema, LifecycleRuntimeIdSchema } from './contracts/index.js';
+
+export interface LifecycleAdminServiceOptions {
+  readonly deliveries: Pick<LifecycleDeliveryRepository, 'reopen' | 'disableHandler'>;
+  readonly auditLogger?: Pick<AuditLogger, 'logLifecycleDisablement'>;
+}
+
+export interface LifecycleDisableHandlerResult {
+  readonly handlerId: string;
+  readonly disabledDeliveries: number;
+}
+
+type LifecycleAdminError = DbError | LifecycleError;
+
+export class LifecycleAdminService {
+  constructor(private readonly options: LifecycleAdminServiceOptions) {}
+
+  replayDelivery(
+    eventId: string,
+    handlerId: string,
+  ): Result<LifecycleDeliveryRow, LifecycleAdminError> {
+    if (
+      !LifecycleRuntimeIdSchema.safeParse(eventId).success ||
+      !LifecycleIdentifierSchema.safeParse(handlerId).success
+    ) {
+      return err(new LifecycleError('invalid lifecycle replay delivery identity'));
+    }
+    return this.options.deliveries.reopen(eventId, handlerId);
+  }
+
+  disableHandler(handlerId: string): Result<LifecycleDisableHandlerResult, LifecycleAdminError> {
+    if (!LifecycleIdentifierSchema.safeParse(handlerId).success) {
+      return err(new LifecycleError('invalid lifecycle handler id'));
+    }
+    const disabled = this.options.deliveries.disableHandler(handlerId);
+    if (disabled.isErr()) return err(disabled.error);
+    const result = {
+      handlerId,
+      disabledDeliveries: disabled.value.disabledDeliveries,
+    };
+    try {
+      this.options.auditLogger?.logLifecycleDisablement({
+        action: 'lifecycle.disablement',
+        details: {
+          operation: 'handler_disable',
+          outcome: 'success',
+          handlerId,
+          disabledDeliveries: result.disabledDeliveries,
+        },
+      });
+    } catch {
+      // Disablement has already committed. Audit outages are advisory.
+    }
+    return ok(result);
+  }
+}

--- a/src/lifecycle/retention-service.ts
+++ b/src/lifecycle/retention-service.ts
@@ -1,0 +1,128 @@
+/** Lifecycle event retention and privacy tombstoning orchestration. */
+
+import { err, ok, type Result } from 'neverthrow';
+import type { AuditLogger } from '../core/logging/audit-logger.js';
+import { DbError, LifecycleError } from '../core/errors/index.js';
+import type {
+  LifecycleDeliveryRepository,
+  LifecycleEventRepository,
+} from '../core/database/repositories/index.js';
+import { LifecycleFilterOwnerNameSchema, LifecycleRuntimeIdSchema } from './contracts/index.js';
+
+export interface LifecycleRetentionServiceOptions {
+  readonly events: Pick<
+    LifecycleEventRepository,
+    'compactCompletedBefore' | 'tombstoneThread' | 'tombstonePersona' | 'transaction'
+  >;
+  readonly deliveries: Pick<LifecycleDeliveryRepository, 'tombstoneThread' | 'tombstonePersona'>;
+  readonly auditLogger?: Pick<AuditLogger, 'logLifecycleDecision'>;
+  readonly clock?: () => number;
+}
+
+export interface LifecycleRetentionResult {
+  readonly compactedEvents: number;
+  readonly disabledDeliveries: number;
+}
+
+type LifecycleRetentionError = DbError | LifecycleError;
+
+export class LifecycleRetentionService {
+  private readonly clock: () => number;
+
+  constructor(private readonly options: LifecycleRetentionServiceOptions) {
+    this.clock = options.clock ?? Date.now;
+  }
+
+  compactCompleted(
+    auditWindowMs: number,
+  ): Result<LifecycleRetentionResult, LifecycleRetentionError> {
+    if (
+      !Number.isSafeInteger(auditWindowMs) ||
+      auditWindowMs < 0 ||
+      !Number.isSafeInteger(this.clock())
+    ) {
+      return err(new LifecycleError('invalid lifecycle retention audit window'));
+    }
+    const cutoff = this.clock() - auditWindowMs;
+    if (!Number.isSafeInteger(cutoff)) {
+      return err(new LifecycleError('invalid lifecycle retention cutoff'));
+    }
+    const compacted = this.options.events.compactCompletedBefore(cutoff);
+    if (compacted.isErr()) return err(compacted.error);
+    const result = {
+      compactedEvents: compacted.value.compactedEvents,
+      disabledDeliveries: 0,
+    };
+    this.audit('retention_compact', result);
+    return ok(result);
+  }
+
+  tombstoneThread(threadId: string): Result<LifecycleRetentionResult, LifecycleRetentionError> {
+    if (!LifecycleRuntimeIdSchema.safeParse(threadId).success) {
+      return err(new LifecycleError('invalid lifecycle privacy thread id'));
+    }
+    return this.atomicPrivacyMutation('privacy_thread', () => {
+      const deliveries = this.options.deliveries.tombstoneThread(threadId);
+      if (deliveries.isErr()) return err(deliveries.error);
+      const events = this.options.events.tombstoneThread(threadId);
+      if (events.isErr()) return err(events.error);
+      return ok({
+        compactedEvents: events.value.compactedEvents,
+        disabledDeliveries: deliveries.value.disabledDeliveries,
+      });
+    });
+  }
+
+  tombstonePersona(persona: string): Result<LifecycleRetentionResult, LifecycleRetentionError> {
+    if (!LifecycleFilterOwnerNameSchema.safeParse(persona).success) {
+      return err(new LifecycleError('invalid lifecycle privacy persona'));
+    }
+    return this.atomicPrivacyMutation('privacy_persona', () => {
+      const deliveries = this.options.deliveries.tombstonePersona(persona);
+      if (deliveries.isErr()) return err(deliveries.error);
+      const events = this.options.events.tombstonePersona(persona);
+      if (events.isErr()) return err(events.error);
+      return ok({
+        compactedEvents: events.value.compactedEvents,
+        disabledDeliveries: deliveries.value.disabledDeliveries,
+      });
+    });
+  }
+
+  private atomicPrivacyMutation(
+    operation: 'privacy_thread' | 'privacy_persona',
+    mutate: () => Result<LifecycleRetentionResult, DbError>,
+  ): Result<LifecycleRetentionResult, LifecycleRetentionError> {
+    let domainError: DbError | undefined;
+    try {
+      const result = this.options.events.transaction(() => {
+        const mutation = mutate();
+        if (mutation.isErr()) {
+          domainError = mutation.error;
+          throw mutation.error;
+        }
+        return mutation.value;
+      });
+      this.audit(operation, result);
+      return ok(result);
+    } catch {
+      return err(domainError ?? new DbError('Failed to apply lifecycle privacy tombstone'));
+    }
+  }
+
+  private audit(operation: string, result: LifecycleRetentionResult): void {
+    try {
+      this.options.auditLogger?.logLifecycleDecision({
+        action: 'lifecycle.retention',
+        details: {
+          operation,
+          outcome: 'success',
+          compactedEvents: result.compactedEvents,
+          disabledDeliveries: result.disabledDeliveries,
+        },
+      });
+    } catch {
+      // Retention durability is decided by SQLite; audit logging is advisory.
+    }
+  }
+}

--- a/tests/unit/core/config/config-schema.test.ts
+++ b/tests/unit/core/config/config-schema.test.ts
@@ -1311,6 +1311,41 @@ describe('TalondConfigSchema', () => {
       }
     });
 
+    it('validates lifecycle retention compaction policy when lifecycle is configured', () => {
+      const defaulted = TalondConfigSchema.safeParse({
+        lifecycle: { enabled: true, handlers: [] },
+      });
+
+      expect(defaulted.success).toBe(true);
+      if (defaulted.success) {
+        expect(defaulted.data.lifecycle?.retention.completedAuditWindowMs).toBe(
+          30 * 24 * 60 * 60 * 1000,
+        );
+      }
+
+      const configured = TalondConfigSchema.safeParse({
+        lifecycle: {
+          enabled: true,
+          handlers: [],
+          retention: { completedAuditWindowMs: 86_400_000 },
+        },
+      });
+      expect(configured.success).toBe(true);
+      if (configured.success) {
+        expect(configured.data.lifecycle?.retention.completedAuditWindowMs).toBe(86_400_000);
+      }
+
+      expect(
+        TalondConfigSchema.safeParse({
+          lifecycle: {
+            enabled: true,
+            handlers: [],
+            retention: { completedAuditWindowMs: -1 },
+          },
+        }).success,
+      ).toBe(false);
+    });
+
     it('preserves duplicate owner names unless lifecycle registry validation is enabled', () => {
       const duplicateOwnerNames = {
         channels: [

--- a/tests/unit/core/database/migrations/runner.test.ts
+++ b/tests/unit/core/database/migrations/runner.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
 import { runMigrations } from '../../../../../src/core/database/migrations/runner.js';
+import { withLifecycleRetentionMutationAuthorization } from '../../../../../src/core/database/lifecycle-sql-functions.js';
 
 /** Creates an isolated in-memory database with WAL disabled (not needed for tests). */
 function freshDb(): Database.Database {
@@ -439,8 +440,8 @@ describe('runMigrations', () => {
     expect(db.pragma('user_version', { simple: true })).toBe(13);
 
     const upgrade = runMigrations(db, realMigrationsDir);
-    expect(upgrade._unsafeUnwrap()).toBe(5);
-    expect(db.pragma('user_version', { simple: true })).toBe(18);
+    expect(upgrade._unsafeUnwrap()).toBe(6);
+    expect(db.pragma('user_version', { simple: true })).toBe(19);
     for (const table of [
       'lifecycle_events',
       'lifecycle_event_deliveries',
@@ -611,6 +612,18 @@ describe('runMigrations', () => {
     expect(() =>
       db
         .prepare(
+          `UPDATE lifecycle_events
+           SET payload = ?, provenance = ?, retention_tombstone_reason = 'privacy-deleted'
+           WHERE event_id = 'event-1'`,
+        )
+        .run(
+          '{"references":[],"metadata":{"lifecycleRetention":"privacy-deleted"}}',
+          '{"source":"retention-service","sourceEventIds":[],"sourceReferences":[]}',
+        ),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
           `INSERT INTO lifecycle_event_deliveries (
           event_id, handler_id, persona, priority, handler_identity, failure_policy,
           status, attempts, max_attempts, created_at, updated_at
@@ -703,8 +716,8 @@ describe('runMigrations', () => {
         )
         .run(identityFor('preserved-handler'));
 
-      expect(runMigrations(preservedDb, realMigrationsDir)._unsafeUnwrap()).toBe(4);
-      expect(preservedDb.pragma('user_version', { simple: true })).toBe(18);
+      expect(runMigrations(preservedDb, realMigrationsDir)._unsafeUnwrap()).toBe(5);
+      expect(preservedDb.pragma('user_version', { simple: true })).toBe(19);
       expect(
         preservedDb
           .prepare(
@@ -768,6 +781,165 @@ describe('runMigrations', () => {
         failurePolicy,
       }),
     ).not.toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lifecycle_events (
+            event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+            causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+            retention_tombstone_reason, occurred_at, created_at
+          ) VALUES ('forged-retention-event', 'v1', 'run.completed.v1', 'thread',
+            'forged-thread', 'forged-correlation', NULL, 0, 1,
+            '{"source":"retention-service","sourceEventIds":[],"sourceReferences":[]}',
+            '{"references":[],"metadata":{"lifecycleRetention":"retention-compacted"}}',
+            'retention-compacted', '2026-07-16T10:00:00.000Z', 1)`,
+        )
+        .run(),
+    ).toThrow(/system-owned/);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lifecycle_event_deliveries (
+            event_id, handler_id, persona, priority, handler_identity, failure_policy,
+            status, attempts, max_attempts, terminal_tombstone_reason, created_at, updated_at
+          ) VALUES ('event-1', 'forged-terminal-handler', 'support', 0, ?, ?,
+            'pending', 0, 1, 'handler-disabled', 1, 1)`,
+        )
+        .run(identityFor('forged-terminal-handler'), failurePolicy),
+    ).toThrow(/system-owned/);
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET status = 'dead_letter',
+               attempts = 1,
+               next_retry_at = NULL,
+               claim_token = NULL,
+               claim_expires_at = NULL,
+               last_error = '{"code":"privacy-deleted"}',
+               terminal_tombstone_reason = 'privacy-deleted',
+               completed_at = NULL,
+               updated_at = 2
+           WHERE event_id = 'event-1' AND handler_id = 'handler-4'`,
+        )
+        .run(),
+    ).toThrow();
+
+    const retentionProvenance =
+      '{"source":"retention-service","sourceEventIds":[],"sourceReferences":[]}';
+    const tombstonePayload = (reason: 'privacy-deleted' | 'retention-compacted'): string =>
+      JSON.stringify({ references: [], metadata: { lifecycleRetention: reason } });
+    const insertReplayGuardEvent = (eventId: string): void => {
+      db.prepare(
+        `INSERT INTO lifecycle_events (
+          event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+          causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+          occurred_at, created_at
+        ) VALUES (@eventId, 'v1', 'run.completed.v1', 'thread', @eventId, @eventId,
+          NULL, 0, 1, '{"source":"daemon","sourceEventIds":[],"sourceReferences":[]}',
+          '{"references":[],"metadata":{}}', '2026-07-16T10:00:00.000Z', 1)`,
+      ).run({ eventId });
+    };
+    const insertReplayGuardDelivery = (eventId: string, handlerId: string): void => {
+      db.prepare(
+        `INSERT INTO lifecycle_event_deliveries (
+          event_id, handler_id, persona, priority, handler_identity, failure_policy,
+          status, attempts, max_attempts, created_at, updated_at
+        ) VALUES (?, ?, 'support', 0, ?, ?, 'pending', 0, 2, 1, 1)`,
+      ).run(eventId, handlerId, identityFor(handlerId), failurePolicy);
+    };
+    const completeReplayGuardDelivery = (eventId: string, handlerId: string): void => {
+      const claimToken = `${handlerId}-claim`;
+      db.prepare(
+        `UPDATE lifecycle_event_deliveries
+         SET status = 'claimed',
+             next_retry_at = NULL,
+             claim_token = ?,
+             claim_expires_at = 100,
+             last_error = NULL,
+             updated_at = 2
+         WHERE event_id = ? AND handler_id = ?`,
+      ).run(claimToken, eventId, handlerId);
+      db.prepare(
+        `UPDATE lifecycle_event_deliveries
+         SET status = 'completed',
+             next_retry_at = NULL,
+             claim_token = NULL,
+             claim_expires_at = NULL,
+             last_error = NULL,
+             completed_at = 3,
+             updated_at = 3
+         WHERE event_id = ? AND handler_id = ?`,
+      ).run(eventId, handlerId);
+    };
+    const tombstoneReplayGuardEvent = (
+      eventId: string,
+      reason: 'privacy-deleted' | 'retention-compacted',
+    ): void => {
+      withLifecycleRetentionMutationAuthorization(db, () => {
+        db.prepare(
+          `UPDATE lifecycle_events
+           SET payload = ?, provenance = ?, retention_tombstone_reason = ?
+           WHERE event_id = ?`,
+        ).run(tombstonePayload(reason), retentionProvenance, reason, eventId);
+      });
+    };
+    const deadLetterReplayGuardDelivery = (
+      eventId: string,
+      handlerId: string,
+      code: 'handler-disabled' | 'privacy-deleted',
+    ): void => {
+      withLifecycleRetentionMutationAuthorization(db, () => {
+        db.prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET status = 'dead_letter',
+               attempts = 1,
+               next_retry_at = NULL,
+               claim_token = NULL,
+               claim_expires_at = NULL,
+               last_error = ?,
+               terminal_tombstone_reason = ?,
+               completed_at = NULL,
+               updated_at = 2
+           WHERE event_id = ? AND handler_id = ?`,
+        ).run(JSON.stringify({ code }), code, eventId, handlerId);
+      });
+    };
+    const directReplay = (eventId: string, handlerId: string): void => {
+      db.prepare(
+        `UPDATE lifecycle_event_deliveries
+         SET status = 'pending',
+             attempts = 0,
+             next_retry_at = NULL,
+             claim_token = NULL,
+             claim_expires_at = NULL,
+             last_error = NULL,
+             completed_at = NULL,
+             updated_at = 4
+         WHERE event_id = ? AND handler_id = ?`,
+      ).run(eventId, handlerId);
+    };
+
+    for (const [eventId, handlerId, reason] of [
+      ['retention-replay-event', 'retention-replay-handler', 'retention-compacted'],
+      ['privacy-replay-event', 'privacy-replay-handler', 'privacy-deleted'],
+    ] as const) {
+      insertReplayGuardEvent(eventId);
+      insertReplayGuardDelivery(eventId, handlerId);
+      completeReplayGuardDelivery(eventId, handlerId);
+      tombstoneReplayGuardEvent(eventId, reason);
+      expect(() => directReplay(eventId, handlerId)).toThrow();
+    }
+    for (const [eventId, handlerId, code] of [
+      ['handler-disabled-replay-event', 'handler-disabled-replay-handler', 'handler-disabled'],
+      ['delivery-privacy-replay-event', 'delivery-privacy-replay-handler', 'privacy-deleted'],
+    ] as const) {
+      insertReplayGuardEvent(eventId);
+      insertReplayGuardDelivery(eventId, handlerId);
+      deadLetterReplayGuardDelivery(eventId, handlerId, code);
+      expect(() => directReplay(eventId, handlerId)).toThrow();
+    }
+
     // Identity and policy are one authority decision. A syntactically valid
     // policy cannot be paired with the wrong handler mode on INSERT or UPDATE.
     for (const [handlerId, identity, incompatiblePolicy] of [

--- a/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
+++ b/tests/unit/core/database/repositories/lifecycle-event-repository.test.ts
@@ -117,6 +117,7 @@ describe('lifecycle event persistence', () => {
     // updates; removing the guards in this isolated test database lets reload
     // validation remain tested as a separate defense in depth.
     db.exec('DROP TRIGGER IF EXISTS lifecycle_events_reject_updates');
+    db.exec('DROP TRIGGER IF EXISTS lifecycle_events_guard_retention_updates');
     db.exec('DROP TRIGGER IF EXISTS lifecycle_event_deliveries_guard_transitions');
     db.pragma('ignore_check_constraints = ON');
     try {
@@ -817,6 +818,133 @@ describe('lifecycle event persistence', () => {
     expect(deliveries.findByEventId(input.eventId)._unsafeUnwrap()).toHaveLength(1);
   });
 
+  it('reopens ordinary dead-letters that use tombstone-like diagnostic codes', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+
+    for (const code of ['privacy-deleted', 'handler-disabled'] as const) {
+      const handlerId = `ordinary-${code}`;
+      const input = event();
+      events.insertWithDeliveries(input, [delivery(handlerId)])._unsafeUnwrap();
+      const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      expect(claim.delivery.event_id).toBe(input.eventId);
+      deliveries
+        .fail(input.eventId, handlerId, claim.delivery.claim_token!, { code }, now + 500, false)
+        ._unsafeUnwrap();
+
+      const reopened = deliveries.reopen(input.eventId, handlerId)._unsafeUnwrap();
+
+      expect(reopened).toMatchObject({
+        status: 'pending',
+        attempts: 0,
+        last_error: null,
+        terminal_tombstone_reason: null,
+      });
+      const replayClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      expect(replayClaim.delivery.event_id).toBe(input.eventId);
+      deliveries
+        .complete(input.eventId, handlerId, replayClaim.delivery.claim_token!)
+        ._unsafeUnwrap();
+    }
+  });
+
+  it('rejects direct SQL replay of tombstoned terminal deliveries', () => {
+    const now = 1_800_000_000_000;
+    leaseNow = now;
+    const directReplay = (eventId: string, handlerId: string): void => {
+      db.prepare(
+        `UPDATE lifecycle_event_deliveries
+         SET status = 'pending',
+             attempts = 0,
+             next_retry_at = NULL,
+             claim_token = NULL,
+             claim_expires_at = NULL,
+             last_error = NULL,
+             completed_at = NULL,
+             updated_at = 2
+         WHERE event_id = ? AND handler_id = ?`,
+      ).run(eventId, handlerId);
+    };
+    const complete = (input: LifecycleEventEnvelope, handlerId: string): void => {
+      const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      expect(claim.delivery.event_id).toBe(input.eventId);
+      deliveries.complete(input.eventId, handlerId, claim.delivery.claim_token!)._unsafeUnwrap();
+    };
+
+    const retentionCompacted = event();
+    events
+      .insertWithDeliveries(retentionCompacted, [delivery('retention-handler')])
+      ._unsafeUnwrap();
+    complete(retentionCompacted, 'retention-handler');
+    expect(events.compactCompletedBefore(Number.MAX_SAFE_INTEGER)._unsafeUnwrap()).toEqual({
+      compactedEvents: 1,
+    });
+    expect(deliveries.reopen(retentionCompacted.eventId, 'retention-handler').isErr()).toBe(true);
+    expect(() => directReplay(retentionCompacted.eventId, 'retention-handler')).toThrow(
+      /invalid lifecycle delivery update/,
+    );
+
+    const privacyThreadId = `thread-${uuid()}`;
+    const privacyDeletedEvent = event({
+      context: { ...event().context, aggregate: { type: 'thread', id: privacyThreadId } },
+    });
+    events
+      .insertWithDeliveries(privacyDeletedEvent, [delivery('privacy-event-handler')])
+      ._unsafeUnwrap();
+    complete(privacyDeletedEvent, 'privacy-event-handler');
+    expect(events.tombstoneThread(privacyThreadId)._unsafeUnwrap()).toEqual({
+      compactedEvents: 1,
+    });
+    expect(deliveries.reopen(privacyDeletedEvent.eventId, 'privacy-event-handler').isErr()).toBe(
+      true,
+    );
+    expect(() => directReplay(privacyDeletedEvent.eventId, 'privacy-event-handler')).toThrow(
+      /invalid lifecycle delivery update/,
+    );
+
+    const handlerDisabled = event();
+    events
+      .insertWithDeliveries(handlerDisabled, [delivery('disabled-replay-handler')])
+      ._unsafeUnwrap();
+    expect(deliveries.disableHandler('disabled-replay-handler')._unsafeUnwrap()).toEqual({
+      disabledDeliveries: 1,
+    });
+    expect(deliveries.reopen(handlerDisabled.eventId, 'disabled-replay-handler').isErr()).toBe(
+      true,
+    );
+    expect(() => directReplay(handlerDisabled.eventId, 'disabled-replay-handler')).toThrow(
+      /invalid lifecycle delivery update/,
+    );
+
+    const privacyDeliveryThreadId = `thread-${uuid()}`;
+    const privacyDeletedDelivery = event({
+      context: { ...event().context, aggregate: { type: 'thread', id: privacyDeliveryThreadId } },
+    });
+    events
+      .insertWithDeliveries(privacyDeletedDelivery, [delivery('privacy-delivery-handler')])
+      ._unsafeUnwrap();
+    expect(deliveries.tombstoneThread(privacyDeliveryThreadId)._unsafeUnwrap()).toEqual({
+      disabledDeliveries: 1,
+    });
+    expect(
+      deliveries.reopen(privacyDeletedDelivery.eventId, 'privacy-delivery-handler').isErr(),
+    ).toBe(true);
+    expect(() => directReplay(privacyDeletedDelivery.eventId, 'privacy-delivery-handler')).toThrow(
+      /invalid lifecycle delivery update/,
+    );
+
+    for (const [eventId, handlerId] of [
+      [retentionCompacted.eventId, 'retention-handler'],
+      [privacyDeletedEvent.eventId, 'privacy-event-handler'],
+      [handlerDisabled.eventId, 'disabled-replay-handler'],
+      [privacyDeletedDelivery.eventId, 'privacy-delivery-handler'],
+    ] as const) {
+      expect(deliveries.findByKey(eventId, handlerId)._unsafeUnwrap()?.status).toMatch(
+        /^(completed|dead_letter)$/,
+      );
+    }
+  });
+
   it('emits bounded audit and metric evidence when reopening a delivery for replay', () => {
     const now = 1_800_000_000_000;
     leaseNow = now;
@@ -905,24 +1033,90 @@ describe('lifecycle event persistence', () => {
     try {
       expect(runMigrations(legacyDb, committedV14Migrations())._unsafeUnwrap()).toBe(15);
       expect(legacyDb.pragma('user_version', { simple: true })).toBe(14);
-      const legacyEvents = new LifecycleEventRepository(legacyDb);
-      const legacyDeliveries = new LifecycleDeliveryRepository(legacyDb, () => upgradeLeaseNow);
       const input = event();
-      legacyEvents.insertWithDeliveries(input, [{ ...delivery(), maxAttempts: 3 }])._unsafeUnwrap();
-      const lease = legacyDeliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      const inputDelivery = delivery();
+      const claimToken = uuid();
+      legacyDb
+        .prepare(
+          `INSERT INTO lifecycle_events (
+            event_id, version, type, aggregate_type, aggregate_id, correlation_id,
+            causation_id, recursion_depth, recursion_max_depth, provenance, payload,
+            occurred_at, created_at
+          ) VALUES (
+            @eventId, @version, @type, @aggregateType, @aggregateId, @correlationId,
+            NULL, @recursionDepth, @recursionMaxDepth, @provenance, @payload,
+            @occurredAt, @createdAt
+          )`,
+        )
+        .run({
+          eventId: input.eventId,
+          version: input.version,
+          type: input.type,
+          aggregateType: input.context.aggregate.type,
+          aggregateId: input.context.aggregate.id,
+          correlationId: input.context.correlationId,
+          recursionDepth: input.context.recursion.depth,
+          recursionMaxDepth: input.context.recursion.maxDepth,
+          provenance: JSON.stringify({
+            source: input.context.provenance.source,
+            sourceEventIds: [],
+            sourceReferences: [],
+          }),
+          payload: JSON.stringify(input.payload),
+          occurredAt: input.occurredAt,
+          createdAt: upgradeLeaseNow,
+        });
+      legacyDb
+        .prepare(
+          `INSERT INTO lifecycle_event_deliveries (
+            event_id, handler_id, persona, priority, handler_identity, failure_policy,
+            status, attempts, max_attempts, created_at, updated_at
+          ) VALUES (
+            @eventId, @handlerId, @persona, @priority, @identity, @failurePolicy,
+            'pending', 0, 3, @createdAt, @updatedAt
+          )`,
+        )
+        .run({
+          eventId: input.eventId,
+          handlerId: inputDelivery.handlerId,
+          persona: inputDelivery.persona,
+          priority: inputDelivery.priority,
+          identity: JSON.stringify(inputDelivery.identity),
+          failurePolicy: JSON.stringify(inputDelivery.failurePolicy),
+          createdAt: upgradeLeaseNow,
+          updatedAt: upgradeLeaseNow,
+        });
+      legacyDb
+        .prepare(
+          `UPDATE lifecycle_event_deliveries
+           SET status = 'claimed',
+               next_retry_at = NULL,
+               claim_token = ?,
+               claim_expires_at = ?,
+               last_error = NULL,
+               updated_at = ?
+           WHERE event_id = ? AND handler_id = ?`,
+        )
+        .run(
+          claimToken,
+          upgradeLeaseNow + 100,
+          upgradeLeaseNow + 1,
+          input.eventId,
+          inputDelivery.handlerId,
+        );
 
       const currentMigrations = join(
         import.meta.dirname,
         '../../../../../src/core/database/migrations',
       );
-      expect(runMigrations(legacyDb, currentMigrations)._unsafeUnwrap()).toBe(4);
-      expect(legacyDb.pragma('user_version', { simple: true })).toBe(18);
+      expect(runMigrations(legacyDb, currentMigrations)._unsafeUnwrap()).toBe(5);
+      expect(legacyDb.pragma('user_version', { simple: true })).toBe(19);
       const upgradedDeliveries = new LifecycleDeliveryRepository(legacyDb, () => upgradeLeaseNow);
       const terminal = upgradedDeliveries
         .fail(
           input.eventId,
           'run-projector',
-          lease.delivery.claim_token!,
+          claimToken,
           { code: 'permanent-failure' },
           upgradeLeaseNow + 500,
           false,

--- a/tests/unit/daemon/reload.test.ts
+++ b/tests/unit/daemon/reload.test.ts
@@ -100,7 +100,13 @@ function makeMockContext(configOverrides: Record<string, unknown> = {}): DaemonC
       schedule: {} as any,
       audit: {} as any,
       message: {} as any,
-      run: { aggregateByPeriod: vi.fn().mockReturnValue(ok({ total_input_tokens: 0, total_output_tokens: 0, total_cost_usd: 0 })) } as any,
+      run: {
+        aggregateByPeriod: vi
+          .fn()
+          .mockReturnValue(
+            ok({ total_input_tokens: 0, total_output_tokens: 0, total_cost_usd: 0 }),
+          ),
+      } as any,
       binding: {} as any,
       memory: {} as any,
     },
@@ -130,7 +136,13 @@ function makeMockContext(configOverrides: Record<string, unknown> = {}): DaemonC
     backgroundAgentManager: { shutdown: vi.fn() } as any,
     contextAssembler: {} as any,
     hostToolsBridge: { path: '/tmp/host-tools.sock', start: vi.fn(), stop: vi.fn() } as any,
-    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() } as any,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      child: vi.fn().mockReturnThis(),
+    } as any,
   };
 }
 
@@ -283,6 +295,82 @@ describe('TalondDaemon.reload()', () => {
       expect(ctx.personaLoader.loadFromConfig).not.toHaveBeenCalled();
       expect(ctx.channelRegistry.stopAll).not.toHaveBeenCalled();
       expect(ctx.config.logLevel).toBe('info');
+    });
+
+    it('rejects lifecycle handler identity/version changes before applying mutable reload work', async () => {
+      const handler = {
+        version: 'v1',
+        id: 'retention-projector',
+        displayName: 'Retention Projector',
+        mode: 'event',
+        inputContract: 'talon.lifecycle.event.envelope.v1',
+        outputContract: 'talon.lifecycle.signal.envelopes.v1',
+        runtime: {
+          kind: 'native',
+          ref: 'retention-projector',
+          implementationVersion: '1.0.0',
+        },
+      };
+      const ctx = setupSuccessfulStart({
+        lifecycle: { enabled: true, handlers: [handler] },
+      });
+      await daemon.start('/config.yaml');
+
+      const newConfig = makeConfig({
+        logLevel: 'debug',
+        lifecycle: {
+          enabled: true,
+          handlers: [
+            {
+              ...handler,
+              displayName: 'Retention Projector v2',
+              runtime: { ...handler.runtime, implementationVersion: '2.0.0' },
+            },
+          ],
+        },
+      });
+      vi.mocked(loadConfig).mockReturnValue(ok(newConfig as any));
+
+      const result = await daemon.reload('/config.yaml');
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().message).toContain('restart required');
+      expect(ctx.personaLoader.loadFromConfig).not.toHaveBeenCalled();
+      expect(ctx.channelRegistry.stopAll).not.toHaveBeenCalled();
+      expect(ctx.config.logLevel).toBe('info');
+    });
+
+    it('rejects lifecycle retention policy changes before applying mutable reload work', async () => {
+      const ctx = setupSuccessfulStart({
+        lifecycle: {
+          enabled: true,
+          handlers: [],
+          retention: { completedAuditWindowMs: 86_400_000 },
+        },
+      });
+      await daemon.start('/config.yaml');
+
+      const newConfig = makeConfig({
+        logLevel: 'debug',
+        lifecycle: {
+          enabled: true,
+          handlers: [],
+          retention: { completedAuditWindowMs: 172_800_000 },
+        },
+      });
+      vi.mocked(loadConfig).mockReturnValue(ok(newConfig as any));
+
+      const result = await daemon.reload('/config.yaml');
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().message).toContain('restart required');
+      expect(ctx.personaLoader.loadFromConfig).not.toHaveBeenCalled();
+      expect(ctx.channelRegistry.stopAll).not.toHaveBeenCalled();
+      expect(ctx.config.lifecycle).toEqual({
+        enabled: true,
+        handlers: [],
+        retention: { completedAuditWindowMs: 86_400_000 },
+      });
     });
 
     it('rejects persona lifecycle subscription changes before reloading personas', async () => {
@@ -541,7 +629,15 @@ describe('TalondDaemon.reload()', () => {
       const logSpy = vi.spyOn(logger, 'info');
 
       const newConfig = makeConfig({
-        personas: [{ name: 'new-bot', model: 'claude-sonnet-4-6', skills: [], capabilities: { allow: [], requireApproval: [] }, mounts: [] }],
+        personas: [
+          {
+            name: 'new-bot',
+            model: 'claude-sonnet-4-6',
+            skills: [],
+            capabilities: { allow: [], requireApproval: [] },
+            mounts: [],
+          },
+        ],
       });
       vi.mocked(loadConfig).mockReturnValue(ok(newConfig as any));
 
@@ -564,7 +660,15 @@ describe('TalondDaemon.reload()', () => {
 
     it('logs removed personas', async () => {
       setupSuccessfulStart({
-        personas: [{ name: 'old-bot', model: 'claude-sonnet-4-6', skills: [], capabilities: { allow: [], requireApproval: [] }, mounts: [] }],
+        personas: [
+          {
+            name: 'old-bot',
+            model: 'claude-sonnet-4-6',
+            skills: [],
+            capabilities: { allow: [], requireApproval: [] },
+            mounts: [],
+          },
+        ],
       });
       const logger = createDiscardLogger('silent');
       const localDaemon = new TalondDaemon(logger);
@@ -592,7 +696,13 @@ describe('TalondDaemon.reload()', () => {
     });
 
     it('logs changed personas', async () => {
-      const persona = { name: 'agent', model: 'claude-sonnet-4-6', skills: [], capabilities: { allow: [], requireApproval: [] }, mounts: [] };
+      const persona = {
+        name: 'agent',
+        model: 'claude-sonnet-4-6',
+        skills: [],
+        capabilities: { allow: [], requireApproval: [] },
+        mounts: [],
+      };
       setupSuccessfulStart({ personas: [persona] });
       const logger = createDiscardLogger('silent');
       const localDaemon = new TalondDaemon(logger);
@@ -628,13 +738,17 @@ describe('TalondDaemon.reload()', () => {
 
   describe('queue / scheduler config changes', () => {
     it('logs a warning when queue config changes', async () => {
-      setupSuccessfulStart({ queue: { maxAttempts: 3, backoffBaseMs: 1000, backoffMaxMs: 60000, concurrencyLimit: 2 } });
+      setupSuccessfulStart({
+        queue: { maxAttempts: 3, backoffBaseMs: 1000, backoffMaxMs: 60000, concurrencyLimit: 2 },
+      });
       const logger = createDiscardLogger('silent');
       const localDaemon = new TalondDaemon(logger);
       await localDaemon.start('/config.yaml');
       const warnSpy = vi.spyOn(logger, 'warn');
 
-      const newConfig = makeConfig({ queue: { maxAttempts: 5, backoffBaseMs: 1000, backoffMaxMs: 60000, concurrencyLimit: 2 } });
+      const newConfig = makeConfig({
+        queue: { maxAttempts: 5, backoffBaseMs: 1000, backoffMaxMs: 60000, concurrencyLimit: 2 },
+      });
       vi.mocked(loadConfig).mockReturnValue(ok(newConfig as any));
 
       await localDaemon.reload('/config.yaml');

--- a/tests/unit/lifecycle/lifecycle-admin-service.test.ts
+++ b/tests/unit/lifecycle/lifecycle-admin-service.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  BaseRepository,
+  LifecycleDeliveryRepository,
+  LifecycleEventRepository,
+  type LifecycleDeliveryFanoutInput,
+} from '../../../src/core/database/repositories/index.js';
+import type { LifecycleEventEnvelope } from '../../../src/lifecycle/contracts/index.js';
+import { LifecycleAdminService } from '../../../src/lifecycle/lifecycle-admin-service.js';
+import { LifecycleRetentionService } from '../../../src/lifecycle/retention-service.js';
+import { createTestDb, uuid } from '../core/database/repositories/helpers.js';
+
+describe('LifecycleAdminService', () => {
+  let db: Database.Database;
+  let events: LifecycleEventRepository;
+  let deliveries: LifecycleDeliveryRepository;
+  let leaseNow: number;
+  let auditLogger: {
+    logLifecycleReplay: ReturnType<typeof vi.fn>;
+    logLifecycleDisablement: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    BaseRepository.__resetMonotonicClockForTests();
+    db = createTestDb();
+    events = new LifecycleEventRepository(db);
+    leaseNow = 1_800_000_000_000;
+    auditLogger = {
+      logLifecycleReplay: vi.fn(),
+      logLifecycleDisablement: vi.fn(),
+    };
+    deliveries = new LifecycleDeliveryRepository(db, {
+      leaseClock: () => leaseNow,
+      auditLogger,
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function event(overrides: Partial<LifecycleEventEnvelope> = {}): LifecycleEventEnvelope {
+    return {
+      version: 'v1',
+      eventId: uuid(),
+      type: 'run.completed.v1',
+      occurredAt: '2026-07-16T10:00:00.000Z',
+      context: {
+        aggregate: { type: 'thread', id: `thread-${uuid()}` },
+        correlationId: uuid(),
+        recursion: { depth: 0, maxDepth: 4 },
+        provenance: { source: 'daemon' },
+      },
+      payload: {
+        references: [{ type: 'run', id: uuid() }],
+        metadata: {},
+      },
+      ...overrides,
+    };
+  }
+
+  function delivery(handlerId: string): LifecycleDeliveryFanoutInput {
+    return {
+      handlerId,
+      persona: 'support',
+      priority: 0,
+      identity: {
+        version: 'v1',
+        handlerId,
+        runtimeKind: 'native',
+        implementationRef: handlerId,
+        implementationVersion: '1.0.0',
+        mode: 'event',
+        inputContract: 'talon.lifecycle.event.envelope.v1',
+        outputContract: 'talon.lifecycle.signal.envelopes.v1',
+      },
+      failurePolicy: { version: 'v1', mode: 'dead_letter' },
+      maxAttempts: 3,
+    };
+  }
+
+  function subject(): LifecycleAdminService {
+    return new LifecycleAdminService({ deliveries, auditLogger });
+  }
+
+  function retentionSubject(): LifecycleRetentionService {
+    return new LifecycleRetentionService({
+      events,
+      deliveries,
+      clock: () => Number.MAX_SAFE_INTEGER,
+    });
+  }
+
+  it('replays exactly one terminal handler delivery without duplicating fan-out identity', () => {
+    const input = event();
+    events
+      .insertWithDeliveries(input, [delivery('first-handler'), delivery('second-handler')])
+      ._unsafeUnwrap();
+    for (let index = 0; index < 2; index += 1) {
+      const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      deliveries
+        .complete(input.eventId, claim.delivery.handler_id, claim.delivery.claim_token!)
+        ._unsafeUnwrap();
+    }
+
+    const replayed = subject().replayDelivery(input.eventId, 'first-handler');
+
+    expect(replayed._unsafeUnwrap()).toMatchObject({
+      event_id: input.eventId,
+      handler_id: 'first-handler',
+      status: 'pending',
+      attempts: 0,
+    });
+    expect(deliveries.findByEventId(input.eventId)._unsafeUnwrap()).toHaveLength(2);
+    expect(deliveries.findByKey(input.eventId, 'second-handler')._unsafeUnwrap()).toMatchObject({
+      status: 'completed',
+    });
+    expect(auditLogger.logLifecycleReplay).toHaveBeenCalledWith({
+      action: 'lifecycle.replay',
+      details: expect.objectContaining({
+        operation: 'delivery_reopen',
+        eventId: input.eventId,
+        handlerId: 'first-handler',
+      }),
+    });
+  });
+
+  it('replays ordinary dead-letter failures without duplicating fan-out identity', () => {
+    const input = event();
+    events.insertWithDeliveries(input, [delivery('failing-handler')])._unsafeUnwrap();
+    const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    deliveries
+      .fail(
+        input.eventId,
+        'failing-handler',
+        claim.delivery.claim_token!,
+        { code: 'ordinary-terminal-failure' },
+        leaseNow + 500,
+        false,
+      )
+      ._unsafeUnwrap();
+
+    const replayed = subject().replayDelivery(input.eventId, 'failing-handler');
+
+    expect(replayed._unsafeUnwrap()).toMatchObject({
+      event_id: input.eventId,
+      handler_id: 'failing-handler',
+      status: 'pending',
+      attempts: 0,
+      last_error: null,
+    });
+    expect(deliveries.findByEventId(input.eventId)._unsafeUnwrap()).toHaveLength(1);
+  });
+
+  it('rejects replay for non-terminal or missing handler deliveries', () => {
+    const input = event();
+    events.insertWithDeliveries(input, [delivery('pending-handler')])._unsafeUnwrap();
+
+    expect(subject().replayDelivery(input.eventId, 'pending-handler').isErr()).toBe(true);
+    expect(subject().replayDelivery(input.eventId, 'missing-handler').isErr()).toBe(true);
+    expect(deliveries.findByEventId(input.eventId)._unsafeUnwrap()).toHaveLength(1);
+  });
+
+  it('rejects replay of retention, privacy, and disablement tombstones', () => {
+    const compacted = event();
+    events.insertWithDeliveries(compacted, [delivery('compacted-handler')])._unsafeUnwrap();
+    const compactedClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    deliveries
+      .complete(compacted.eventId, 'compacted-handler', compactedClaim.delivery.claim_token!)
+      ._unsafeUnwrap();
+    retentionSubject().compactCompleted(0)._unsafeUnwrap();
+
+    expect(subject().replayDelivery(compacted.eventId, 'compacted-handler').isErr()).toBe(true);
+    expect(
+      deliveries.findByKey(compacted.eventId, 'compacted-handler')._unsafeUnwrap(),
+    ).toMatchObject({
+      status: 'completed',
+      attempts: 0,
+    });
+
+    const threadId = `thread-${uuid()}`;
+    const privacyDeleted = event({
+      context: {
+        ...event().context,
+        aggregate: { type: 'thread', id: threadId },
+        correlationId: uuid(),
+      },
+    });
+    events.insertWithDeliveries(privacyDeleted, [delivery('privacy-handler')])._unsafeUnwrap();
+    retentionSubject().tombstoneThread(threadId)._unsafeUnwrap();
+
+    expect(subject().replayDelivery(privacyDeleted.eventId, 'privacy-handler').isErr()).toBe(true);
+    expect(
+      deliveries.findByKey(privacyDeleted.eventId, 'privacy-handler')._unsafeUnwrap(),
+    ).toMatchObject({
+      status: 'dead_letter',
+      last_error: '{"code":"privacy-deleted"}',
+    });
+
+    const disabled = event();
+    events.insertWithDeliveries(disabled, [delivery('disabled-replay-handler')])._unsafeUnwrap();
+    subject().disableHandler('disabled-replay-handler')._unsafeUnwrap();
+
+    expect(subject().replayDelivery(disabled.eventId, 'disabled-replay-handler').isErr()).toBe(
+      true,
+    );
+    expect(
+      deliveries.findByKey(disabled.eventId, 'disabled-replay-handler')._unsafeUnwrap(),
+    ).toMatchObject({
+      status: 'dead_letter',
+      last_error: '{"code":"handler-disabled"}',
+    });
+  });
+
+  it('disables outstanding deliveries for one handler while preserving completed history', () => {
+    const pendingEvent = event();
+    events.insertWithDeliveries(pendingEvent, [delivery('disabled-handler')])._unsafeUnwrap();
+    const completedEvent = event();
+    events.insertWithDeliveries(completedEvent, [delivery('disabled-handler')])._unsafeUnwrap();
+
+    const firstClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    deliveries
+      .complete(pendingEvent.eventId, 'disabled-handler', firstClaim.delivery.claim_token!)
+      ._unsafeUnwrap();
+
+    const result = subject().disableHandler('disabled-handler');
+
+    expect(result._unsafeUnwrap()).toEqual({
+      handlerId: 'disabled-handler',
+      disabledDeliveries: 1,
+    });
+    expect(
+      deliveries.findByKey(completedEvent.eventId, 'disabled-handler')._unsafeUnwrap(),
+    ).toMatchObject({
+      status: 'dead_letter',
+      attempts: 1,
+      last_error: '{"code":"handler-disabled"}',
+    });
+    expect(
+      deliveries.findByKey(pendingEvent.eventId, 'disabled-handler')._unsafeUnwrap(),
+    ).toMatchObject({
+      status: 'completed',
+    });
+    expect(auditLogger.logLifecycleDisablement).toHaveBeenCalledWith({
+      action: 'lifecycle.disablement',
+      details: expect.objectContaining({
+        operation: 'handler_disable',
+        handlerId: 'disabled-handler',
+        disabledDeliveries: 1,
+      }),
+    });
+  });
+
+  it('invalidates an active claim so stale completion cannot win after disablement', () => {
+    const input = event();
+    events.insertWithDeliveries(input, [delivery('claimed-handler')])._unsafeUnwrap();
+    const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+
+    expect(subject().disableHandler('claimed-handler')._unsafeUnwrap()).toMatchObject({
+      disabledDeliveries: 1,
+    });
+
+    expect(
+      deliveries.complete(input.eventId, 'claimed-handler', claim.delivery.claim_token!).isErr(),
+    ).toBe(true);
+    expect(deliveries.findByKey(input.eventId, 'claimed-handler')._unsafeUnwrap()).toMatchObject({
+      status: 'dead_letter',
+      claim_token: null,
+      last_error: '{"code":"handler-disabled"}',
+    });
+  });
+});

--- a/tests/unit/lifecycle/retention-service.test.ts
+++ b/tests/unit/lifecycle/retention-service.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { ok } from 'neverthrow';
+import {
+  BaseRepository,
+  LifecycleDeliveryRepository,
+  LifecycleEventRepository,
+  type LifecycleDeliveryFanoutInput,
+} from '../../../src/core/database/repositories/index.js';
+import type { LifecycleEventEnvelope } from '../../../src/lifecycle/contracts/index.js';
+import { LifecycleRetentionService } from '../../../src/lifecycle/retention-service.js';
+import { createTestDb, uuid } from '../core/database/repositories/helpers.js';
+
+describe('LifecycleRetentionService', () => {
+  let db: Database.Database;
+  let events: LifecycleEventRepository;
+  let deliveries: LifecycleDeliveryRepository;
+  let leaseNow: number;
+
+  beforeEach(() => {
+    BaseRepository.__resetMonotonicClockForTests();
+    db = createTestDb();
+    events = new LifecycleEventRepository(db);
+    leaseNow = 1_800_000_000_000;
+    deliveries = new LifecycleDeliveryRepository(db, () => leaseNow);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function event(overrides: Partial<LifecycleEventEnvelope> = {}): LifecycleEventEnvelope {
+    return {
+      version: 'v1',
+      eventId: uuid(),
+      type: 'run.completed.v1',
+      occurredAt: '2026-07-16T10:00:00.000Z',
+      context: {
+        aggregate: { type: 'thread', id: `thread-${uuid()}` },
+        correlationId: uuid(),
+        recursion: { depth: 0, maxDepth: 4 },
+        provenance: { source: 'daemon' },
+      },
+      payload: {
+        references: [{ type: 'run', id: uuid() }],
+        metadata: { retained: 'content-detail' },
+      },
+      ...overrides,
+    };
+  }
+
+  function delivery(
+    handlerId = 'retention-projector',
+    persona = 'support',
+  ): LifecycleDeliveryFanoutInput {
+    return {
+      handlerId,
+      persona,
+      priority: 0,
+      identity: {
+        version: 'v1',
+        handlerId,
+        runtimeKind: 'native',
+        implementationRef: handlerId,
+        implementationVersion: '1.0.0',
+        mode: 'event',
+        inputContract: 'talon.lifecycle.event.envelope.v1',
+        outputContract: 'talon.lifecycle.signal.envelopes.v1',
+      },
+      failurePolicy: { version: 'v1', mode: 'dead_letter' },
+      maxAttempts: 2,
+    };
+  }
+
+  function subject(clock = () => Number.MAX_SAFE_INTEGER): LifecycleRetentionService {
+    return new LifecycleRetentionService({
+      events,
+      deliveries,
+      auditLogger: { logLifecycleDecision: vi.fn() },
+      clock,
+    });
+  }
+
+  function storedPayload(eventId: string): Record<string, unknown> {
+    const row = events.findById(eventId)._unsafeUnwrap();
+    expect(row).not.toBeNull();
+    return JSON.parse(row!.payload) as Record<string, unknown>;
+  }
+
+  function storedRetentionReason(eventId: string): string | null {
+    const row = db
+      .prepare(`SELECT retention_tombstone_reason FROM lifecycle_events WHERE event_id = ?`)
+      .get(eventId) as { retention_tombstone_reason: string | null };
+    return row.retention_tombstone_reason;
+  }
+
+  it('compacts only completed or subscriber-free event detail after the audit window', () => {
+    const completed = event();
+    events.insertWithDeliveries(completed, [delivery()])._unsafeUnwrap();
+    const completedClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    deliveries
+      .complete(completed.eventId, 'retention-projector', completedClaim.delivery.claim_token!)
+      ._unsafeUnwrap();
+
+    const deadLettered = event();
+    events.insertWithDeliveries(deadLettered, [delivery('dead-projector')])._unsafeUnwrap();
+    const deadClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    deliveries
+      .fail(
+        deadLettered.eventId,
+        'dead-projector',
+        deadClaim.delivery.claim_token!,
+        { code: 'permanent-failure' },
+        leaseNow + 500,
+        false,
+      )
+      ._unsafeUnwrap();
+
+    const pending = event();
+    events.insertWithDeliveries(pending, [delivery('pending-projector')])._unsafeUnwrap();
+
+    const noSubscribers = event();
+    events.insert(noSubscribers)._unsafeUnwrap();
+
+    const result = subject().compactCompleted(0);
+
+    expect(result._unsafeUnwrap()).toEqual({ compactedEvents: 2, disabledDeliveries: 0 });
+    expect(storedPayload(completed.eventId)).toEqual({
+      references: [],
+      metadata: { lifecycleRetention: 'retention-compacted' },
+    });
+    expect(storedPayload(noSubscribers.eventId)).toEqual({
+      references: [],
+      metadata: { lifecycleRetention: 'retention-compacted' },
+    });
+    expect(storedPayload(pending.eventId)).toMatchObject({
+      metadata: { retained: 'content-detail' },
+    });
+    expect(storedPayload(deadLettered.eventId)).toMatchObject({
+      metadata: { retained: 'content-detail' },
+    });
+  });
+
+  it('compacts eligible events even when caller metadata uses the retention key', () => {
+    const completed = event({
+      payload: {
+        references: [],
+        metadata: { lifecycleRetention: 'retention-compacted' },
+      },
+    });
+    events.insertWithDeliveries(completed, [delivery()])._unsafeUnwrap();
+    const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    deliveries
+      .complete(completed.eventId, 'retention-projector', claim.delivery.claim_token!)
+      ._unsafeUnwrap();
+
+    const result = subject().compactCompleted(0);
+
+    expect(result._unsafeUnwrap()).toEqual({ compactedEvents: 1, disabledDeliveries: 0 });
+    expect(storedPayload(completed.eventId)).toEqual({
+      references: [],
+      metadata: { lifecycleRetention: 'retention-compacted' },
+    });
+    expect(storedRetentionReason(completed.eventId)).toBe('retention-compacted');
+  });
+
+  it('tombstones thread payload detail and dead-letters outstanding work atomically', () => {
+    const threadId = `thread-${uuid()}`;
+    const target = event({
+      context: {
+        ...event().context,
+        aggregate: { type: 'thread', id: threadId },
+        correlationId: uuid(),
+      },
+    });
+    events.insertWithDeliveries(target, [delivery()])._unsafeUnwrap();
+    const aggregateIdImposter = event({
+      context: {
+        ...event().context,
+        aggregate: { type: 'run', id: threadId },
+        correlationId: uuid(),
+      },
+    });
+    events
+      .insertWithDeliveries(aggregateIdImposter, [delivery('aggregate-id-imposter')])
+      ._unsafeUnwrap();
+    const unrelated = event();
+    events.insertWithDeliveries(unrelated, [delivery('other-projector')])._unsafeUnwrap();
+
+    const result = subject().tombstoneThread(threadId);
+
+    expect(result._unsafeUnwrap()).toEqual({ compactedEvents: 1, disabledDeliveries: 1 });
+    expect(storedPayload(target.eventId)).toEqual({
+      references: [],
+      metadata: { lifecycleRetention: 'privacy-deleted' },
+    });
+    expect(storedPayload(unrelated.eventId)).toMatchObject({
+      metadata: { retained: 'content-detail' },
+    });
+    expect(storedPayload(aggregateIdImposter.eventId)).toMatchObject({
+      metadata: { retained: 'content-detail' },
+    });
+    expect(
+      deliveries.findByKey(target.eventId, 'retention-projector')._unsafeUnwrap(),
+    ).toMatchObject({
+      status: 'dead_letter',
+      attempts: 1,
+      last_error: '{"code":"privacy-deleted"}',
+      claim_token: null,
+    });
+    expect(
+      deliveries.findByKey(aggregateIdImposter.eventId, 'aggregate-id-imposter')._unsafeUnwrap(),
+    ).toMatchObject({
+      status: 'pending',
+    });
+  });
+
+  it('tombstones persona payload detail without touching other personas', () => {
+    const supportEvent = event();
+    events
+      .insertWithDeliveries(supportEvent, [delivery('support-projector', 'support')])
+      ._unsafeUnwrap();
+    const opsEvent = event();
+    events.insertWithDeliveries(opsEvent, [delivery('ops-projector', 'ops')])._unsafeUnwrap();
+
+    const result = subject().tombstonePersona('support');
+
+    expect(result._unsafeUnwrap()).toEqual({ compactedEvents: 1, disabledDeliveries: 1 });
+    expect(storedPayload(supportEvent.eventId)).toEqual({
+      references: [],
+      metadata: { lifecycleRetention: 'privacy-deleted' },
+    });
+    expect(storedPayload(opsEvent.eventId)).toMatchObject({
+      metadata: { retained: 'content-detail' },
+    });
+    expect(
+      deliveries.findByKey(supportEvent.eventId, 'support-projector')._unsafeUnwrap(),
+    ).toMatchObject({
+      status: 'dead_letter',
+      last_error: '{"code":"privacy-deleted"}',
+    });
+    expect(deliveries.findByKey(opsEvent.eventId, 'ops-projector')._unsafeUnwrap()).toMatchObject({
+      status: 'pending',
+    });
+  });
+
+  it('does not downgrade privacy tombstones during later compaction', () => {
+    const threadId = `thread-${uuid()}`;
+    const target = event({
+      context: {
+        ...event().context,
+        aggregate: { type: 'thread', id: threadId },
+        correlationId: uuid(),
+      },
+    });
+    events.insertWithDeliveries(target, [delivery()])._unsafeUnwrap();
+    const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+    deliveries
+      .complete(target.eventId, 'retention-projector', claim.delivery.claim_token!)
+      ._unsafeUnwrap();
+
+    subject().tombstoneThread(threadId)._unsafeUnwrap();
+    subject().compactCompleted(0)._unsafeUnwrap();
+
+    expect(storedPayload(target.eventId)).toEqual({
+      references: [],
+      metadata: { lifecycleRetention: 'privacy-deleted' },
+    });
+  });
+
+  it('rolls back event tombstoning when delivery privacy mutation fails', () => {
+    const threadId = `thread-${uuid()}`;
+    const target = event({
+      context: {
+        ...event().context,
+        aggregate: { type: 'thread', id: threadId },
+        correlationId: uuid(),
+      },
+    });
+    events.insertWithDeliveries(target, [delivery()])._unsafeUnwrap();
+    const failingDeliveries = {
+      tombstoneThread: vi.fn(() => {
+        throw new Error('simulated delivery failure');
+      }),
+      tombstonePersona: vi.fn(() => ok({ disabledDeliveries: 0 })),
+    };
+    const failingSubject = new LifecycleRetentionService({
+      events,
+      deliveries: failingDeliveries as unknown as LifecycleDeliveryRepository,
+      clock: () => Number.MAX_SAFE_INTEGER,
+    });
+
+    const result = failingSubject.tombstoneThread(threadId);
+
+    expect(result.isErr()).toBe(true);
+    expect(storedPayload(target.eventId)).toMatchObject({
+      metadata: { retained: 'content-detail' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add lifecycle retention/admin service primitives for completed-event compaction, thread/persona privacy tombstoning, handler disablement, and exact delivery replay
- add migration 019 with system-owned retention and terminal tombstone columns plus SQLite trigger guards for direct-SQL bypass protection
- document `lifecycle.retention.completedAuditWindowMs` and update focused lifecycle/reload/config/migration tests

## Review gate

- GPT-5.5/xhigh full-diff review, Codex session `019f9c80-79e8-7770-bcf4-8ef4f8d2a5fb`
- Verdict: PASS
- Severity counts: 0 Critical / 0 High / 0 Medium / 0 Low
- Prior blockers explicitly resolved: direct SQL replay bypass, caller-owned `payload.metadata.lifecycleRetention` authority, and replay eligibility based on handler-writable `last_error.code`

## Verification

- `git diff --check`
- `npx vitest run tests/unit/lifecycle/retention-service.test.ts tests/unit/lifecycle/lifecycle-admin-service.test.ts tests/unit/core/database/migrations/runner.test.ts tests/unit/core/database/repositories/lifecycle-event-repository.test.ts tests/unit/core/config/config-schema.test.ts tests/unit/daemon/reload.test.ts` — 190 tests passed
- `npm run build`
- scoped ESLint over task-owned source passed

Full `npm test` intentionally not run per WDD/controller instruction.
