### PR TITLE
feat(lifecycle): add operator lifecycle cli

### DIFF
--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/TICKET-006-operations-adoption/in-progress/TASK-016-lifecycle-operator-cli.md
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/TICKET-006-operations-adoption/in-progress/TASK-016-lifecycle-operator-cli.md
@@ -7,11 +7,11 @@ wave: WAVE-008
 slug: lifecycle-operator-cli
 title: Add lifecycle operator CLI, IPC, health, and backlog controls
 status: in-progress
-depends_on: ["TASK-014-lifecycle-retention-reload-replay", "TASK-015-behavior-signal-projector"]
+depends_on: ['TASK-014-lifecycle-retention-reload-replay', 'TASK-015-behavior-signal-projector']
 conflict_domains:
-  - "src/cli/index.ts"
-  - "src/ipc/**"
-  - "src/daemon/daemon.ts"
+  - 'src/cli/index.ts'
+  - 'src/ipc/**'
+  - 'src/daemon/daemon.ts'
 assigned_model_class: codexHigh
 review_model_class: reviewGate
 branch: task/TASK-016-lifecycle-operator-cli
@@ -21,10 +21,10 @@ pr: null
 current_gate: worktree_readiness_review_pending
 branch_freshness: at_activation_sync_commit_pending_readiness
 verification:
-  - "npx vitest run tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc"
-  - "npm run build"
-  - "npm run lint"
-  - "git diff --check"
+  - 'npx vitest run tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc'
+  - 'npm run build'
+  - 'npm run lint'
+  - 'git diff --check'
 ---
 
 # TASK-016-lifecycle-operator-cli: Add lifecycle operator CLI, IPC, health, and backlog controls
@@ -76,11 +76,11 @@ No web UI, bulk replay, raw secrets, or direct SQLite CLI access.
 ## Likely Files / Areas
 
 - src/cli/index.ts
-- src/cli/commands/lifecycle*.ts
-- src/ipc/**
+- src/cli/commands/lifecycle\*.ts
+- src/ipc/\*\*
 - src/daemon/daemon.ts
 - tests/unit/cli/lifecycle-commands.test.ts
-- tests/unit/ipc/**
+- tests/unit/ipc/\*\*
 
 ## Dependencies
 
@@ -90,7 +90,7 @@ No web UI, bulk replay, raw secrets, or direct SQLite CLI access.
 ## Conflict Domains
 
 - src/cli/index.ts
-- src/ipc/**
+- src/ipc/\*\*
 - src/daemon/daemon.ts
 
 ## Assigned Model Class
@@ -152,22 +152,34 @@ Refactor only the new/touched boundary after green; do not broaden scope or chan
 
 ## Task-Level Definition of Done
 
-- [ ] Objective and scoped behavior are complete.
-- [ ] Focused RED/GREEN, build/lint, and listed validation evidence are recorded.
+- [x] Objective and scoped behavior are complete.
+- [x] Focused RED/GREEN, build/lint, and listed validation evidence are recorded.
 - [ ] Required review has no unresolved P1/P2 findings.
 - [ ] PR targets the epic branch and freshness is checked.
 - [ ] Shared-context findings are proposed when needed.
 
 ## Validation Steps
 
-- npx vitest run tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc
+- npx vitest run tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc tests/unit/daemon/daemon.test.ts
 - npm run build
-- npm run lint
+- scoped eslint/prettier for touched files
 - git diff --check
 
 ## Verification Evidence
 
-- Not run yet.
+- RED: `npx vitest run tests/unit/cli/lifecycle-commands.test.ts` failed before implementation because `src/cli/commands/lifecycle.js` did not exist.
+- GREEN: `npx vitest run tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc` passed 4 files / 34 tests.
+- `npm run build` passed.
+- `npm run lint` was attempted and failed on pre-existing unrelated source lint debt outside the TASK-016 touched files (for example WhatsApp connector/auth, run-subagent, context-assembler, provider/subagent utilities); no errors were reported for TASK-016 files in that run.
+- Scoped lint passed: `npx eslint src/cli/commands/daemon-control.ts src/cli/commands/lifecycle.ts src/cli/index.ts src/ipc/daemon-ipc.ts src/core/database/repositories/lifecycle-delivery-repository.ts src/core/database/repositories/index.ts src/daemon/daemon.ts`.
+- Prettier check passed for touched source and test files: `npx prettier --check src/cli/commands/daemon-control.ts src/cli/commands/lifecycle.ts src/cli/index.ts src/ipc/daemon-ipc.ts src/core/database/repositories/lifecycle-delivery-repository.ts src/core/database/repositories/index.ts src/daemon/daemon.ts tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc/lifecycle-daemon-ipc.test.ts`.
+- `git diff --check` passed.
+- Remediation type check passed: `npx tsc --noEmit --pretty false`.
+- Remediation focused tests passed: `npx vitest run tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc tests/unit/daemon/daemon.test.ts` passed 5 files / 88 tests.
+- Remediation build passed: `npm run build`.
+- Remediation scoped lint passed: `npx eslint --no-warn-ignored src/cli/commands/daemon-control.ts src/cli/commands/lifecycle.ts src/cli/commands/queue-purge.ts src/cli/index.ts src/ipc/daemon-ipc.ts src/ipc/daemon-ipc-client.ts src/ipc/daemon-ipc-server.ts src/core/database/repositories/lifecycle-delivery-repository.ts src/core/database/repositories/behavior-signal-repository.ts src/core/database/repositories/index.ts src/daemon/daemon.ts tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc/lifecycle-daemon-ipc.test.ts tests/unit/ipc/daemon-ipc-server.test.ts tests/unit/daemon/daemon.test.ts`.
+- Remediation Prettier check passed: `npx prettier --check .wdd/epics/EPIC-durable-lifecycle-pipeline/TICKET-006-operations-adoption/in-progress/TASK-016-lifecycle-operator-cli.md README.md src/cli/commands/daemon-control.ts src/cli/commands/lifecycle.ts src/cli/commands/queue-purge.ts src/cli/index.ts src/ipc/daemon-ipc.ts src/ipc/daemon-ipc-client.ts src/ipc/daemon-ipc-server.ts src/core/database/repositories/lifecycle-delivery-repository.ts src/core/database/repositories/behavior-signal-repository.ts src/core/database/repositories/index.ts src/daemon/daemon.ts tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc/lifecycle-daemon-ipc.test.ts tests/unit/ipc/daemon-ipc-server.test.ts tests/unit/daemon/daemon.test.ts`.
+- Remediation whitespace check passed: `git diff --check`.
 
 ## Review Feedback
 
@@ -183,6 +195,17 @@ Refactor only the new/touched boundary after green; do not broaden scope or chan
 
 - None.
 
+### GPT-5.5/xhigh Medium Remediation
+
+- Fixed handler backlog summaries by selecting displayed handler IDs before querying backlog and using a handler-ID scoped aggregation without SQL row truncation.
+- Fixed candidate output bounds by adding a repository-level limited candidate summary/provenance read and using it from daemon candidates.
+- Replaced generic lifecycle IPC payload acceptance with strict per-command Zod discriminated-union payload schemas; malformed lifecycle list/mutation payloads are rejected by IPC schema validation before daemon handlers run.
+- Added daemon/IPCs regressions for lifecycle handlers, inspect, replay, disable/audit, candidates, invalid payloads, repository errors, and limit behavior.
+
 ## Completion Notes
 
-- None yet.
+- Added `talonctl lifecycle` subcommands for handler/backlog health, delivery inspection, exact replay, handler disablement, and behavior-candidate provenance.
+- Added typed daemon IPC command variants for lifecycle operator actions and daemon handlers that use repository read models plus `LifecycleAdminService` for replay/disable mutations.
+- Added bounded lifecycle delivery status/handler summary repository methods and bounded behavior-candidate summary/provenance repository methods.
+- Updated README for the public `talonctl lifecycle` CLI. No guided `.agents/skills` update was made because the existing skills cover setup/channel/persona workflows, not lifecycle operator administration.
+- No commit, push, PR, full `npm test`, dependency install, dependency rebuild, or `.minispec` changes were performed. Controller GPT-5.5/xhigh review remains pending before commit.

--- a/README.md
+++ b/README.md
@@ -1577,11 +1577,12 @@ Custom sub-agents override built-in ones if they share the same name (dataDir ta
 
 ### Daemon Management
 
-| Command  | Description                                                   |
-| -------- | ------------------------------------------------------------- |
-| `status` | Show daemon health, active channels, queue depth, token usage |
-| `reload` | Hot-reload config without restarting the daemon               |
-| `chat`   | Connect to a persona via the terminal channel                 |
+| Command     | Description                                                             |
+| ----------- | ----------------------------------------------------------------------- |
+| `status`    | Show daemon health, active channels, queue depth, token usage           |
+| `reload`    | Hot-reload config without restarting the daemon                         |
+| `lifecycle` | Inspect lifecycle handlers, deliveries, replay, disable, and candidates |
+| `chat`      | Connect to a persona via the terminal channel                           |
 
 **`status`** / **`reload`** options:
 
@@ -1604,8 +1605,27 @@ Custom sub-agents override built-in ones if they share the same name (dataDir ta
 ```bash
 npx talonctl status --timeout 5000
 npx talonctl reload
+npx talonctl lifecycle handlers
+npx talonctl lifecycle inspect <event-id> --handler <handler-id>
+npx talonctl lifecycle replay <event-id> <handler-id>
+npx talonctl lifecycle disable <handler-id>
+npx talonctl lifecycle candidates <persona> --limit 25
 npx talonctl chat --token mytoken --persona assistant
 ```
+
+**`lifecycle`** subcommands:
+
+| Subcommand                       | Description                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `handlers`                       | List configured lifecycle handlers with dispatcher health and bounded backlog   |
+| `inspect <event-id>`             | Show one lifecycle event and its handler deliveries                             |
+| `replay <event-id> <handler-id>` | Reopen one ordinary terminal delivery for exact replay                          |
+| `disable <handler-id>`           | Dead-letter pending, failed, or claimed deliveries for one handler and audit it |
+| `candidates <persona>`           | List bounded behavior-candidate summaries and distinct evidence-source counts   |
+
+All lifecycle subcommands accept `--ipc-dir <path>` and `--timeout <ms>`.
+`handlers` and `candidates` also accept `--limit <n>` capped at 100. `inspect`
+accepts `--handler <handler-id>` to narrow delivery output.
 
 ### Setup and Configuration
 
@@ -2536,8 +2556,9 @@ lifecycle:
 
 Thread/persona privacy deletion uses the same retention service to tombstone
 matching lifecycle event detail and dead-letter outstanding matching deliveries.
-Operator CLI commands for invoking these primitives are owned by the lifecycle
-operator CLI workstream.
+Use `talonctl lifecycle handlers`, `inspect`, `replay`, `disable`, and
+`candidates` for operator visibility and exact delivery controls through the
+daemon IPC boundary.
 
 ---
 

--- a/src/cli/commands/daemon-control.ts
+++ b/src/cli/commands/daemon-control.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+
+import { DaemonIpcClient } from '../../ipc/daemon-ipc-client.js';
+import type { DaemonCommandType, DaemonResponse } from '../../ipc/daemon-ipc.js';
+
+const DEFAULT_IPC_DIR = 'data/ipc/daemon';
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export interface DaemonControlOptions {
+  readonly ipcDir?: string;
+  readonly timeoutMs?: number;
+}
+
+export async function sendDaemonControlCommand(
+  command: DaemonCommandType,
+  payload?: Record<string, unknown>,
+  options: DaemonControlOptions = {},
+): Promise<DaemonResponse | null> {
+  const ipcDir = options.ipcDir ?? DEFAULT_IPC_DIR;
+  const client = new DaemonIpcClient({
+    inputDir: path.join(ipcDir, 'input'),
+    outputDir: path.join(ipcDir, 'output'),
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  });
+  return client.sendCommand(command, payload);
+}

--- a/src/cli/commands/lifecycle.ts
+++ b/src/cli/commands/lifecycle.ts
@@ -1,0 +1,333 @@
+import { sendDaemonControlCommand } from './daemon-control.js';
+
+type LifecycleAction = 'handlers' | 'inspect' | 'replay' | 'disable' | 'candidates';
+
+export interface LifecycleCommandOptions {
+  readonly action: LifecycleAction;
+  readonly ipcDir?: string;
+  readonly timeoutMs?: number;
+  readonly limit?: number;
+  readonly eventId?: string;
+  readonly handlerId?: string;
+  readonly persona?: string;
+}
+
+interface LifecycleBacklogSummary {
+  readonly pending?: number;
+  readonly claimed?: number;
+  readonly failed?: number;
+  readonly completed?: number;
+  readonly dead_letter?: number;
+}
+
+interface LifecycleBacklogTiming {
+  readonly oldestCreatedAt?: number | null;
+  readonly oldestAgeMs?: number | null;
+  readonly nextRetryAt?: number | null;
+}
+
+interface LifecycleHandlerSummary {
+  readonly handlerId: string;
+  readonly displayName?: string;
+  readonly mode?: string;
+  readonly runtimeKind?: string;
+  readonly personas?: readonly string[];
+  readonly subscriptions?: number;
+  readonly backlog?: LifecycleBacklogSummary;
+  readonly timing?: LifecycleBacklogTiming;
+  readonly circuit?: string;
+}
+
+interface LifecycleHandlersData {
+  readonly lifecycleEnabled?: boolean;
+  readonly dispatcher?: {
+    readonly running?: boolean;
+    readonly stopping?: boolean;
+    readonly inFlight?: number;
+    readonly handlers?: readonly { readonly handlerId: string; readonly circuit?: string }[];
+  };
+  readonly backlog?: LifecycleBacklogSummary;
+  readonly handlers?: readonly LifecycleHandlerSummary[];
+}
+
+interface LifecycleDeliveryRowData {
+  readonly eventId?: string;
+  readonly handlerId?: string;
+  readonly persona?: string;
+  readonly status?: string;
+  readonly attempts?: number;
+  readonly maxAttempts?: number;
+  readonly nextRetryAt?: number | null;
+  readonly lastErrorCode?: string | null;
+  readonly tombstoneReason?: string | null;
+}
+
+interface LifecycleInspectData {
+  readonly event?: {
+    readonly eventId?: string;
+    readonly type?: string;
+    readonly aggregateType?: string;
+    readonly aggregateId?: string;
+    readonly retentionTombstoneReason?: string | null;
+    readonly createdAt?: number;
+  } | null;
+  readonly deliveries?: readonly LifecycleDeliveryRowData[];
+}
+
+interface LifecycleCandidateSummary {
+  readonly candidateId: string;
+  readonly status?: string;
+  readonly kind?: string;
+  readonly confidence?: number;
+  readonly evidenceSources?: number;
+  readonly summary?: string;
+}
+
+interface LifecycleCandidatesData {
+  readonly persona?: string;
+  readonly candidates?: readonly LifecycleCandidateSummary[];
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+export async function lifecycleCommand(options: LifecycleCommandOptions): Promise<void> {
+  const limit = normalizeLimit(options.limit);
+  const payload = payloadForAction(options, limit);
+  if (payload === null) return;
+
+  const response = await sendDaemonControlCommand(commandForAction(options.action), payload, {
+    ipcDir: options.ipcDir,
+    timeoutMs: options.timeoutMs,
+  });
+
+  if (!response) {
+    fail('Daemon did not respond within timeout.\nIs talond running?');
+    return;
+  }
+  if (!response.success) {
+    fail(response.error ?? 'Unknown daemon error');
+    return;
+  }
+
+  renderLifecycleResponse(options.action, response.data ?? {});
+}
+
+function commandForAction(action: LifecycleAction) {
+  switch (action) {
+    case 'handlers':
+      return 'lifecycle-handlers' as const;
+    case 'inspect':
+      return 'lifecycle-inspect' as const;
+    case 'replay':
+      return 'lifecycle-replay' as const;
+    case 'disable':
+      return 'lifecycle-disable' as const;
+    case 'candidates':
+      return 'lifecycle-candidates' as const;
+  }
+}
+
+function payloadForAction(
+  options: LifecycleCommandOptions,
+  limit: number,
+): Record<string, unknown> | null {
+  switch (options.action) {
+    case 'handlers':
+      return { limit };
+    case 'inspect':
+      if (!options.eventId) return fail('event id is required for lifecycle inspect');
+      return {
+        eventId: options.eventId,
+        ...(options.handlerId ? { handlerId: options.handlerId } : {}),
+      };
+    case 'replay':
+      if (!options.eventId) return fail('event id is required for lifecycle replay');
+      if (!options.handlerId) return fail('handler id is required for lifecycle replay');
+      return { eventId: options.eventId, handlerId: options.handlerId };
+    case 'disable':
+      if (!options.handlerId) return fail('handler id is required for lifecycle disable');
+      return { handlerId: options.handlerId };
+    case 'candidates':
+      if (!options.persona) return fail('persona is required for lifecycle candidates');
+      return { persona: options.persona, limit };
+  }
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(Math.trunc(value), 1), MAX_LIMIT);
+}
+
+function fail(message: string): null {
+  for (const line of message.split('\n')) console.error(`Error: ${line}`);
+  process.exit(1);
+  return null;
+}
+
+function renderLifecycleResponse(action: LifecycleAction, data: Record<string, unknown>): void {
+  switch (action) {
+    case 'handlers':
+      renderHandlers(data as LifecycleHandlersData);
+      break;
+    case 'inspect':
+      renderInspect(data as LifecycleInspectData);
+      break;
+    case 'replay':
+      renderReplay(data as LifecycleDeliveryRowData);
+      break;
+    case 'disable':
+      renderDisable(data as { handlerId?: string; disabledDeliveries?: number });
+      break;
+    case 'candidates':
+      renderCandidates(data as LifecycleCandidatesData);
+      break;
+  }
+}
+
+function renderHandlers(data: LifecycleHandlersData): void {
+  console.log('Lifecycle handlers');
+  console.log('------------------');
+  console.log(`Enabled: ${data.lifecycleEnabled === false ? 'no' : 'yes'}`);
+  const dispatcher = data.dispatcher;
+  if (dispatcher) {
+    console.log(
+      `Dispatcher: ${dispatcher.running ? 'running' : 'stopped'}, in-flight=${dispatcher.inFlight ?? 0}`,
+    );
+  }
+  if (data.backlog) console.log(`Backlog: ${formatBacklog(data.backlog)}`);
+  const handlers = data.handlers ?? [];
+  if (handlers.length === 0) {
+    console.log('No configured lifecycle handlers.');
+    return;
+  }
+  for (const handler of handlers) {
+    console.log(
+      [
+        handler.handlerId,
+        handler.displayName ? `(${handler.displayName})` : '',
+        `mode=${handler.mode ?? 'unknown'}`,
+        `runtime=${handler.runtimeKind ?? 'unknown'}`,
+        `personas=${(handler.personas ?? []).join(',') || '-'}`,
+        `subscriptions=${handler.subscriptions ?? 0}`,
+        `backlog=${formatBacklog(handler.backlog ?? {})}`,
+        `lag=${formatDurationMs(handler.timing?.oldestAgeMs)}`,
+        `oldest=${formatTimestamp(handler.timing?.oldestCreatedAt)}`,
+        `nextRetry=${formatTimestamp(handler.timing?.nextRetryAt)}`,
+        `circuit=${handler.circuit ?? 'closed'}`,
+      ]
+        .filter(Boolean)
+        .join(' '),
+    );
+  }
+}
+
+function renderInspect(data: LifecycleInspectData): void {
+  console.log('Lifecycle delivery inspection');
+  console.log('-----------------------------');
+  if (!data.event) {
+    console.log('Event: not found');
+    return;
+  }
+  console.log(`Event: ${data.event.eventId ?? 'unknown'}`);
+  console.log(`Type: ${data.event.type ?? 'unknown'}`);
+  console.log(
+    `Aggregate: ${data.event.aggregateType ?? 'unknown'}:${data.event.aggregateId ?? 'unknown'}`,
+  );
+  console.log(`Retention: ${data.event.retentionTombstoneReason ?? 'active'}`);
+  const deliveries = data.deliveries ?? [];
+  if (deliveries.length === 0) {
+    console.log('Deliveries: none');
+    return;
+  }
+  console.log('Deliveries:');
+  for (const delivery of deliveries) {
+    console.log(`- ${formatDelivery(delivery)}`);
+  }
+}
+
+function renderReplay(data: LifecycleDeliveryRowData): void {
+  console.log('Reopened lifecycle delivery.');
+  console.log(`Event: ${data.eventId ?? 'unknown'}`);
+  console.log(`Handler: ${data.handlerId ?? 'unknown'}`);
+  console.log(`Status: ${data.status ?? 'unknown'}`);
+  console.log(`Attempts: ${data.attempts ?? 0}/${data.maxAttempts ?? '?'}`);
+}
+
+function renderDisable(data: { handlerId?: string; disabledDeliveries?: number }): void {
+  console.log(`Disabled lifecycle handler "${data.handlerId ?? 'unknown'}".`);
+  console.log(`Disabled deliveries: ${data.disabledDeliveries ?? 0}`);
+}
+
+function renderCandidates(data: LifecycleCandidatesData): void {
+  const persona = data.persona ?? 'unknown';
+  console.log(`Behavior candidates for "${persona}"`);
+  console.log('------------------------------');
+  const candidates = data.candidates ?? [];
+  if (candidates.length === 0) {
+    console.log('No behavior candidates found.');
+    return;
+  }
+  for (const candidate of candidates) {
+    console.log(
+      [
+        candidate.candidateId,
+        `status=${candidate.status ?? 'unknown'}`,
+        `kind=${candidate.kind ?? 'unknown'}`,
+        `confidence=${formatConfidence(candidate.confidence)}`,
+        `evidence=${candidate.evidenceSources ?? 0}`,
+        candidate.summary ?? '',
+      ]
+        .filter(Boolean)
+        .join(' '),
+    );
+  }
+}
+
+function formatBacklog(backlog: LifecycleBacklogSummary): string {
+  return [
+    `pending=${backlog.pending ?? 0}`,
+    `claimed=${backlog.claimed ?? 0}`,
+    `failed=${backlog.failed ?? 0}`,
+    `completed=${backlog.completed ?? 0}`,
+    `dead_letter=${backlog.dead_letter ?? 0}`,
+  ].join(' ');
+}
+
+function formatDurationMs(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return '-';
+  if (value < 1_000) return `${Math.trunc(value)}ms`;
+  const totalSeconds = Math.floor(value / 1_000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 48) return `${totalHours}h`;
+  return `${Math.floor(totalHours / 24)}d`;
+}
+
+function formatTimestamp(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '-';
+  const timestamp = new Date(value);
+  return Number.isNaN(timestamp.getTime()) ? '-' : timestamp.toISOString();
+}
+
+function formatDelivery(delivery: LifecycleDeliveryRowData): string {
+  return [
+    delivery.handlerId ?? 'unknown',
+    `persona=${delivery.persona ?? 'unknown'}`,
+    `status=${delivery.status ?? 'unknown'}`,
+    `attempts=${delivery.attempts ?? 0}/${delivery.maxAttempts ?? '?'}`,
+    delivery.nextRetryAt === undefined || delivery.nextRetryAt === null
+      ? ''
+      : `nextRetryAt=${delivery.nextRetryAt}`,
+    delivery.lastErrorCode ? `error=${delivery.lastErrorCode}` : '',
+    delivery.tombstoneReason ? `tombstone=${delivery.tombstoneReason}` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function formatConfidence(value: number | undefined): string {
+  return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(2) : 'unknown';
+}

--- a/src/cli/commands/queue-purge.ts
+++ b/src/cli/commands/queue-purge.ts
@@ -10,21 +10,35 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import writeFileAtomic from 'write-file-atomic';
 
-import type { DaemonCommand, DaemonResponse } from '../../ipc/daemon-ipc.js';
-import { DaemonResponseSchema } from '../../ipc/daemon-ipc.js';
+import type { DaemonResponse } from '../../ipc/daemon-ipc.js';
+import { DaemonCommandSchema, DaemonResponseSchema } from '../../ipc/daemon-ipc.js';
 
 const DEFAULT_IPC_DIR = 'data/ipc/daemon';
 const DEFAULT_TIMEOUT_MS = 5_000;
 const POLL_INTERVAL_MS = 100;
 
-const VALID_STATUSES = ['pending', 'claimed', 'processing', 'completed', 'failed', 'dead_letter'] as const;
+const VALID_STATUSES = [
+  'pending',
+  'claimed',
+  'processing',
+  'completed',
+  'failed',
+  'dead_letter',
+] as const;
+type QueuePurgeStatus = (typeof VALID_STATUSES)[number];
 
-export async function queuePurgeCommand(options: {
-  ipcDir?: string;
-  timeoutMs?: number;
-  statuses?: string[];
-  all?: boolean;
-} = {}): Promise<void> {
+function isQueuePurgeStatus(value: string): value is QueuePurgeStatus {
+  return VALID_STATUSES.includes(value as QueuePurgeStatus);
+}
+
+export async function queuePurgeCommand(
+  options: {
+    ipcDir?: string;
+    timeoutMs?: number;
+    statuses?: string[];
+    all?: boolean;
+  } = {},
+): Promise<void> {
   const ipcDir = options.ipcDir ?? DEFAULT_IPC_DIR;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const inputDir = path.join(ipcDir, 'input');
@@ -32,22 +46,23 @@ export async function queuePurgeCommand(options: {
 
   const statuses = options.all
     ? [...VALID_STATUSES]
-    : options.statuses ?? ['pending', 'failed', 'completed'];
+    : (options.statuses ?? ['pending', 'failed', 'completed']);
 
   // Validate provided status values.
-  const invalidStatuses = statuses.filter((s) => !VALID_STATUSES.includes(s as (typeof VALID_STATUSES)[number]));
+  const invalidStatuses = statuses.filter((status) => !isQueuePurgeStatus(status));
   if (invalidStatuses.length > 0) {
     console.error(`Error: Invalid status value(s): ${invalidStatuses.join(', ')}`);
     console.error(`Valid statuses: ${VALID_STATUSES.join(', ')}`);
     process.exit(1);
     return;
   }
+  const requestedStatuses = statuses.filter(isQueuePurgeStatus);
 
-  const command: DaemonCommand = {
+  const command = DaemonCommandSchema.parse({
     id: randomUUID(),
     command: 'queue-purge',
-    payload: { statuses },
-  };
+    payload: { statuses: requestedStatuses },
+  });
 
   // Write command to daemon input directory.
   try {
@@ -62,7 +77,7 @@ export async function queuePurgeCommand(options: {
     return;
   }
 
-  console.log(`Purging queue items with statuses: ${statuses.join(', ')}...`);
+  console.log(`Purging queue items with statuses: ${requestedStatuses.join(', ')}...`);
 
   // Poll output directory for matching response.
   const deadline = Date.now() + timeoutMs;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,6 +49,7 @@ import { resetProviderAffinityCommand } from './commands/reset-provider-affinity
 import { whatsappAuthCommand } from './commands/whatsapp-auth.js';
 import { setCapabilitiesCommand } from './commands/set-capabilities.js';
 import { a2aListCommand, a2aSendCommand } from './commands/a2a.js';
+import { lifecycleCommand } from './commands/lifecycle.js';
 
 // Load .env before anything else so ${VAR} substitution works in config.
 const envPath = resolve(process.env.TALOND_ENV_FILE || '.env');
@@ -254,6 +255,88 @@ program
       timeoutMs: parseInt(opts.timeout, 10),
       statuses: opts.statuses?.split(',').map((s) => s.trim()),
       all: opts.all,
+    });
+  });
+
+const lifecycle = program
+  .command('lifecycle')
+  .description('Inspect and control durable lifecycle handlers and deliveries');
+
+lifecycle
+  .command('handlers')
+  .description('List effective lifecycle handlers, backlog, and dispatcher health')
+  .option('--ipc-dir <path>', 'IPC directory (overrides config default)')
+  .option('--timeout <ms>', 'Response timeout in milliseconds', '5000')
+  .option('--limit <n>', 'Maximum handlers to show', '50')
+  .action(async (opts: { ipcDir?: string; timeout: string; limit: string }) => {
+    await lifecycleCommand({
+      action: 'handlers',
+      ipcDir: opts.ipcDir,
+      timeoutMs: parseInt(opts.timeout, 10),
+      limit: parseInt(opts.limit, 10),
+    });
+  });
+
+lifecycle
+  .command('inspect <event-id>')
+  .description('Inspect one lifecycle event and its handler deliveries')
+  .option('--handler <handler-id>', 'Limit output to one handler delivery')
+  .option('--ipc-dir <path>', 'IPC directory (overrides config default)')
+  .option('--timeout <ms>', 'Response timeout in milliseconds', '5000')
+  .action(async (eventId: string, opts: { handler?: string; ipcDir?: string; timeout: string }) => {
+    await lifecycleCommand({
+      action: 'inspect',
+      eventId,
+      handlerId: opts.handler,
+      ipcDir: opts.ipcDir,
+      timeoutMs: parseInt(opts.timeout, 10),
+    });
+  });
+
+lifecycle
+  .command('replay <event-id> <handler-id>')
+  .description('Reopen one terminal lifecycle delivery for exact replay')
+  .option('--ipc-dir <path>', 'IPC directory (overrides config default)')
+  .option('--timeout <ms>', 'Response timeout in milliseconds', '5000')
+  .action(
+    async (eventId: string, handlerId: string, opts: { ipcDir?: string; timeout: string }) => {
+      await lifecycleCommand({
+        action: 'replay',
+        eventId,
+        handlerId,
+        ipcDir: opts.ipcDir,
+        timeoutMs: parseInt(opts.timeout, 10),
+      });
+    },
+  );
+
+lifecycle
+  .command('disable <handler-id>')
+  .description('Disable pending, failed, or claimed deliveries for one handler')
+  .option('--ipc-dir <path>', 'IPC directory (overrides config default)')
+  .option('--timeout <ms>', 'Response timeout in milliseconds', '5000')
+  .action(async (handlerId: string, opts: { ipcDir?: string; timeout: string }) => {
+    await lifecycleCommand({
+      action: 'disable',
+      handlerId,
+      ipcDir: opts.ipcDir,
+      timeoutMs: parseInt(opts.timeout, 10),
+    });
+  });
+
+lifecycle
+  .command('candidates <persona>')
+  .description('List behavior candidate provenance for a persona')
+  .option('--ipc-dir <path>', 'IPC directory (overrides config default)')
+  .option('--timeout <ms>', 'Response timeout in milliseconds', '5000')
+  .option('--limit <n>', 'Maximum candidates to show', '50')
+  .action(async (persona: string, opts: { ipcDir?: string; timeout: string; limit: string }) => {
+    await lifecycleCommand({
+      action: 'candidates',
+      persona,
+      ipcDir: opts.ipcDir,
+      timeoutMs: parseInt(opts.timeout, 10),
+      limit: parseInt(opts.limit, 10),
     });
   });
 
@@ -640,14 +723,8 @@ program
   .option('--base-url <url>', 'Set options.baseUrl for OpenAI-compatible providers')
   .option('--provider-id <id>', 'Set options.providerId for OpenAI-compatible credential lookup')
   .option('--tool-output-cap <chars>', 'Set options.toolOutputCap for OpenAI-compatible providers')
-  .option(
-    '--api-mode <mode>',
-    'OpenAI-compatible API mode: chat-completions or responses',
-  )
-  .option(
-    '--session-mode <mode>',
-    'OpenAI-compatible session mode: none or previous_response_id',
-  )
+  .option('--api-mode <mode>', 'OpenAI-compatible API mode: chat-completions or responses')
+  .option('--session-mode <mode>', 'OpenAI-compatible session mode: none or previous_response_id')
   .option(
     '--omlx-responses',
     'Deprecated alias for --api-mode responses --session-mode previous_response_id',

--- a/src/core/database/repositories/behavior-signal-repository.ts
+++ b/src/core/database/repositories/behavior-signal-repository.ts
@@ -96,6 +96,10 @@ export interface BehaviorCandidateRow {
   expired_at: number | null;
 }
 
+export interface BehaviorCandidateSummaryRow extends BehaviorCandidateRow {
+  evidence_sources: number;
+}
+
 export interface BehaviorPromotionInput {
   readonly promotionId: string;
   readonly persona: string;
@@ -132,11 +136,7 @@ export interface BehaviorPromotionRollbackInput {
 }
 
 export interface BehaviorSignalMetricsRecorder {
-  increment(
-    name: string,
-    labels?: Record<string, string | number | boolean>,
-    value?: number,
-  ): void;
+  increment(name: string, labels?: Record<string, string | number | boolean>, value?: number): void;
 }
 
 export interface BehaviorSignalRepositoryOptions {
@@ -274,6 +274,7 @@ export class BehaviorSignalRepository extends BaseRepository {
   private readonly insertCandidateEvidenceStmt: Database.Statement;
   private readonly findCandidateStmt: Database.Statement;
   private readonly findCandidatesByPersonaStmt: Database.Statement;
+  private readonly findCandidateSummariesByPersonaStmt: Database.Statement;
   private readonly transitionCandidateStmt: Database.Statement;
   private readonly expireCandidateStmt: Database.Statement;
   private readonly countDistinctSourcesStmt: Database.Statement;
@@ -329,6 +330,27 @@ export class BehaviorSignalRepository extends BaseRepository {
     `);
     this.findCandidatesByPersonaStmt = db.prepare(`
       SELECT * FROM behavior_candidates WHERE persona = ? ORDER BY created_at ASC, candidate_id ASC
+    `);
+    this.findCandidateSummariesByPersonaStmt = db.prepare(`
+      SELECT
+        c.*,
+        COALESCE((
+          SELECT COUNT(*)
+          FROM (
+            SELECT e.source_kind, e.source_id
+            FROM behavior_candidate_evidence ce
+            JOIN behavior_evidence e
+              ON e.evidence_id = ce.evidence_id
+             AND e.persona = ce.persona
+            WHERE ce.persona = c.persona
+              AND ce.candidate_id = c.candidate_id
+            GROUP BY e.source_kind, e.source_id
+          )
+        ), 0) AS evidence_sources
+      FROM behavior_candidates c
+      WHERE c.persona = ?
+      ORDER BY c.created_at ASC, c.candidate_id ASC
+      LIMIT ?
     `);
     this.transitionCandidateStmt = db.prepare(`
       UPDATE behavior_candidates
@@ -574,6 +596,35 @@ export class BehaviorSignalRepository extends BaseRepository {
       return ok(rows.map((row) => this.validateCandidateRow(row)));
     } catch (cause) {
       return err(toDbError('find behavior candidates', cause));
+    }
+  }
+
+  findCandidateSummariesByPersona(
+    persona: string,
+    limit = 50,
+  ): Result<BehaviorCandidateSummaryRow[], DbError> {
+    try {
+      if (!isBehaviorPersona(persona)) {
+        return err(new DbError('Failed to summarize behavior candidates: invalid persona'));
+      }
+      if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+        return err(new DbError('Failed to summarize behavior candidates: invalid limit'));
+      }
+      const rows = this.findCandidateSummariesByPersonaStmt.all(
+        persona,
+        limit,
+      ) as BehaviorCandidateSummaryRow[];
+      return ok(
+        rows.map((row) => {
+          const candidate = this.validateCandidateRow(row);
+          if (!Number.isSafeInteger(row.evidence_sources) || row.evidence_sources < 0) {
+            throw new Error('invalid persisted behavior candidate summary row');
+          }
+          return { ...candidate, evidence_sources: row.evidence_sources };
+        }),
+      );
+    } catch (cause) {
+      return err(toDbError('summarize behavior candidates', cause));
     }
   }
 

--- a/src/core/database/repositories/index.ts
+++ b/src/core/database/repositories/index.ts
@@ -86,6 +86,8 @@ export type {
   LifecycleDeliveryClock,
   LifecycleFailureDiagnostic,
   LifecycleDeliveryRetentionResult,
+  LifecycleDeliveryStatusCount,
+  LifecycleHandlerBacklogSummary,
 } from './lifecycle-delivery-repository.js';
 export {
   LifecycleDeliveryRepository,
@@ -101,6 +103,7 @@ export { LifecycleSignalRepository } from './lifecycle-signal-repository.js';
 export type {
   BehaviorCandidateInput,
   BehaviorCandidateRow,
+  BehaviorCandidateSummaryRow,
   BehaviorEvidenceInput,
   BehaviorEvidenceRow,
   BehaviorMetadata,

--- a/src/core/database/repositories/lifecycle-delivery-repository.ts
+++ b/src/core/database/repositories/lifecycle-delivery-repository.ts
@@ -104,6 +104,20 @@ export interface LifecycleDeliveryRetentionResult {
   disabledDeliveries: number;
 }
 
+export interface LifecycleDeliveryStatusCount {
+  readonly status: LifecycleDeliveryStatus;
+  readonly count: number;
+}
+
+export interface LifecycleHandlerBacklogSummary {
+  readonly handler_id: string;
+  readonly persona: string;
+  readonly status: LifecycleDeliveryStatus;
+  readonly count: number;
+  readonly oldest_created_at: number | null;
+  readonly next_retry_at: number | null;
+}
+
 /** Persisted failure diagnostics intentionally carry only a stable, non-secret code. */
 export interface LifecycleFailureDiagnostic {
   code: string;
@@ -135,6 +149,9 @@ export class LifecycleDeliveryRepository extends BaseRepository {
   private readonly claimNextStmt: Database.Statement;
   private readonly findByKeyStmt: Database.Statement;
   private readonly findByEventIdStmt: Database.Statement;
+  private readonly countByStatusStmt: Database.Statement;
+  private readonly summarizeHandlersStmt: Database.Statement;
+  private readonly summarizeHandlersByIdsStmt: Database.Statement;
   private readonly completeStmt: Database.Statement;
   private readonly failStmt: Database.Statement;
   private readonly expireClaimsStmt: Database.Statement;
@@ -200,6 +217,40 @@ export class LifecycleDeliveryRepository extends BaseRepository {
     `);
     this.findByEventIdStmt = db.prepare(`
       SELECT * FROM lifecycle_event_deliveries WHERE event_id = ? ORDER BY priority DESC, created_at ASC
+    `);
+    this.countByStatusStmt = db.prepare(`
+      SELECT status, COUNT(*) AS count
+      FROM lifecycle_event_deliveries
+      GROUP BY status
+      ORDER BY status ASC
+    `);
+    this.summarizeHandlersStmt = db.prepare(`
+      SELECT
+        handler_id,
+        persona,
+        status,
+        COUNT(*) AS count,
+        MIN(created_at) AS oldest_created_at,
+        MIN(next_retry_at) AS next_retry_at
+      FROM lifecycle_event_deliveries
+      GROUP BY handler_id, persona, status
+      ORDER BY handler_id ASC, persona ASC, status ASC
+      LIMIT ?
+    `);
+    this.summarizeHandlersByIdsStmt = db.prepare(`
+      SELECT
+        handler_id,
+        persona,
+        status,
+        COUNT(*) AS count,
+        MIN(created_at) AS oldest_created_at,
+        MIN(next_retry_at) AS next_retry_at
+      FROM lifecycle_event_deliveries
+      WHERE handler_id IN (
+        SELECT value FROM json_each(@handler_ids)
+      )
+      GROUP BY handler_id, persona, status
+      ORDER BY handler_id ASC, persona ASC, status ASC
     `);
     this.completeStmt = db.prepare(`
       UPDATE lifecycle_event_deliveries
@@ -601,6 +652,50 @@ export class LifecycleDeliveryRepository extends BaseRepository {
     }
   }
 
+  countByStatus(): Result<LifecycleDeliveryStatusCount[], DbError> {
+    try {
+      const rows = this.countByStatusStmt.all() as LifecycleDeliveryStatusCount[];
+      return ok(
+        rows.map((row) => ({
+          status: this.parseStatus(row.status),
+          count: Number(row.count),
+        })),
+      );
+    } catch (cause) {
+      return err(toDbError('count lifecycle deliveries by status', cause));
+    }
+  }
+
+  summarizeHandlers(limit = 50): Result<LifecycleHandlerBacklogSummary[], DbError> {
+    try {
+      if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+        return err(new DbError('Failed to summarize lifecycle handlers: invalid limit'));
+      }
+      const rows = this.summarizeHandlersStmt.all(limit) as LifecycleHandlerBacklogSummary[];
+      return ok(rows.map((row) => this.validateHandlerBacklogSummary(row)));
+    } catch (cause) {
+      return err(toDbError('summarize lifecycle handlers', cause));
+    }
+  }
+
+  summarizeHandlersByIds(
+    handlerIds: readonly string[],
+  ): Result<LifecycleHandlerBacklogSummary[], DbError> {
+    try {
+      const ids = [...new Set(handlerIds)];
+      if (ids.length > 100 || ids.some((handlerId) => !this.isIdentifier(handlerId))) {
+        return err(new DbError('Failed to summarize lifecycle handlers: invalid handler ids'));
+      }
+      if (ids.length === 0) return ok([]);
+      const rows = this.summarizeHandlersByIdsStmt.all({
+        handler_ids: JSON.stringify(ids),
+      }) as LifecycleHandlerBacklogSummary[];
+      return ok(rows.map((row) => this.validateHandlerBacklogSummary(row)));
+    } catch (cause) {
+      return err(toDbError('summarize lifecycle handlers', cause));
+    }
+  }
+
   /** Terminally disables outstanding work for one stable handler identity. */
   disableHandler(handlerId: string): Result<LifecycleDeliveryRetentionResult, DbError> {
     try {
@@ -676,6 +771,20 @@ export class LifecycleDeliveryRepository extends BaseRepository {
     const excludedHandlerIds = this.normalizeExcludedHandlerIds(snapshot.excludedHandlerIds);
     if (!excludedHandlerIds) return null;
     return { leaseMs, excludedHandlerIds };
+  }
+
+  private validateHandlerBacklogSummary(
+    row: LifecycleHandlerBacklogSummary,
+  ): LifecycleHandlerBacklogSummary {
+    return {
+      handler_id: this.asIdentifier(row.handler_id),
+      persona: this.asPersona(row.persona),
+      status: this.parseStatus(row.status),
+      count: Number(row.count),
+      oldest_created_at:
+        row.oldest_created_at === null ? null : this.asSafeInteger(row.oldest_created_at),
+      next_retry_at: row.next_retry_at === null ? null : this.asSafeInteger(row.next_retry_at),
+    };
   }
 
   private normalizeExcludedHandlerIds(value: unknown): string[] | null {
@@ -895,6 +1004,27 @@ export class LifecycleDeliveryRepository extends BaseRepository {
       ) &&
       this.parses(LifecycleFilterOwnerNameSchema, value)
     );
+  }
+
+  private parseStatus(value: unknown): LifecycleDeliveryStatus {
+    const parsed = LifecycleDeliveryStatusSchema.safeParse(value);
+    if (!parsed.success) throw new Error('invalid persisted lifecycle delivery status');
+    return parsed.data;
+  }
+
+  private asIdentifier(value: unknown): string {
+    if (!this.isIdentifier(value)) throw new Error('invalid persisted lifecycle handler id');
+    return value as string;
+  }
+
+  private asPersona(value: unknown): string {
+    if (!this.isBoundedPersona(value)) throw new Error('invalid persisted lifecycle persona');
+    return value as string;
+  }
+
+  private asSafeInteger(value: unknown): number {
+    if (!Number.isSafeInteger(value)) throw new Error('invalid persisted lifecycle timestamp');
+    return value as number;
   }
 
   private isNullableTimestamp(value: unknown): boolean {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -31,6 +31,21 @@ import { DaemonIpcServer } from '../ipc/daemon-ipc-server.js';
 import type { DaemonCommand, DaemonResponse } from '../ipc/daemon-ipc.js';
 import type { TalondConfig } from '../core/config/config-types.js';
 import { ensureOwnerOnlyDir } from '../core/fs/private-paths.js';
+import { LifecycleAdminService } from '../lifecycle/lifecycle-admin-service.js';
+
+type LifecycleHandlersCommand = Extract<DaemonCommand, { command: 'lifecycle-handlers' }>;
+type LifecycleInspectCommand = Extract<DaemonCommand, { command: 'lifecycle-inspect' }>;
+type LifecycleReplayCommand = Extract<DaemonCommand, { command: 'lifecycle-replay' }>;
+type LifecycleDisableCommand = Extract<DaemonCommand, { command: 'lifecycle-disable' }>;
+type LifecycleCandidatesCommand = Extract<DaemonCommand, { command: 'lifecycle-candidates' }>;
+type LifecycleBacklog = ReturnType<typeof emptyLifecycleBacklog>;
+type LifecycleBacklogTiming = ReturnType<typeof emptyLifecycleBacklogTiming>;
+
+interface LifecycleHandlerBacklogData {
+  readonly backlog: LifecycleBacklog;
+  readonly timing: LifecycleBacklogTiming;
+  readonly statusTiming: Partial<Record<keyof LifecycleBacklog, LifecycleBacklogTiming>>;
+}
 
 // ---------------------------------------------------------------------------
 // TalondDaemon
@@ -678,16 +693,262 @@ export class TalondDaemon {
         };
       }
 
-      default: {
-        const unknownCommand = command.command;
-        return {
-          id: responseId,
-          commandId: command.id,
-          success: false,
-          error: `Unknown command: ${String(unknownCommand)}`,
+      case 'lifecycle-handlers':
+        return this.handleLifecycleHandlersCommand(command, responseId);
+
+      case 'lifecycle-inspect':
+        return this.handleLifecycleInspectCommand(command, responseId);
+
+      case 'lifecycle-replay':
+        return this.handleLifecycleReplayCommand(command, responseId);
+
+      case 'lifecycle-disable':
+        return this.handleLifecycleDisableCommand(command, responseId);
+
+      case 'lifecycle-candidates':
+        return this.handleLifecycleCandidatesCommand(command, responseId);
+    }
+  }
+
+  private handleLifecycleHandlersCommand(
+    command: LifecycleHandlersCommand,
+    responseId: string,
+  ): DaemonResponse {
+    if (!this.ctx) return this.ipcError(responseId, command.id, 'Daemon not running');
+    const limit = this.payloadLimit(command.payload?.limit);
+    const statusCounts = this.ctx.repos.lifecycleDelivery.countByStatus();
+    if (statusCounts.isErr())
+      return this.ipcError(responseId, command.id, statusCounts.error.message);
+
+    const backlog = emptyLifecycleBacklog();
+    for (const row of statusCounts.value) backlog[row.status] = row.count;
+    const dispatcher = this.ctx.lifecycleRuntime?.dispatcher.snapshot();
+    const dispatcherHandlers = new Map(
+      (dispatcher?.handlers ?? []).map((handler) => [handler.handlerId, handler]),
+    );
+
+    const subscriptionsByHandler = new Map<string, { personas: Set<string>; count: number }>();
+    for (const persona of this.ctx.config.personas) {
+      for (const subscription of persona.lifecycle?.subscriptions ?? []) {
+        const current = subscriptionsByHandler.get(subscription.handler) ?? {
+          personas: new Set<string>(),
+          count: 0,
         };
+        current.personas.add(persona.name);
+        current.count += 1;
+        subscriptionsByHandler.set(subscription.handler, current);
       }
     }
+
+    const configuredHandlers = this.ctx.config.lifecycle?.handlers ?? [];
+    const displayedHandlers = configuredHandlers.slice(0, limit);
+    const handlerBacklog = this.ctx.repos.lifecycleDelivery.summarizeHandlersByIds(
+      displayedHandlers.map((handler) => handler.id),
+    );
+    if (handlerBacklog.isErr()) {
+      return this.ipcError(responseId, command.id, handlerBacklog.error.message);
+    }
+    const handlerRows = new Map<string, LifecycleHandlerBacklogData>();
+    const readAt = Date.now();
+    for (const row of handlerBacklog.value) {
+      const summary = handlerRows.get(row.handler_id) ?? emptyLifecycleHandlerBacklogData();
+      summary.backlog[row.status] += row.count;
+      const statusTiming = rowTiming(row.oldest_created_at, row.next_retry_at, readAt);
+      summary.statusTiming[row.status] = statusTiming;
+      if (isActiveLifecycleBacklogStatus(row.status)) {
+        mergeLifecycleBacklogTiming(summary.timing, statusTiming);
+      }
+      handlerRows.set(row.handler_id, summary);
+    }
+
+    const handlers = displayedHandlers.map((handler) => {
+      const subscriptions = subscriptionsByHandler.get(handler.id);
+      const circuit = dispatcherHandlers.get(handler.id)?.circuit ?? 'closed';
+      const handlerBacklogData = handlerRows.get(handler.id) ?? emptyLifecycleHandlerBacklogData();
+      return {
+        handlerId: handler.id,
+        ...(handler.displayName ? { displayName: handler.displayName } : {}),
+        mode: handler.mode,
+        runtimeKind: handler.runtime.kind,
+        personas: [...(subscriptions?.personas ?? new Set<string>())].sort(),
+        subscriptions: subscriptions?.count ?? 0,
+        backlog: handlerBacklogData.backlog,
+        timing: handlerBacklogData.timing,
+        statusTiming: handlerBacklogData.statusTiming,
+        circuit,
+      };
+    });
+
+    return {
+      id: responseId,
+      commandId: command.id,
+      success: true,
+      data: {
+        lifecycleEnabled: this.ctx.config.lifecycle?.enabled ?? false,
+        dispatcher: dispatcher
+          ? {
+              running: dispatcher.running,
+              stopping: dispatcher.stopping,
+              inFlight: dispatcher.inFlight,
+              handlers: dispatcher.handlers,
+            }
+          : null,
+        backlog,
+        handlers,
+      },
+    };
+  }
+
+  private handleLifecycleInspectCommand(
+    command: LifecycleInspectCommand,
+    responseId: string,
+  ): DaemonResponse {
+    if (!this.ctx) return this.ipcError(responseId, command.id, 'Daemon not running');
+    const eventId = command.payload.eventId;
+    const handlerId = command.payload.handlerId;
+    const event = this.ctx.repos.lifecycleEvent.findById(eventId);
+    if (event.isErr()) return this.ipcError(responseId, command.id, event.error.message);
+    const deliveries = this.ctx.repos.lifecycleDelivery.findByEventId(eventId);
+    if (deliveries.isErr()) return this.ipcError(responseId, command.id, deliveries.error.message);
+    return {
+      id: responseId,
+      commandId: command.id,
+      success: true,
+      data: {
+        event: event.value
+          ? {
+              eventId: event.value.event_id,
+              type: event.value.type,
+              aggregateType: event.value.aggregate_type,
+              aggregateId: event.value.aggregate_id,
+              retentionTombstoneReason: event.value.retention_tombstone_reason,
+              createdAt: event.value.created_at,
+            }
+          : null,
+        deliveries: deliveries.value
+          .filter((delivery) => handlerId === undefined || delivery.handler_id === handlerId)
+          .map((delivery) => this.lifecycleDeliveryData(delivery)),
+      },
+    };
+  }
+
+  private handleLifecycleReplayCommand(
+    command: LifecycleReplayCommand,
+    responseId: string,
+  ): DaemonResponse {
+    if (!this.ctx) return this.ipcError(responseId, command.id, 'Daemon not running');
+    const eventId = command.payload.eventId;
+    const handlerId = command.payload.handlerId;
+    const service = new LifecycleAdminService({
+      deliveries: this.ctx.repos.lifecycleDelivery,
+      auditLogger: this.ctx.auditLogger,
+    });
+    const replay = service.replayDelivery(eventId, handlerId);
+    if (replay.isErr()) return this.ipcError(responseId, command.id, replay.error.message);
+    return {
+      id: responseId,
+      commandId: command.id,
+      success: true,
+      data: this.lifecycleDeliveryData(replay.value),
+    };
+  }
+
+  private handleLifecycleDisableCommand(
+    command: LifecycleDisableCommand,
+    responseId: string,
+  ): DaemonResponse {
+    if (!this.ctx) return this.ipcError(responseId, command.id, 'Daemon not running');
+    const handlerId = command.payload.handlerId;
+    const service = new LifecycleAdminService({
+      deliveries: this.ctx.repos.lifecycleDelivery,
+      auditLogger: this.ctx.auditLogger,
+    });
+    const disabled = service.disableHandler(handlerId);
+    if (disabled.isErr()) return this.ipcError(responseId, command.id, disabled.error.message);
+    return {
+      id: responseId,
+      commandId: command.id,
+      success: true,
+      data: {
+        handlerId: disabled.value.handlerId,
+        disabledDeliveries: disabled.value.disabledDeliveries,
+      },
+    };
+  }
+
+  private handleLifecycleCandidatesCommand(
+    command: LifecycleCandidatesCommand,
+    responseId: string,
+  ): DaemonResponse {
+    if (!this.ctx) return this.ipcError(responseId, command.id, 'Daemon not running');
+    const persona = command.payload.persona;
+    const limit = this.payloadLimit(command.payload?.limit);
+    const candidates = this.ctx.repos.behaviorSignal.findCandidateSummariesByPersona(
+      persona,
+      limit,
+    );
+    if (candidates.isErr()) return this.ipcError(responseId, command.id, candidates.error.message);
+    const data = [];
+    for (const candidate of candidates.value) {
+      data.push({
+        candidateId: candidate.candidate_id,
+        persona: candidate.persona,
+        kind: candidate.kind,
+        status: candidate.status,
+        summary: candidate.summary,
+        proposedBehavior: candidate.proposed_behavior,
+        confidence: candidate.confidence,
+        evidenceSources: candidate.evidence_sources,
+        createdAt: candidate.created_at,
+        updatedAt: candidate.updated_at,
+      });
+    }
+    return {
+      id: responseId,
+      commandId: command.id,
+      success: true,
+      data: { persona, candidates: data },
+    };
+  }
+
+  private lifecycleDeliveryData(delivery: {
+    event_id: string;
+    handler_id: string;
+    persona: string;
+    status: string;
+    attempts: number;
+    max_attempts: number;
+    next_retry_at: number | null;
+    last_error: string | null;
+    terminal_tombstone_reason: string | null;
+    completed_at: number | null;
+    created_at: number;
+    updated_at: number;
+  }): Record<string, unknown> {
+    return {
+      eventId: delivery.event_id,
+      handlerId: delivery.handler_id,
+      persona: delivery.persona,
+      status: delivery.status,
+      attempts: delivery.attempts,
+      maxAttempts: delivery.max_attempts,
+      nextRetryAt: delivery.next_retry_at,
+      lastErrorCode: parseLifecycleErrorCode(delivery.last_error),
+      tombstoneReason: delivery.terminal_tombstone_reason,
+      completedAt: delivery.completed_at,
+      createdAt: delivery.created_at,
+      updatedAt: delivery.updated_at,
+    };
+  }
+
+  private payloadLimit(value: unknown): number {
+    return typeof value === 'number' && Number.isFinite(value)
+      ? Math.min(Math.max(Math.trunc(value), 1), 100)
+      : 50;
+  }
+
+  private ipcError(responseId: string, commandId: string, error: string): DaemonResponse {
+    return { id: responseId, commandId, success: false, error };
   }
 
   // ---------------------------------------------------------------------------
@@ -746,4 +1007,90 @@ function lifecycleConfigurationChanged(oldConfig: TalondConfig, newConfig: Talon
     );
 
   return personaLifecycleConfiguration(oldConfig) !== personaLifecycleConfiguration(newConfig);
+}
+
+function emptyLifecycleBacklog(): {
+  pending: number;
+  claimed: number;
+  failed: number;
+  completed: number;
+  dead_letter: number;
+} {
+  return {
+    pending: 0,
+    claimed: 0,
+    failed: 0,
+    completed: 0,
+    dead_letter: 0,
+  };
+}
+
+function emptyLifecycleBacklogTiming(): {
+  oldestCreatedAt: number | null;
+  oldestAgeMs: number | null;
+  nextRetryAt: number | null;
+} {
+  return {
+    oldestCreatedAt: null,
+    oldestAgeMs: null,
+    nextRetryAt: null,
+  };
+}
+
+function emptyLifecycleHandlerBacklogData(): LifecycleHandlerBacklogData {
+  return {
+    backlog: emptyLifecycleBacklog(),
+    timing: emptyLifecycleBacklogTiming(),
+    statusTiming: {},
+  };
+}
+
+function rowTiming(
+  oldestCreatedAt: number | null,
+  nextRetryAt: number | null,
+  readAt: number,
+): LifecycleBacklogTiming {
+  return {
+    oldestCreatedAt,
+    oldestAgeMs: oldestCreatedAt === null ? null : Math.max(0, readAt - oldestCreatedAt),
+    nextRetryAt,
+  };
+}
+
+function mergeLifecycleBacklogTiming(
+  target: LifecycleBacklogTiming,
+  source: LifecycleBacklogTiming,
+): void {
+  if (
+    source.oldestCreatedAt !== null &&
+    (target.oldestCreatedAt === null || source.oldestCreatedAt < target.oldestCreatedAt)
+  ) {
+    target.oldestCreatedAt = source.oldestCreatedAt;
+    target.oldestAgeMs = source.oldestAgeMs;
+  }
+  if (
+    source.nextRetryAt !== null &&
+    (target.nextRetryAt === null || source.nextRetryAt < target.nextRetryAt)
+  ) {
+    target.nextRetryAt = source.nextRetryAt;
+  }
+}
+
+function isActiveLifecycleBacklogStatus(status: keyof LifecycleBacklog): boolean {
+  return status === 'pending' || status === 'claimed' || status === 'failed';
+}
+
+function parseLifecycleErrorCode(value: string | null): string | null {
+  if (value === null) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed &&
+      typeof parsed === 'object' &&
+      'code' in parsed &&
+      typeof parsed.code === 'string'
+      ? parsed.code
+      : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/ipc/daemon-ipc-client.ts
+++ b/src/ipc/daemon-ipc-client.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 import writeFileAtomic from 'write-file-atomic';
 
-import { DaemonResponseSchema } from './daemon-ipc.js';
+import { DaemonCommandSchema, DaemonResponseSchema } from './daemon-ipc.js';
 import type { DaemonCommand, DaemonCommandType, DaemonResponse } from './daemon-ipc.js';
 import { ensureOwnerOnlyDir } from '../core/fs/private-paths.js';
 
@@ -78,11 +78,11 @@ export class DaemonIpcClient {
     type: DaemonCommandType,
     payload?: Record<string, unknown>,
   ): Promise<DaemonResponse | null> {
-    const command: DaemonCommand = {
+    const command = DaemonCommandSchema.parse({
       id: randomUUID(),
       command: type,
       ...(payload !== undefined ? { payload } : {}),
-    };
+    });
     return this.send(command);
   }
 

--- a/src/ipc/daemon-ipc-server.ts
+++ b/src/ipc/daemon-ipc-server.ts
@@ -265,11 +265,7 @@ export class DaemonIpcServer {
    * Writes a sibling `.error.json` annotation file alongside the original
    * content so operators can inspect what went wrong.
    */
-  private async moveToErrors(
-    filepath: string,
-    rawContent: string,
-    reason: string,
-  ): Promise<void> {
+  private async moveToErrors(filepath: string, rawContent: string, reason: string): Promise<void> {
     try {
       await ensureOwnerOnlyDir(this.opts.errorsDir);
 

--- a/src/ipc/daemon-ipc.ts
+++ b/src/ipc/daemon-ipc.ts
@@ -17,17 +17,16 @@ import { z } from 'zod';
 // ---------------------------------------------------------------------------
 
 /** Union of all supported daemon control commands. */
-export type DaemonCommandType = 'status' | 'reload' | 'shutdown' | 'queue-purge';
-
-/** A command sent by `talonctl` to the running `talond` process. */
-export interface DaemonCommand {
-  /** UUID v4 uniquely identifying this command instance. */
-  id: string;
-  /** The command to execute. */
-  command: DaemonCommandType;
-  /** Optional command-specific parameters. */
-  payload?: Record<string, unknown>;
-}
+export type DaemonCommandType =
+  | 'status'
+  | 'reload'
+  | 'shutdown'
+  | 'queue-purge'
+  | 'lifecycle-handlers'
+  | 'lifecycle-inspect'
+  | 'lifecycle-replay'
+  | 'lifecycle-disable'
+  | 'lifecycle-candidates';
 
 // ---------------------------------------------------------------------------
 // Response types
@@ -51,12 +50,103 @@ export interface DaemonResponse {
 // Zod schemas
 // ---------------------------------------------------------------------------
 
+const CommandIdSchema = z.uuid();
+const LifecycleLimitSchema = z.number().int().min(1).max(100).optional();
+const QueueStatusSchema = z.enum([
+  'pending',
+  'claimed',
+  'processing',
+  'completed',
+  'failed',
+  'dead_letter',
+]);
+
+const EmptyPayloadSchema = z.object({}).strict();
+const ReloadPayloadSchema = z.object({ configPath: z.string().min(1).optional() }).strict();
+const QueuePurgePayloadSchema = z
+  .object({ statuses: z.array(QueueStatusSchema).min(1).max(6).optional() })
+  .strict();
+const LifecycleHandlersPayloadSchema = z.object({ limit: LifecycleLimitSchema }).strict();
+const LifecycleInspectPayloadSchema = z
+  .object({ eventId: z.string().min(1), handlerId: z.string().min(1).optional() })
+  .strict();
+const LifecycleReplayPayloadSchema = z
+  .object({ eventId: z.string().min(1), handlerId: z.string().min(1) })
+  .strict();
+const LifecycleDisablePayloadSchema = z.object({ handlerId: z.string().min(1) }).strict();
+const LifecycleCandidatesPayloadSchema = z
+  .object({ persona: z.string().min(1), limit: LifecycleLimitSchema })
+  .strict();
+
 /** Zod schema for validating serialised {@link DaemonCommand} objects. */
-export const DaemonCommandSchema = z.object({
-  id: z.uuid(),
-  command: z.enum(['status', 'reload', 'shutdown', 'queue-purge']),
-  payload: z.record(z.string(), z.unknown()).optional(),
-});
+export const DaemonCommandSchema = z.discriminatedUnion('command', [
+  z
+    .object({
+      id: CommandIdSchema,
+      command: z.literal('status'),
+      payload: EmptyPayloadSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      id: CommandIdSchema,
+      command: z.literal('reload'),
+      payload: ReloadPayloadSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      id: CommandIdSchema,
+      command: z.literal('shutdown'),
+      payload: EmptyPayloadSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      id: CommandIdSchema,
+      command: z.literal('queue-purge'),
+      payload: QueuePurgePayloadSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      id: CommandIdSchema,
+      command: z.literal('lifecycle-handlers'),
+      payload: LifecycleHandlersPayloadSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      id: CommandIdSchema,
+      command: z.literal('lifecycle-inspect'),
+      payload: LifecycleInspectPayloadSchema,
+    })
+    .strict(),
+  z
+    .object({
+      id: CommandIdSchema,
+      command: z.literal('lifecycle-replay'),
+      payload: LifecycleReplayPayloadSchema,
+    })
+    .strict(),
+  z
+    .object({
+      id: CommandIdSchema,
+      command: z.literal('lifecycle-disable'),
+      payload: LifecycleDisablePayloadSchema,
+    })
+    .strict(),
+  z
+    .object({
+      id: CommandIdSchema,
+      command: z.literal('lifecycle-candidates'),
+      payload: LifecycleCandidatesPayloadSchema,
+    })
+    .strict(),
+]);
+
+/** A command sent by `talonctl` to the running `talond` process. */
+export type DaemonCommand = z.infer<typeof DaemonCommandSchema>;
 
 /** Zod schema for validating serialised {@link DaemonResponse} objects. */
 export const DaemonResponseSchema = z.object({

--- a/tests/unit/cli/lifecycle-commands.test.ts
+++ b/tests/unit/cli/lifecycle-commands.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+  watch,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { lifecycleCommand } from '../../../src/cli/commands/lifecycle.js';
+import type { DaemonCommand } from '../../../src/ipc/daemon-ipc.js';
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'talon-lifecycle-cli-test-'));
+}
+
+function readLastCommand(inputDir: string): DaemonCommand {
+  const files = readdirSync(inputDir)
+    .filter((file) => file.endsWith('.json'))
+    .sort();
+  expect(files.length).toBeGreaterThan(0);
+  return JSON.parse(
+    readFileSync(join(inputDir, files[files.length - 1]!), 'utf8'),
+  ) as DaemonCommand;
+}
+
+async function respondToNextCommand(
+  inputDir: string,
+  outputDir: string,
+  data: Record<string, unknown>,
+  success = true,
+): Promise<{ close(): void }> {
+  mkdirSync(inputDir, { recursive: true });
+  mkdirSync(outputDir, { recursive: true });
+  const seen = new Set<string>();
+  const watcher = watch(inputDir, (_event, filename) => {
+    if (!filename || !filename.endsWith('.json') || seen.has(filename)) return;
+    seen.add(filename);
+    try {
+      const command = JSON.parse(readFileSync(join(inputDir, filename), 'utf8')) as DaemonCommand;
+      const response = {
+        id: randomUUID(),
+        commandId: command.id,
+        success,
+        ...(success ? { data } : { error: String(data.error ?? 'daemon failure') }),
+      };
+      writeFileSync(
+        join(outputDir, `${Date.now()}-${randomUUID().replace(/-/g, '')}.json`),
+        JSON.stringify(response),
+      );
+    } catch {
+      // Atomic writes can briefly expose a path before content is readable.
+    }
+  });
+  return watcher;
+}
+
+describe('lifecycleCommand()', () => {
+  let tmpDir: string;
+  let inputDir: string;
+  let outputDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    inputDir = join(tmpDir, 'input');
+    outputDir = join(tmpDir, 'output');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('requests effective lifecycle handlers with bounded status summaries', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const watcher = await respondToNextCommand(inputDir, outputDir, {
+      lifecycleEnabled: true,
+      dispatcher: { running: true, stopping: false, inFlight: 1, handlers: [] },
+      backlog: { pending: 2, claimed: 1, failed: 0, completed: 3, dead_letter: 1 },
+      handlers: [
+        {
+          handlerId: 'behavior-signal-projector',
+          displayName: 'Behavior signal projector',
+          mode: 'event',
+          runtimeKind: 'native',
+          personas: ['assistant'],
+          subscriptions: 1,
+          backlog: { pending: 2, claimed: 0, failed: 0, completed: 1, dead_letter: 0 },
+          timing: {
+            oldestCreatedAt: 1_700_000_000_000,
+            oldestAgeMs: 90_000,
+            nextRetryAt: 1_800_000_060_000,
+          },
+          circuit: 'closed',
+        },
+      ],
+    });
+
+    await lifecycleCommand({ action: 'handlers', ipcDir: tmpDir, timeoutMs: 2_000 });
+    watcher.close();
+
+    const command = readLastCommand(inputDir);
+    expect(command.command).toBe('lifecycle-handlers');
+    expect(command.payload).toEqual({ limit: 50 });
+    const output = consoleSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(output).toContain('Lifecycle handlers');
+    expect(output).toContain('behavior-signal-projector');
+    expect(output).toContain('pending=2');
+    expect(output).toContain('lag=1m');
+    expect(output).toContain('oldest=2023-11-14T22:13:20.000Z');
+    expect(output).toContain('nextRetry=2027-01-15T08:01:00.000Z');
+  });
+
+  it('requests exact delivery replay and renders the reopened identity', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const watcher = await respondToNextCommand(inputDir, outputDir, {
+      eventId: 'event-123',
+      handlerId: 'handler-one',
+      status: 'pending',
+      attempts: 0,
+      maxAttempts: 3,
+    });
+
+    await lifecycleCommand({
+      action: 'replay',
+      eventId: 'event-123',
+      handlerId: 'handler-one',
+      ipcDir: tmpDir,
+      timeoutMs: 2_000,
+    });
+    watcher.close();
+
+    const command = readLastCommand(inputDir);
+    expect(command.command).toBe('lifecycle-replay');
+    expect(command.payload).toEqual({ eventId: 'event-123', handlerId: 'handler-one' });
+    const output = consoleSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(output).toContain('Reopened lifecycle delivery');
+    expect(output).toContain('event-123');
+    expect(output).toContain('handler-one');
+  });
+
+  it('requests handler disablement and renders audit-relevant counts', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const watcher = await respondToNextCommand(inputDir, outputDir, {
+      handlerId: 'handler-one',
+      disabledDeliveries: 4,
+    });
+
+    await lifecycleCommand({
+      action: 'disable',
+      handlerId: 'handler-one',
+      ipcDir: tmpDir,
+      timeoutMs: 2_000,
+    });
+    watcher.close();
+
+    const command = readLastCommand(inputDir);
+    expect(command.command).toBe('lifecycle-disable');
+    expect(command.payload).toEqual({ handlerId: 'handler-one' });
+    const output = consoleSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(output).toContain('Disabled lifecycle handler "handler-one"');
+    expect(output).toContain('Disabled deliveries: 4');
+  });
+
+  it('requests behavior-candidate provenance by persona with an explicit limit', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const watcher = await respondToNextCommand(inputDir, outputDir, {
+      persona: 'assistant',
+      candidates: [
+        {
+          candidateId: 'candidate-1',
+          status: 'ready',
+          kind: 'preference',
+          confidence: 0.9,
+          evidenceSources: 2,
+          summary: 'Prefer shorter answers',
+        },
+      ],
+    });
+
+    await lifecycleCommand({
+      action: 'candidates',
+      persona: 'assistant',
+      limit: 10,
+      ipcDir: tmpDir,
+      timeoutMs: 2_000,
+    });
+    watcher.close();
+
+    const command = readLastCommand(inputDir);
+    expect(command.command).toBe('lifecycle-candidates');
+    expect(command.payload).toEqual({ persona: 'assistant', limit: 10 });
+    const output = consoleSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(output).toContain('Behavior candidates for "assistant"');
+    expect(output).toContain('candidate-1');
+    expect(output).toContain('evidence=2');
+  });
+
+  it('exits with code 1 when required replay arguments are missing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((_code?: number) => undefined as never);
+
+    await lifecycleCommand({
+      action: 'replay',
+      eventId: 'event-123',
+      ipcDir: tmpDir,
+      timeoutMs: 10,
+    });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy.mock.calls.map((call) => String(call[0])).join('\n')).toContain(
+      'handler id is required',
+    );
+  });
+});

--- a/tests/unit/daemon/daemon.test.ts
+++ b/tests/unit/daemon/daemon.test.ts
@@ -9,6 +9,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ok, err } from 'neverthrow';
 import type pino from 'pino';
+import Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -51,6 +53,20 @@ import { injectSiblingBotIds } from '../../../src/channels/channel-setup.js';
 import { DaemonError } from '../../../src/core/errors/index.js';
 import type { DaemonContext } from '../../../src/daemon/daemon-context.js';
 import { createDiscardLogger } from './helpers.js';
+import {
+  BaseRepository,
+  BehaviorSignalRepository,
+  LifecycleDeliveryRepository,
+  LifecycleEventRepository,
+  type LifecycleDeliveryFanoutInput,
+} from '../../../src/core/database/repositories/index.js';
+import {
+  DaemonCommandSchema,
+  type DaemonCommand,
+  type DaemonResponse,
+} from '../../../src/ipc/daemon-ipc.js';
+import type { LifecycleEventEnvelope } from '../../../src/lifecycle/contracts/index.js';
+import { createTestDb } from '../core/database/repositories/helpers.js';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -171,6 +187,72 @@ function setupSuccessfulBootstrap(overrides: Partial<DaemonContext> = {}) {
   return ctx;
 }
 
+function setDaemonContext(target: TalondDaemon, ctx: DaemonContext): void {
+  (target as unknown as { ctx: DaemonContext }).ctx = ctx;
+}
+
+async function handleDaemonCommand(
+  target: TalondDaemon,
+  command: DaemonCommand,
+): Promise<DaemonResponse> {
+  return (
+    target as unknown as {
+      handleIpcCommand(command: DaemonCommand): Promise<DaemonResponse>;
+    }
+  ).handleIpcCommand(command);
+}
+
+function lifecycleCommand(
+  command: DaemonCommand['command'],
+  payload?: Record<string, unknown>,
+): DaemonCommand {
+  return DaemonCommandSchema.parse({
+    id: randomUUID(),
+    command,
+    ...(payload !== undefined ? { payload } : {}),
+  });
+}
+
+function lifecycleEvent(overrides: Partial<LifecycleEventEnvelope> = {}): LifecycleEventEnvelope {
+  return {
+    version: 'v1',
+    eventId: randomUUID(),
+    type: 'run.completed.v1',
+    occurredAt: '2026-07-16T10:00:00.000Z',
+    context: {
+      aggregate: { type: 'thread', id: `thread-${randomUUID()}` },
+      correlationId: randomUUID(),
+      recursion: { depth: 0, maxDepth: 4 },
+      provenance: { source: 'daemon' },
+    },
+    payload: {
+      references: [{ type: 'run', id: randomUUID() }],
+      metadata: { outcome: 'completed' },
+    },
+    ...overrides,
+  };
+}
+
+function lifecycleDelivery(handlerId: string, persona: string): LifecycleDeliveryFanoutInput {
+  return {
+    handlerId,
+    persona,
+    priority: 0,
+    identity: {
+      version: 'v1',
+      handlerId,
+      runtimeKind: 'native',
+      implementationRef: handlerId,
+      implementationVersion: '1.0.0',
+      mode: 'event',
+      inputContract: 'talon.lifecycle.event.envelope.v1',
+      outputContract: 'talon.lifecycle.signal.envelopes.v1',
+    },
+    failurePolicy: { version: 'v1', mode: 'dead_letter' },
+    maxAttempts: 2,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -209,6 +291,293 @@ describe('TalondDaemon', () => {
         claimed: 0,
         processing: 0,
         deadLetter: 0,
+      });
+    });
+  });
+
+  describe('lifecycle IPC operator commands', () => {
+    let db: Database.Database | null = null;
+
+    afterEach(() => {
+      db?.close();
+      db = null;
+    });
+
+    function installRealLifecycleRepos(): {
+      ctx: DaemonContext;
+      events: LifecycleEventRepository;
+      deliveries: LifecycleDeliveryRepository;
+      behavior: BehaviorSignalRepository;
+    } {
+      BaseRepository.__resetMonotonicClockForTests();
+      db = createTestDb();
+      const events = new LifecycleEventRepository(db);
+      const deliveries = new LifecycleDeliveryRepository(db, () => 1_800_000_000_000);
+      const behavior = new BehaviorSignalRepository(db);
+      const ctx = makeMockContext();
+      ctx.repos = {
+        ...ctx.repos,
+        lifecycleEvent: events,
+        lifecycleDelivery: deliveries,
+        behaviorSignal: behavior,
+      } as any;
+      setDaemonContext(daemon, ctx);
+      return { ctx, events, deliveries, behavior };
+    }
+
+    it('summarizes displayed handler backlog without truncating grouped persona rows', async () => {
+      const dateNow = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+      const { ctx, events, deliveries } = installRealLifecycleRepos();
+      const personas = Array.from({ length: 60 }, (_, index) => `persona-${index}`);
+      ctx.config.lifecycle = {
+        enabled: true,
+        handlers: [
+          { id: 'handler-a', mode: 'event', runtime: { kind: 'native' } },
+          { id: 'handler-b', mode: 'event', runtime: { kind: 'native' } },
+          { id: 'handler-c', mode: 'event', runtime: { kind: 'native' } },
+        ],
+      } as any;
+      ctx.config.personas = personas.map((name) => ({
+        name,
+        lifecycle: {
+          subscriptions: [{ handler: 'handler-a' }, { handler: 'handler-b' }],
+        },
+      })) as any;
+      ctx.lifecycleRuntime = {
+        dispatcher: {
+          snapshot: vi.fn().mockReturnValue({
+            running: true,
+            stopping: false,
+            inFlight: 0,
+            handlers: [{ handlerId: 'handler-b', circuit: 'open' }],
+          }),
+        },
+      } as any;
+
+      const failedEvent = lifecycleEvent();
+      events
+        .insertWithDeliveries(failedEvent, [lifecycleDelivery('handler-b', 'persona-failed')])
+        ._unsafeUnwrap();
+      const failedClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      deliveries
+        .fail(
+          failedEvent.eventId,
+          'handler-b',
+          failedClaim.delivery.claim_token!,
+          { code: 'transient-failure' },
+          1_800_000_060_000,
+        )
+        ._unsafeUnwrap();
+      const failedRow = deliveries.findByKey(failedEvent.eventId, 'handler-b')._unsafeUnwrap()!;
+      dateNow.mockReturnValue(1_800_000_120_000);
+
+      for (const persona of personas.slice(0, 5)) {
+        const input = lifecycleEvent();
+        events
+          .insertWithDeliveries(input, [lifecycleDelivery('handler-b', persona)])
+          ._unsafeUnwrap();
+        const claim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+        deliveries
+          .complete(input.eventId, 'handler-b', claim.delivery.claim_token!)
+          ._unsafeUnwrap();
+      }
+      for (const persona of personas) {
+        events
+          .insertWithDeliveries(lifecycleEvent(), [lifecycleDelivery('handler-a', persona)])
+          ._unsafeUnwrap();
+      }
+      for (const persona of personas.slice(5)) {
+        events
+          .insertWithDeliveries(lifecycleEvent(), [lifecycleDelivery('handler-b', persona)])
+          ._unsafeUnwrap();
+      }
+      events
+        .insertWithDeliveries(lifecycleEvent(), [lifecycleDelivery('handler-c', 'persona-extra')])
+        ._unsafeUnwrap();
+
+      const response = await handleDaemonCommand(
+        daemon,
+        lifecycleCommand('lifecycle-handlers', { limit: 2 }),
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.data).toMatchObject({
+        backlog: { pending: 116, failed: 1, completed: 5 },
+        handlers: [
+          { handlerId: 'handler-a', backlog: { pending: 60 } },
+          {
+            handlerId: 'handler-b',
+            backlog: { pending: 55, failed: 1, completed: 5 },
+            timing: {
+              oldestCreatedAt: failedRow.created_at,
+              oldestAgeMs: 1_800_000_120_000 - failedRow.created_at,
+              nextRetryAt: failedRow.next_retry_at,
+            },
+            statusTiming: {
+              failed: {
+                oldestCreatedAt: failedRow.created_at,
+                oldestAgeMs: 1_800_000_120_000 - failedRow.created_at,
+                nextRetryAt: failedRow.next_retry_at,
+              },
+            },
+            circuit: 'open',
+          },
+        ],
+      });
+      dateNow.mockRestore();
+    });
+
+    it('inspects, replays, disables, and audits lifecycle delivery mutations', async () => {
+      const { ctx, events, deliveries } = installRealLifecycleRepos();
+      const auditLogger = {
+        logLifecycleDisablement: vi.fn(),
+      };
+      ctx.auditLogger = auditLogger as any;
+      const replayEvent = lifecycleEvent();
+      events
+        .insertWithDeliveries(replayEvent, [lifecycleDelivery('replay-handler', 'support')])
+        ._unsafeUnwrap();
+      const replayClaim = deliveries.claimNext({ leaseMs: 100 })._unsafeUnwrap()!;
+      deliveries
+        .complete(replayEvent.eventId, 'replay-handler', replayClaim.delivery.claim_token!)
+        ._unsafeUnwrap();
+      const disabledEvent = lifecycleEvent();
+      events
+        .insertWithDeliveries(disabledEvent, [lifecycleDelivery('disabled-handler', 'support')])
+        ._unsafeUnwrap();
+
+      const inspect = await handleDaemonCommand(
+        daemon,
+        lifecycleCommand('lifecycle-inspect', {
+          eventId: replayEvent.eventId,
+          handlerId: 'replay-handler',
+        }),
+      );
+      const replay = await handleDaemonCommand(
+        daemon,
+        lifecycleCommand('lifecycle-replay', {
+          eventId: replayEvent.eventId,
+          handlerId: 'replay-handler',
+        }),
+      );
+      const disabled = await handleDaemonCommand(
+        daemon,
+        lifecycleCommand('lifecycle-disable', { handlerId: 'disabled-handler' }),
+      );
+
+      expect(inspect.success).toBe(true);
+      expect(inspect.data).toMatchObject({
+        event: { eventId: replayEvent.eventId },
+        deliveries: [{ handlerId: 'replay-handler', status: 'completed' }],
+      });
+      expect(replay.success).toBe(true);
+      expect(replay.data).toMatchObject({
+        eventId: replayEvent.eventId,
+        handlerId: 'replay-handler',
+        status: 'pending',
+        attempts: 0,
+      });
+      expect(disabled.success).toBe(true);
+      expect(disabled.data).toEqual({
+        handlerId: 'disabled-handler',
+        disabledDeliveries: 1,
+      });
+      expect(auditLogger.logLifecycleDisablement).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'lifecycle.disablement',
+          details: expect.objectContaining({
+            handlerId: 'disabled-handler',
+            disabledDeliveries: 1,
+          }),
+        }),
+      );
+    });
+
+    it('returns repository errors from lifecycle handler reads', async () => {
+      const ctx = makeMockContext({
+        repos: {
+          ...makeMockContext().repos,
+          lifecycleDelivery: {
+            countByStatus: vi.fn().mockReturnValue(err(new Error('count failed'))),
+          },
+        } as any,
+      });
+      setDaemonContext(daemon, ctx);
+
+      const response = await handleDaemonCommand(
+        daemon,
+        lifecycleCommand('lifecycle-handlers', { limit: 10 }),
+      );
+
+      expect(response).toMatchObject({
+        success: false,
+        error: 'count failed',
+      });
+    });
+
+    it('lists behavior candidates through the storage-bounded summary query', async () => {
+      const { behavior } = installRealLifecycleRepos();
+      const firstEvidenceId = randomUUID();
+      const secondEvidenceId = randomUUID();
+      expect(
+        behavior
+          .recordEvidence({
+            evidenceId: firstEvidenceId,
+            persona: 'support',
+            sourceKind: 'message',
+            sourceId: randomUUID(),
+            sourceOccurredAt: '2026-07-25T12:00:00.000Z',
+            fingerprint: randomUUID(),
+            sentiment: 'positive',
+            confidence: 0.8,
+            summary: 'The user prefers concise responses.',
+          })
+          .isOk(),
+      ).toBe(true);
+      expect(
+        behavior
+          .recordEvidence({
+            evidenceId: secondEvidenceId,
+            persona: 'support',
+            sourceKind: 'tool_call',
+            sourceId: randomUUID(),
+            sourceOccurredAt: '2026-07-25T12:01:00.000Z',
+            fingerprint: randomUUID(),
+            sentiment: 'positive',
+            confidence: 0.7,
+            summary: 'A tool call confirmed the concise preference.',
+          })
+          .isOk(),
+      ).toBe(true);
+      for (const [index, candidateId] of ['candidate-a', 'candidate-b', 'candidate-c'].entries()) {
+        expect(
+          behavior
+            .createCandidate({
+              candidateId,
+              persona: 'support',
+              kind: 'style',
+              status: index === 0 ? 'ready' : 'collecting',
+              summary: `Candidate ${index}`,
+              proposedBehavior: `Apply candidate ${index}`,
+              confidence: 0.5,
+              createdFromEvidenceIds: index === 0 ? [firstEvidenceId, secondEvidenceId] : [],
+            })
+            .isOk(),
+        ).toBe(true);
+      }
+
+      const response = await handleDaemonCommand(
+        daemon,
+        lifecycleCommand('lifecycle-candidates', { persona: 'support', limit: 2 }),
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.data).toMatchObject({
+        persona: 'support',
+        candidates: [
+          { candidateId: 'candidate-a', evidenceSources: 2 },
+          { candidateId: 'candidate-b', evidenceSources: 0 },
+        ],
       });
     });
   });

--- a/tests/unit/ipc/daemon-ipc-server.test.ts
+++ b/tests/unit/ipc/daemon-ipc-server.test.ts
@@ -295,12 +295,38 @@ describe('DaemonIpcServer', () => {
       expect(errorFiles.length).toBeGreaterThan(0);
     });
 
-    it('creates a .error.json companion file for invalid commands', async () => {
+    it('rejects malformed lifecycle payloads before invoking the handler', async () => {
+      const badCommand = {
+        id: randomUUID(),
+        command: 'lifecycle-disable',
+        payload: {},
+      };
       await fs.writeFile(
-        path.join(inputDir, '000000000001000-bad.json'),
-        'not json',
+        path.join(inputDir, '000000000001000-bad-lifecycle.json'),
+        JSON.stringify(badCommand),
         'utf8',
       );
+      const commandHandler = vi.fn(async (cmd: DaemonCommand) => ({
+        ...DEFAULT_RESPONSE,
+        commandId: cmd.id,
+      }));
+      const server = new DaemonIpcServer({
+        inputDir,
+        outputDir,
+        errorsDir,
+        logger: makeLogger(),
+        commandHandler,
+      });
+
+      const processed = await server.pollOnce();
+
+      expect(processed).toHaveLength(0);
+      expect(commandHandler).not.toHaveBeenCalled();
+      expect(await fs.readdir(outputDir)).toHaveLength(0);
+    });
+
+    it('creates a .error.json companion file for invalid commands', async () => {
+      await fs.writeFile(path.join(inputDir, '000000000001000-bad.json'), 'not json', 'utf8');
 
       const server = new DaemonIpcServer({
         inputDir,

--- a/tests/unit/ipc/lifecycle-daemon-ipc.test.ts
+++ b/tests/unit/ipc/lifecycle-daemon-ipc.test.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { DaemonCommandSchema } from '../../../src/ipc/daemon-ipc.js';
+import type { DaemonCommandType } from '../../../src/ipc/daemon-ipc.js';
+
+describe('daemon lifecycle IPC command schema', () => {
+  it('accepts every lifecycle operator command type', () => {
+    const commands: Array<{ command: DaemonCommandType; payload: Record<string, unknown> }> = [
+      { command: 'lifecycle-handlers', payload: { limit: 10 } },
+      { command: 'lifecycle-inspect', payload: { eventId: 'event-1', handlerId: 'handler-1' } },
+      { command: 'lifecycle-replay', payload: { eventId: 'event-1', handlerId: 'handler-1' } },
+      { command: 'lifecycle-disable', payload: { handlerId: 'handler-1' } },
+      { command: 'lifecycle-candidates', payload: { persona: 'assistant', limit: 10 } },
+    ];
+
+    for (const { command, payload } of commands) {
+      const parsed = DaemonCommandSchema.safeParse({
+        id: randomUUID(),
+        command,
+        payload,
+      });
+      expect(parsed.success).toBe(true);
+    }
+  });
+
+  it('rejects unregistered lifecycle-like command names', () => {
+    const parsed = DaemonCommandSchema.safeParse({
+      id: randomUUID(),
+      command: 'lifecycle-delete',
+      payload: { handlerId: 'handler-1' },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects malformed lifecycle list payloads', () => {
+    for (const payload of [
+      { limit: 0 },
+      { limit: 101 },
+      { limit: '10' },
+      { limit: 10, unexpected: true },
+    ]) {
+      expect(
+        DaemonCommandSchema.safeParse({
+          id: randomUUID(),
+          command: 'lifecycle-handlers',
+          payload,
+        }).success,
+      ).toBe(false);
+    }
+  });
+
+  it('rejects malformed lifecycle mutation payloads', () => {
+    for (const command of ['lifecycle-replay', 'lifecycle-disable'] as const) {
+      expect(
+        DaemonCommandSchema.safeParse({
+          id: randomUUID(),
+          command,
+          payload: command === 'lifecycle-replay' ? { eventId: 'event-1' } : {},
+        }).success,
+      ).toBe(false);
+    }
+
+    expect(
+      DaemonCommandSchema.safeParse({
+        id: randomUUID(),
+        command: 'lifecycle-replay',
+        payload: { eventId: 'event-1', handlerId: 'handler-1', dryRun: true },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects malformed lifecycle candidate payloads', () => {
+    for (const payload of [{ limit: 10 }, { persona: 'assistant', limit: 250 }]) {
+      expect(
+        DaemonCommandSchema.safeParse({
+          id: randomUUID(),
+          command: 'lifecycle-candidates',
+          payload,
+        }).success,
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `talonctl lifecycle` operator commands for handlers, inspect, replay, disable, and behavior-candidate provenance.
- Adds typed daemon IPC request/response variants and daemon lifecycle handlers.
- Adds bounded lifecycle delivery/handler and behavior-candidate read models plus README documentation.

## Verification

- `npx vitest run tests/unit/cli/lifecycle-commands.test.ts tests/unit/ipc tests/unit/daemon/daemon.test.ts` passed: 5 files / 88 tests.
- `npm run build` passed.
- Scoped ESLint passed for touched source/test files.
- Scoped Prettier check passed for touched source/test files.
- `git diff --check` passed.
- GPT-5.5/xhigh review `019f9ce5-400e-7430-860a-3f7ad042d99d` passed with 0 Critical / 0 High / 0 Medium / 1 Low.

Full `npm test` was not run per project instruction.
