### PR TITLE
docs(lifecycle): document adoption workflow

### DIFF
--- a/.agents/skills/create-personality/SKILL.md
+++ b/.agents/skills/create-personality/SKILL.md
@@ -19,6 +19,11 @@ Guide the user through creating personality files for a Talon persona.
 Personality files are markdown files in `personas/<name>/personality/` that
 get appended to the system prompt (after `system.md`, before skills).
 
+This skill is for explicit operator-authored personality files. Do not use it
+to apply lifecycle behavior-learning candidates automatically; those changes
+must go through `talonctl lifecycle candidates`, `promote`, and
+`rollback-promotion`.
+
 ## Phase 1: Select Persona
 
 1. Run `npx talonctl list-personas` to show available personas.

--- a/.agents/skills/create-profile/SKILL.md
+++ b/.agents/skills/create-profile/SKILL.md
@@ -27,6 +27,9 @@ show the draft, refine it, then scaffold it.
 - **Confirm before mutating files.** Show the inferred summary first.
 - **Write/send defaults are gated.** Put write/send capabilities in
   `requireApproval` unless the user explicitly wants broader access.
+- **Lifecycle behavior changes are governed.** If the persona should learn from
+  behavior feedback, mention lifecycle subscriptions as an advanced config step;
+  do not instruct model-backed agents to rewrite prompt files directly.
 - **Preview before reload.** The operator can inspect and edit generated files
   before running `talonctl reload`.
 
@@ -45,6 +48,8 @@ If needed, follow up one question at a time to learn:
 - Main purpose
 - Whether it needs file read/write, messaging, HTTP/API access, memory,
   subagent delegation, scheduling, or database access
+- Whether it should participate in lifecycle behavior review/prompt promotion
+  after setup
 - Whether quality or speed/cost matters more
 
 ## Phase 2: Infer defaults
@@ -114,6 +119,22 @@ Rules:
 ### Skills
 
 Default to no skills unless the user explicitly asks for one.
+
+### Lifecycle behavior review
+
+If the user wants the persona to learn preferences over time, explain that this
+is not part of `talonctl add-persona` yet. It requires explicit
+`personas[].lifecycle.subscriptions` to the configured behavior handlers, then
+operator review through:
+
+```bash
+npx talonctl lifecycle candidates <persona> --limit 25
+npx talonctl lifecycle promote <persona> <promotion-id> --approved-by <operator-id>
+npx talonctl lifecycle rollback-promotion <persona> <activation-id> --reason operator-rejected
+```
+
+Summarize this as a follow-up config step instead of editing the lifecycle YAML
+implicitly during profile creation.
 
 ### Description
 

--- a/.agents/skills/manage-schedules/SKILL.md
+++ b/.agents/skills/manage-schedules/SKILL.md
@@ -24,6 +24,7 @@ Ask what they want to do:
 1. **Create** a new scheduled task
 2. **List** existing schedules
 3. **Remove** a schedule
+4. **Create a behavior-review reminder** for lifecycle candidates
 
 ## Phase 2a: Create Schedule
 
@@ -42,6 +43,23 @@ Ask what they want to do:
 8. Run: `npx talonctl add-schedule --persona <name> --channel <channel> --cron "<expr>" --label "<label>" --prompt "<prompt>" --config talond.yaml`
 9. Confirm with schedule ID and next run time.
 
+For behavior-review reminders, suggest a narrow operator-facing prompt such as:
+
+```text
+Review recent lifecycle behavior candidates for this persona. Summarize the
+candidate IDs, evidence-source counts, confidence, and whether any need
+operator approval. Do not edit prompt files directly; tell the operator to use
+talonctl lifecycle promote or rollback-promotion.
+```
+
+The actual promotion/rollback path is governed by lifecycle IPC commands:
+
+```bash
+npx talonctl lifecycle candidates <persona> --limit 25
+npx talonctl lifecycle promote <persona> <promotion-id> --approved-by <operator-id>
+npx talonctl lifecycle rollback-promotion <persona> <activation-id> --reason operator-rejected
+```
+
 ## Phase 2b: List Schedules
 
 Run: `npx talonctl list-schedules --config talond.yaml`
@@ -58,4 +76,6 @@ Optionally filter: `--persona <name>`
 - Schedules fire in system local time (CET on the VM).
 - Schedule output is silent -- the agent only sends messages if it explicitly uses channel.send.
 - The daemon must be running for schedules to fire (they live in the DB, not the config).
+- Behavior-review schedules may summarize candidates, but they must not directly
+  rewrite system prompts. Use lifecycle promotion commands for governed changes.
 - After creating schedules, remind the user: schedules require a running daemon to execute.

--- a/.agents/skills/run-talon-smoke/SKILL.md
+++ b/.agents/skills/run-talon-smoke/SKILL.md
@@ -131,6 +131,8 @@ Report these facts:
 - mode used: `fake`, `live`, or `both`
 - whether `npm run rebuild:sqlite` was needed
 - `talonctl doctor` result
+- lifecycle handler status from `talonctl lifecycle handlers` when the smoke
+  config enables lifecycle handlers
 - terminal client auth result
 - exact prompt and response
 - DB evidence: thread/message/queue/run counts and last outbound body

--- a/.agents/skills/talon-setup-docker/SKILL.md
+++ b/.agents/skills/talon-setup-docker/SKILL.md
@@ -127,6 +127,11 @@ installed `talonctl` if `./install.sh` has been run):
 | `talonctl list-schedules` | Configured scheduled tasks |
 | `talonctl add-schedule --persona <p> --channel <c> --cron <expr> --label <l> --prompt <text>` | Add a scheduled task |
 | `talonctl remove-schedule <id>` | Remove a scheduled task |
+| `talonctl lifecycle handlers` | Show lifecycle handler health, backlog, and dispatcher status |
+| `talonctl lifecycle inspect <event-id> --handler <handler-id>` | Inspect a durable lifecycle event and delivery state |
+| `talonctl lifecycle replay <event-id> <handler-id>` | Reopen one terminal lifecycle delivery for exact replay |
+| `talonctl lifecycle disable <handler-id>` | Dead-letter pending/failed/claimed deliveries for one handler |
+| `talonctl lifecycle candidates <persona> --limit <n>` | List behavior-candidate provenance for a persona |
 | `talonctl lifecycle promote <persona> <promotion-id> --approved-by <id>` | Apply a governed behavior prompt promotion |
 | `talonctl lifecycle rollback-promotion <persona> <activation-id> --reason <id>` | Roll back an active behavior prompt promotion |
 
@@ -344,6 +349,11 @@ Once boot is verified, anything else uses `talonctl`:
 - **Adjust capabilities** — `talonctl set-capabilities --persona <p> --show`
   to see current, then `--add` or `--remove`.
 - **Schedule tasks** — `talonctl add-schedule …` (see `/manage-schedules`).
+- **Inspect lifecycle health/provenance** — `talonctl lifecycle handlers` and
+  `talonctl lifecycle candidates <persona> --limit 25`.
+- **Apply governed behavior changes** — use `talonctl lifecycle promote` only
+  for an existing candidate, and `rollback-promotion` if an activation needs to
+  be restored.
 - **Add MCP servers** — `talonctl add-mcp …`. Pre-built MCP servers for
   GitHub, Atlassian, Gmail, Slack, etc. are documented in
   `starter/docs/troubleshooting.md` and the upstream MCP server registry.

--- a/.agents/skills/talon-setup/SKILL.md
+++ b/.agents/skills/talon-setup/SKILL.md
@@ -53,6 +53,11 @@ All config mutations go through these commands:
 | `npx talonctl list-schedules` | Show scheduled tasks |
 | `npx talonctl add-schedule --persona <p> --channel <c> --cron <expr> --label <l> --prompt <text>` | Add scheduled task |
 | `npx talonctl remove-schedule <id>` | Remove a scheduled task |
+| `npx talonctl lifecycle handlers` | Show lifecycle handler health, backlog, and dispatcher status |
+| `npx talonctl lifecycle inspect <event-id> --handler <handler-id>` | Inspect a durable lifecycle event and delivery state |
+| `npx talonctl lifecycle replay <event-id> <handler-id>` | Reopen one terminal lifecycle delivery for exact replay |
+| `npx talonctl lifecycle disable <handler-id>` | Dead-letter pending/failed/claimed deliveries for one handler |
+| `npx talonctl lifecycle candidates <persona> --limit <n>` | List behavior-candidate provenance for a persona |
 | `npx talonctl lifecycle promote <persona> <promotion-id> --approved-by <id>` | Apply a governed behavior prompt promotion |
 | `npx talonctl lifecycle rollback-promotion <persona> <activation-id> --reason <id>` | Roll back an active behavior prompt promotion |
 | `npx talonctl list-capabilities` | Show all available capability labels |
@@ -352,9 +357,10 @@ Suggested schedules (optional):
   a) Morning briefing (weekdays 7am) — calendar, email, Jira, GitHub summary
   b) End-of-day summary (weekdays 6pm) — recap and tomorrow preview
   c) Weekly review (Friday 4pm) — stale tickets, forgotten follow-ups
-  d) Week planning (Sunday 7pm) — upcoming week overview
-  e) Custom schedule
-  f) Done, skip the rest
+  d) Behavior review / preference digest — lifecycle candidates needing approval
+  e) Week planning (Sunday 7pm) — upcoming week overview
+  f) Custom schedule
+  g) Done, skip the rest
 ```
 
 For each selected, the user needs a task prompt file at `personas/<name>/prompts/<prompt-name>.md`. Either use the defaults that ship with the assistant persona or help the user write one.
@@ -369,6 +375,12 @@ npx talonctl add-schedule \
   --label "<label>" \
   --prompt "Run the <prompt-name> task prompt"
 ```
+
+For behavior-review schedules, keep the prompt narrow and operator-facing, for
+example: "Review recent lifecycle behavior candidates for this persona and
+summarize which ones need operator approval." Do not instruct the schedule to
+rewrite prompts directly; governed prompt changes must go through
+`npx talonctl lifecycle candidates`, `promote`, and `rollback-promotion`.
 
 Common cron expressions for reference:
 - `0 7 * * 1-5` — weekdays at 7am

--- a/.claude/skills/create-personality/SKILL.md
+++ b/.claude/skills/create-personality/SKILL.md
@@ -19,6 +19,11 @@ Guide the user through creating personality files for a Talon persona.
 Personality files are markdown files in `personas/<name>/personality/` that
 get appended to the system prompt (after `system.md`, before skills).
 
+This skill is for explicit operator-authored personality files. Do not use it
+to apply lifecycle behavior-learning candidates automatically; those changes
+must go through `talonctl lifecycle candidates`, `promote`, and
+`rollback-promotion`.
+
 ## Phase 1: Select Persona
 
 1. Run `npx talonctl list-personas` to show available personas.

--- a/.claude/skills/create-profile/SKILL.md
+++ b/.claude/skills/create-profile/SKILL.md
@@ -27,6 +27,9 @@ show the draft, refine it, then scaffold it.
 - **Confirm before mutating files.** Show the inferred summary first.
 - **Write/send defaults are gated.** Put write/send capabilities in
   `requireApproval` unless the user explicitly wants broader access.
+- **Lifecycle behavior changes are governed.** If the persona should learn from
+  behavior feedback, mention lifecycle subscriptions as an advanced config step;
+  do not instruct model-backed agents to rewrite prompt files directly.
 - **Preview before reload.** The operator can inspect and edit generated files
   before running `talonctl reload`.
 
@@ -45,6 +48,8 @@ If needed, follow up one question at a time to learn:
 - Main purpose
 - Whether it needs file read/write, messaging, HTTP/API access, memory,
   subagent delegation, scheduling, or database access
+- Whether it should participate in lifecycle behavior review/prompt promotion
+  after setup
 - Whether quality or speed/cost matters more
 
 ## Phase 2: Infer defaults
@@ -112,6 +117,22 @@ Rules:
 ### Skills
 
 Default to no skills unless the user explicitly asks for one.
+
+### Lifecycle behavior review
+
+If the user wants the persona to learn preferences over time, explain that this
+is not part of `talonctl add-persona` yet. It requires explicit
+`personas[].lifecycle.subscriptions` to the configured behavior handlers, then
+operator review through:
+
+```bash
+npx talonctl lifecycle candidates <persona> --limit 25
+npx talonctl lifecycle promote <persona> <promotion-id> --approved-by <operator-id>
+npx talonctl lifecycle rollback-promotion <persona> <activation-id> --reason operator-rejected
+```
+
+Summarize this as a follow-up config step instead of editing the lifecycle YAML
+implicitly during profile creation.
 
 ### Description
 

--- a/.claude/skills/manage-schedules/SKILL.md
+++ b/.claude/skills/manage-schedules/SKILL.md
@@ -24,6 +24,7 @@ Ask what they want to do:
 1. **Create** a new scheduled task
 2. **List** existing schedules
 3. **Remove** a schedule
+4. **Create a behavior-review reminder** for lifecycle candidates
 
 ## Phase 2a: Create Schedule
 
@@ -42,6 +43,23 @@ Ask what they want to do:
 8. Run: `npx talonctl add-schedule --persona <name> --channel <channel> --cron "<expr>" --label "<label>" --prompt "<prompt>" --config talond.yaml`
 9. Confirm with schedule ID and next run time.
 
+For behavior-review reminders, suggest a narrow operator-facing prompt such as:
+
+```text
+Review recent lifecycle behavior candidates for this persona. Summarize the
+candidate IDs, evidence-source counts, confidence, and whether any need
+operator approval. Do not edit prompt files directly; tell the operator to use
+talonctl lifecycle promote or rollback-promotion.
+```
+
+The actual promotion/rollback path is governed by lifecycle IPC commands:
+
+```bash
+npx talonctl lifecycle candidates <persona> --limit 25
+npx talonctl lifecycle promote <persona> <promotion-id> --approved-by <operator-id>
+npx talonctl lifecycle rollback-promotion <persona> <activation-id> --reason operator-rejected
+```
+
 ## Phase 2b: List Schedules
 
 Run: `npx talonctl list-schedules --config talond.yaml`
@@ -58,4 +76,6 @@ Optionally filter: `--persona <name>`
 - Schedules fire in system local time (CET on the VM).
 - Schedule output is silent -- the agent only sends messages if it explicitly uses channel.send.
 - The daemon must be running for schedules to fire (they live in the DB, not the config).
+- Behavior-review schedules may summarize candidates, but they must not directly
+  rewrite system prompts. Use lifecycle promotion commands for governed changes.
 - After creating schedules, remind the user: schedules require a running daemon to execute.

--- a/.claude/skills/talon-setup-docker/SKILL.md
+++ b/.claude/skills/talon-setup-docker/SKILL.md
@@ -118,7 +118,7 @@ installed `talonctl` if `./install.sh` has been run):
 | `talonctl unbind --persona <p> --channel <c>` | Remove a binding |
 | `talonctl add-mcp --skill <s> --name <n> --transport stdio --command <c>` | Add an MCP server to a skill |
 | `talonctl list-providers` | Configured AI providers |
-| `talonctl add-provider --name <n> --command <c> [--context both]` | Add a provider |
+| `talonctl add-provider --name <n> --command <c> [--context both] [--type <t>]` | Add a provider |
 | `talonctl set-default-provider --name <n> --context <ctx>` | Set default provider |
 | `talonctl test-provider --name <n>` | Verify a provider connects |
 | `talonctl list-capabilities` | All available capability labels |
@@ -127,6 +127,13 @@ installed `talonctl` if `./install.sh` has been run):
 | `talonctl list-schedules` | Configured scheduled tasks |
 | `talonctl add-schedule --persona <p> --channel <c> --cron <expr> --label <l> --prompt <text>` | Add a scheduled task |
 | `talonctl remove-schedule <id>` | Remove a scheduled task |
+| `talonctl lifecycle handlers` | Show lifecycle handler health, backlog, and dispatcher status |
+| `talonctl lifecycle inspect <event-id> --handler <handler-id>` | Inspect a durable lifecycle event and delivery state |
+| `talonctl lifecycle replay <event-id> <handler-id>` | Reopen one terminal lifecycle delivery for exact replay |
+| `talonctl lifecycle disable <handler-id>` | Dead-letter pending/failed/claimed deliveries for one handler |
+| `talonctl lifecycle candidates <persona> --limit <n>` | List behavior-candidate provenance for a persona |
+| `talonctl lifecycle promote <persona> <promotion-id> --approved-by <id>` | Apply a governed behavior prompt promotion |
+| `talonctl lifecycle rollback-promotion <persona> <activation-id> --reason <id>` | Roll back an active behavior prompt promotion |
 
 Use these for all post-boot mutations. **Do not edit `config/talond.yaml`
 by hand** once the daemon is running — talonctl handles it correctly.
@@ -307,6 +314,11 @@ Once boot is verified, anything else uses `talonctl`:
 - **Adjust capabilities** — `talonctl set-capabilities --persona <p> --show`
   to see current, then `--add` or `--remove`.
 - **Schedule tasks** — `talonctl add-schedule …` (see `/manage-schedules`).
+- **Inspect lifecycle health/provenance** — `talonctl lifecycle handlers` and
+  `talonctl lifecycle candidates <persona> --limit 25`.
+- **Apply governed behavior changes** — use `talonctl lifecycle promote` only
+  for an existing candidate, and `rollback-promotion` if an activation needs to
+  be restored.
 - **Add MCP servers** — `talonctl add-mcp …`. Pre-built MCP servers for
   GitHub, Atlassian, Gmail, Slack, etc. are documented in
   `starter/docs/troubleshooting.md` and the upstream MCP server registry.

--- a/.claude/skills/talon-setup/SKILL.md
+++ b/.claude/skills/talon-setup/SKILL.md
@@ -43,7 +43,7 @@ All config mutations go through these commands:
 | `npx talonctl bind --persona <p> --channel <c>` | Bind persona to channel |
 | `npx talonctl unbind --persona <p> --channel <c>` | Remove binding |
 | `npx talonctl add-mcp --skill <s> --name <n> --transport stdio --command <c>` | Add MCP server |
-| `npx talonctl add-provider --name <n> --command <c> [--context both]` | Add a provider |
+| `npx talonctl add-provider --name <n> --command <c> [--context both] [--type <t>]` | Add a provider |
 | `npx talonctl set-default-provider --name <n> --context <ctx>` | Set default provider |
 | `npx talonctl test-provider --name <n>` | Test a provider works |
 | `npx talonctl list-providers` | Show all providers |
@@ -53,6 +53,13 @@ All config mutations go through these commands:
 | `npx talonctl list-schedules` | Show scheduled tasks |
 | `npx talonctl add-schedule --persona <p> --channel <c> --cron <expr> --label <l> --prompt <text>` | Add scheduled task |
 | `npx talonctl remove-schedule <id>` | Remove a scheduled task |
+| `npx talonctl lifecycle handlers` | Show lifecycle handler health, backlog, and dispatcher status |
+| `npx talonctl lifecycle inspect <event-id> --handler <handler-id>` | Inspect a durable lifecycle event and delivery state |
+| `npx talonctl lifecycle replay <event-id> <handler-id>` | Reopen one terminal lifecycle delivery for exact replay |
+| `npx talonctl lifecycle disable <handler-id>` | Dead-letter pending/failed/claimed deliveries for one handler |
+| `npx talonctl lifecycle candidates <persona> --limit <n>` | List behavior-candidate provenance for a persona |
+| `npx talonctl lifecycle promote <persona> <promotion-id> --approved-by <id>` | Apply a governed behavior prompt promotion |
+| `npx talonctl lifecycle rollback-promotion <persona> <activation-id> --reason <id>` | Roll back an active behavior prompt promotion |
 | `npx talonctl list-capabilities` | Show all available capability labels |
 | `npx talonctl set-capabilities --persona <p> --allow <labels>` | Set persona capabilities |
 | `npx talonctl set-capabilities --persona <p> --add <labels>` | Add capabilities to persona |
@@ -307,9 +314,10 @@ Suggested schedules (optional):
   a) Morning briefing (weekdays 7am) — calendar, email, Jira, GitHub summary
   b) End-of-day summary (weekdays 6pm) — recap and tomorrow preview
   c) Weekly review (Friday 4pm) — stale tickets, forgotten follow-ups
-  d) Week planning (Sunday 7pm) — upcoming week overview
-  e) Custom schedule
-  f) Done, skip the rest
+  d) Behavior review / preference digest — lifecycle candidates needing approval
+  e) Week planning (Sunday 7pm) — upcoming week overview
+  f) Custom schedule
+  g) Done, skip the rest
 ```
 
 For each selected, the user needs a task prompt file at `personas/<name>/prompts/<prompt-name>.md`. Either use the defaults that ship with the assistant persona or help the user write one.
@@ -324,6 +332,12 @@ npx talonctl add-schedule \
   --label "<label>" \
   --prompt "Run the <prompt-name> task prompt"
 ```
+
+For behavior-review schedules, keep the prompt narrow and operator-facing, for
+example: "Review recent lifecycle behavior candidates for this persona and
+summarize which ones need operator approval." Do not instruct the schedule to
+rewrite prompts directly; governed prompt changes must go through
+`npx talonctl lifecycle candidates`, `promote`, and `rollback-promotion`.
 
 Common cron expressions for reference:
 - `0 7 * * 1-5` — weekdays at 7am

--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/TICKET-006-operations-adoption/in-progress/TASK-020-lifecycle-documentation-adoption.md
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/TICKET-006-operations-adoption/in-progress/TASK-020-lifecycle-documentation-adoption.md
@@ -20,10 +20,10 @@ assigned_model_class: codexHigh
 review_model_class: reviewGate
 branch: task/TASK-020-lifecycle-documentation-adoption
 worker_worktree: /Users/ivo.toby/workspace/talon/.worktrees/WAVE-011-lifecycle-documentation-adoption
-worktree_status: created_clean_at_activation_sync
+worktree_status: task_review_passed_uncommitted
 pr: null
-current_gate: worktree_readiness_review_pending
-branch_freshness: branch_current_at_activation_sync_0053209_pending_readiness_ff
+current_gate: commit_pending
+branch_freshness: branch_current_at_readiness_8ee0b3f_with_reviewed_uncommitted_task_diff
 verification:
   - "npx vitest run tests/unit/deploy/starter-bundle.test.ts tests/unit/core/config/config-schema.test.ts tests/unit/cli/lifecycle-commands.test.ts"
   - "npm run build"
@@ -117,10 +117,20 @@ task/TASK-020-lifecycle-documentation-adoption
 Created clean from pushed activation-sync checkpoint
 `0053209080b96c02c2d4fb7af02a24a1af0a477d` after GPT-5.5/xhigh
 activation-sync review `019f9dd8-ead7-77f1-ab13-7fa6eae8132c` passed
-0C/0H/0M/0L. The controller must not dispatch this task until the
-worktree-readiness checkpoint has passed GPT-5.5/xhigh review, been
-committed/pushed, and this branch/worktree has been fast-forwarded to that
-exact readiness commit and reverified clean/current.
+0C/0H/0M/0L. Worktree-readiness review
+`019f9de5-d632-7d30-9dec-69e552084d2d` passed 0C/0H/0M/0L after the prior
+Medium stale-metadata finding was remediated. Reviewed readiness commit
+`8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438` was pushed, and this branch/worktree
+was fast-forwarded to that exact commit before implementation. Current task
+diff is uncommitted and awaits mandatory GPT-5.5/xhigh full-diff review.
+Initial task review `019f9e01-d202-7150-a5c5-c8b921a1dcf1` failed
+0C/0H/2M/2L. Medium findings were remediated by documenting the required
+`personas[].subagents` authority for lifecycle sub-agent handlers and clarifying
+that lifecycle `budget.maxConcurrency` is accepted by the contract but is not
+currently dispatcher-enforced per handler/subscription. Low/P3 findings remain
+non-blocking follow-ups and were not automatically edited.
+Fresh task review `019f9e0a-eb3d-72e0-85b9-928f21d833a6` passed
+0C/0H/0M/3L; commit is now authorized after recording this review evidence.
 
 ## PR / Patch Reference
 
@@ -174,7 +184,25 @@ Refactor only the new/touched boundary after green; do not broaden scope or chan
 
 ## Verification Evidence
 
-- Not run yet.
+- 2026-07-26T10:31:31Z:
+  `npx vitest run tests/unit/deploy/starter-bundle.test.ts tests/unit/core/config/config-schema.test.ts tests/unit/cli/lifecycle-commands.test.ts`
+  passed 3 files / 121 tests.
+- 2026-07-26T10:32:00Z: `npm run build` passed.
+- 2026-07-26T10:32:16Z: `git diff --check` passed.
+- 2026-07-26T10:43:44Z: GPT-5.5/xhigh task review
+  `019f9e01-d202-7150-a5c5-c8b921a1dcf1` failed 0C/0H/2M/2L. Medium findings:
+  missing persona `subagents` authority note for lifecycle sub-agent handlers
+  and overstated `budget.maxConcurrency` runtime enforcement.
+- 2026-07-26T10:45:54Z: Medium remediation complete.
+  `npx vitest run tests/unit/deploy/starter-bundle.test.ts tests/unit/core/config/config-schema.test.ts tests/unit/cli/lifecycle-commands.test.ts`
+  passed 3 files / 121 tests; `npm run build`, `git diff --check`, and
+  `jq empty .wdd/epics/EPIC-durable-lifecycle-pipeline/orchestration.json`
+  passed. Current gate: fresh GPT-5.5/xhigh full-diff task review before commit.
+- 2026-07-26T10:54:13Z: Fresh GPT-5.5/xhigh task review
+  `019f9e0a-eb3d-72e0-85b9-928f21d833a6` passed 0C/0H/0M/3L. Low/P3 findings
+  remain non-blocking follow-ups: nested `budget`/`failurePolicy` version rows,
+  lifecycle disable tombstone wording, and AGENTS migration-location wording.
+  Current gate: commit/push the reviewed task branch.
 
 ## Review Feedback
 
@@ -184,12 +212,29 @@ Refactor only the new/touched boundary after green; do not broaden scope or chan
 
 ### P2
 
-- None.
+- Resolved: task review `019f9e01-d202-7150-a5c5-c8b921a1dcf1` found missing
+  persona `subagents` authority documentation for lifecycle sub-agent handlers.
+  Remediated in `docs/reference/config-schema.mdx`, `README.md`, `selfdoc.md`,
+  and example config comments.
+- Resolved: task review `019f9e01-d202-7150-a5c5-c8b921a1dcf1` found
+  `budget.maxConcurrency` documented as a runtime-enforced handler cap even
+  though current runtime enforces dispatcher policy plus `timeoutMs`. Remediated
+  in `docs/reference/config-schema.mdx`.
 
 ### P3
 
-- None.
+- Non-blocking follow-up: lifecycle config tables omit required nested
+  `version: v1` rows for `budget` and `failurePolicy`.
+- Non-blocking follow-up: setup skill tables describe `talonctl lifecycle
+  disable` as dead-lettering instead of handler-disabled tombstoning.
+- Non-blocking follow-up: AGENTS.md lists lifecycle/behavior tables in a
+  sentence anchored to `001-initial-schema.sql`, while those tables live in
+  later migrations.
 
 ## Completion Notes
 
-- None yet.
+- Implemented documentation/adoption update in the TASK-020 worktree:
+  lifecycle config reference, restored `selfdoc.md`, README/AGENTS pointers,
+  disabled lifecycle examples in main/starter configs, starter README operator
+  guidance, setup/profile/personality/schedule/smoke skill guidance, starter
+  skill sync, and drift tests.

--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/controller-state.md
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/controller-state.md
@@ -3,7 +3,7 @@ id: EPIC-durable-lifecycle-pipeline-CONTROLLER
 kind: controller_state
 epic: EPIC-durable-lifecycle-pipeline
 active_wave: WAVE-011
-status: wave011_readiness_medium_remediated_review_pending
+status: wave011_task_review_pending
 updated_at: 2026-07-26
 ---
 
@@ -238,7 +238,17 @@ Every task advances independently as soon as its gates clear.
   sync checkpoint was committed and pushed at
   `0053209080b96c02c2d4fb7af02a24a1af0a477d`. TASK-020 branch/worktree were
   created and pushed from that exact commit; the worktree is clean with current
-  WDD artifacts. Worktree-readiness review is required before dispatch.
+  WDD artifacts.
+- WAVE-011 worktree-readiness checkpoint: GPT-5.5/xhigh review
+  `019f9de5-d632-7d30-9dec-69e552084d2d` passed 0C/0H/0M/0L after the prior
+  stale-metadata Medium was remediated. Reviewed readiness checkpoint
+  `8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438` was committed/pushed, and
+  TASK-020 branch/worktree were fast-forwarded to that exact commit and
+  verified before implementation.
+- WAVE-011 implementation checkpoint: TASK-020 documentation/adoption diff is
+  complete and uncommitted in the task worktree. Targeted Vitest passed
+  3 files / 121 tests, `npm run build` passed, and `git diff --check` passed.
+  Current gate: GPT-5.5/xhigh full-diff task review before commit.
 
 ## Pending Waves
 
@@ -254,41 +264,43 @@ Every task advances independently as soon as its gates clear.
 | WAVE-008 | TASK-016-lifecycle-operator-cli, TASK-017-behavior-review-reducers | full / parallel / risk_based / adaptive | explicit user implementation request | done |
 | WAVE-009 | TASK-018-governed-prompt-promotion | full / bundled / risk_based / adaptive | explicit user implementation request | done |
 | WAVE-010 | TASK-019-lifecycle-end-to-end-verification | full / bundled / risk_based / adaptive | explicit user implementation request | done |
-| WAVE-011 | TASK-020-lifecycle-documentation-adoption | full / bundled / risk_based / adaptive | explicit user implementation request | in_progress_worktree_readiness_review_pending |
+| WAVE-011 | TASK-020-lifecycle-documentation-adoption | full / bundled / risk_based / adaptive | explicit user implementation request | in_progress_task_review_pending |
 
 ## Active Wave
 
-WAVE-011 is active at the worktree-readiness gate. TASK-020 is moved to
-`in-progress`; its branch/worktree are created and pushed from exact activation-
-sync commit `0053209080b96c02c2d4fb7af02a24a1af0a477d` and are clean with
-current WDD artifacts. Current gate: `worktree_readiness_review_pending`.
-Worker dispatch remains blocked until readiness review passes, the readiness
-checkpoint is committed/pushed, and the task branch/worktree are fast-forwarded
-to that exact readiness commit and reverified clean/current.
+WAVE-011 is active at the task-review gate. TASK-020 is moved to
+`in-progress`; its branch/worktree are current at pushed readiness commit
+`8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438`. The documentation/adoption diff is
+complete, its initial GPT-5.5/xhigh review failed 0C/0H/2M/2L, the two Medium
+findings are remediated, targeted verification is green again, and fresh
+GPT-5.5/xhigh review `019f9e0a-eb3d-72e0-85b9-928f21d833a6` passed
+0C/0H/0M/3L. Current gate: `commit_pending`; commit and push the task branch.
 
 ## Monitoring
 
 - Mode: manual fallback while the recurring remaining-waves thread monitor remains available.
 - Cadence: adaptive
-- Status: WAVE-011 readiness review found one Medium stale metadata note; remediated and pending fresh GPT-5.5/xhigh review.
+- Status: WAVE-011 TASK-020 review passed 0C/0H/0M/3L; task commit/push pending.
 - Scheduler provenance: `talon-issue-256-wdd-remaining-waves-monitor`
-- Last checked: 2026-07-26T10:06:32Z
-- Next check due: 2026-07-26T10:11:32Z
+- Last checked: 2026-07-26T10:54:13Z
+- Next check due: 2026-07-26T10:59:13Z
 - Stop condition: all remaining waves are merged/reconciled and epic validation
   plus final PR handoff are ready, or a real blocker is recorded.
 - Fallback prompt: run one bounded WDD controller heartbeat for
   EPIC-durable-lifecycle-pipeline in /Users/ivo.toby/workspace/talon. WAVE-011
-  worktree-readiness review `019f9de0-4467-7e52-931e-19df30d02e7b` failed
-  0C/0H/1M/0L on stale current branch/worktree metadata; remediation is applied
-  and needs fresh GPT-5.5/xhigh review before commit/push. Sync checkpoint
-  `0053209080b96c02c2d4fb7af02a24a1af0a477d` is pushed and TASK-020 branch/
-  worktree are clean at that exact commit. Do not dispatch TASK-020 until
-  readiness review passes, the readiness checkpoint is committed/pushed, and the
-  task branch/worktree are fast-forwarded to that exact readiness commit and
-  verified clean/current. Use only global old WDD skills, never repo-local WDD
-  cruft or wddctl. Do not use GPT-5.6. Implementation/remediation are capped at
-  GPT-5.5/high; reviews are GPT-5.5/xhigh. Do not run full npm test without
-  explicit user approval. Preserve unrelated changes and keep `.minispec/`
+  TASK-020 implementation is complete and uncommitted in
+  `/Users/ivo.toby/workspace/talon/.worktrees/WAVE-011-lifecycle-documentation-adoption`
+  on branch `task/TASK-020-lifecycle-documentation-adoption`. Readiness review
+  `019f9de5-d632-7d30-9dec-69e552084d2d` passed 0C/0H/0M/0L and readiness
+  commit `8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438` is pushed/current. Initial
+  task review `019f9e01-d202-7150-a5c5-c8b921a1dcf1` failed 0C/0H/2M/2L; the
+  two Medium findings are remediated and targeted Vitest (3 files / 121 tests),
+  `npm run build`, `git diff --check`, and WDD JSON validation passed. Fresh
+  GPT-5.5/xhigh task review `019f9e0a-eb3d-72e0-85b9-928f21d833a6` passed
+  0C/0H/0M/3L; Low/P3 findings remain non-blocking follow-ups. Commit and push
+  the task branch, open/monitor the PR against the epic branch, and continue to
+  WAVE-011 reconciliation after merge. Do not use GPT-5.6, do not run full
+  `npm test` without approval, preserve unrelated changes, and keep `.minispec/`
   untouched.
 
 ## Current Task Gates
@@ -480,11 +492,12 @@ to that exact readiness commit and reverified clean/current.
   `019f9dbd-a0a6-7d53-9a0d-4729c26ac35a` with 0C/0H/0M/0L; reviewed
   checkpoint `ee1b057166fdd02e6b31b1799b512c5e27f24be4` is pushed and local/
   remote epic heads match.
-- TASK-020-lifecycle-documentation-adoption: active in WAVE-011 readiness.
+- TASK-020-lifecycle-documentation-adoption: active in WAVE-011 task review.
   Branch `task/TASK-020-lifecycle-documentation-adoption` and worktree
   `/Users/ivo.toby/workspace/talon/.worktrees/WAVE-011-lifecycle-documentation-adoption`
-  are created clean from sync commit `0053209080b96c02c2d4fb7af02a24a1af0a477d`.
-  Current gate: `worktree_readiness_review_pending`.
+  are current at readiness commit `8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438`.
+  The uncommitted implementation diff passed targeted Vitest, build, and diff
+  checks. Current gate: `task_review_pending`.
 - orchestration.json is authoritative for paths, dependencies, conflicts, models, branches, worktrees, freshness, feedback, verification, and gates.
 
 ## Worker Worktrees
@@ -558,9 +571,9 @@ to that exact readiness commit and reverified clean/current.
 - WAVE-011 / TASK-020: branch
   `task/TASK-020-lifecycle-documentation-adoption`; worktree
   `/Users/ivo.toby/workspace/talon/.worktrees/WAVE-011-lifecycle-documentation-adoption`
-  is created clean from pushed activation-sync commit
-  `0053209080b96c02c2d4fb7af02a24a1af0a477d`; readiness review is required
-  before dispatch.
+  is current at readiness commit `8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438`.
+  Documentation/adoption implementation is complete and uncommitted; GPT-5.5/
+  xhigh full-diff task review is required before commit.
 
 ## Gate Definitions
 
@@ -657,9 +670,10 @@ passed readiness, implementation, review, PR merge, local/GitHub/Sprites
 validation, and worktree cleanup. WAVE-010 reconciliation passed mandatory
 GPT-5.5/xhigh checkpoint review
 `019f9dbd-a0a6-7d53-9a0d-4729c26ac35a` with 0C/0H/0M/0L and was committed and
-pushed at `ee1b057166fdd02e6b31b1799b512c5e27f24be4`. WAVE-011 activation and
-activation-sync gates now passed; TASK-020 branch freshness is now
-`branch_current_at_activation_sync_0053209_pending_readiness_ff`.
+pushed at `ee1b057166fdd02e6b31b1799b512c5e27f24be4`. WAVE-011 activation,
+activation-sync, readiness, and initial implementation gates now passed;
+TASK-020 Medium task-review findings are remediated, and branch freshness is now
+`branch_current_at_readiness_8ee0b3f_with_remediated_uncommitted_task_diff`.
 
 ## Open P1/P2 Feedback
 
@@ -733,12 +747,19 @@ activation-sync gates now passed; TASK-020 branch freshness is now
   checkpoint `0053209080b96c02c2d4fb7af02a24a1af0a477d` is pushed; TASK-020
   branch/worktree were created and pushed from that exact commit and verified
   clean with task, orchestration, and controller artifacts present.
-  Worktree-readiness review is next.
+  Worktree-readiness later passed before implementation.
 - WAVE-011 worktree-readiness review
   `019f9de0-4467-7e52-931e-19df30d02e7b` failed 0C/0H/1M/0L on stale current
   branch/worktree metadata. The Medium is remediated by aligning the WAVE-011
   notes and branch freshness summary to the created-clean activation-sync state;
-  a fresh GPT-5.5/xhigh review is required before commit/push.
+  fresh GPT-5.5/xhigh review
+  `019f9de5-d632-7d30-9dec-69e552084d2d` passed 0C/0H/0M/0L and reviewed
+  readiness commit `8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438` was pushed/
+  fast-forwarded into TASK-020 before implementation.
+- WAVE-011 TASK-020 implementation is complete and uncommitted. Verification:
+  targeted Vitest passed 3 files / 121 tests, `npm run build` passed, and
+  `git diff --check` passed. The next gate is GPT-5.5/xhigh full-diff review
+  before commit.
 - WAVE-008 activation artifact verification passed: GPT-5.5/xhigh review
   `019f9ca8-adb5-7822-b8ac-ddc66ad76f64` reported 0C/0H/0M/0L, `jq empty`
   passed for orchestration.json, and `git diff --check` passed. Activation-sync
@@ -1507,12 +1528,28 @@ activation-sync gates now passed; TASK-020 branch freshness is now
   `019f9de0-4467-7e52-931e-19df30d02e7b` failed 0C/0H/1M/0L on stale current
   branch/worktree metadata. The Medium was fixed by aligning the WAVE-011 notes
   and branch freshness summary to the created-clean activation-sync state.
+- 2026-07-26T10:32:36Z: WAVE-011 TASK-020 documentation/adoption implementation
+  completed in the task worktree. The stale readiness metadata was advanced to
+  task-review pending; targeted Vitest passed 3 files / 121 tests,
+  `npm run build` passed, and `git diff --check` passed. Fresh GPT-5.5/xhigh
+  full-diff review is the next gate before commit.
+- 2026-07-26T10:46:11Z: Initial GPT-5.5/xhigh task review
+  `019f9e01-d202-7150-a5c5-c8b921a1dcf1` failed 0C/0H/2M/2L. The two Medium
+  findings were remediated by documenting persona `subagents` authority for
+  lifecycle sub-agent handlers and correcting the `budget.maxConcurrency`
+  runtime-enforcement wording. Targeted Vitest, `npm run build`,
+  `git diff --check`, and WDD JSON validation passed again. Fresh GPT-5.5/xhigh
+  full-diff review is the next gate before commit.
+- 2026-07-26T10:54:13Z: Fresh GPT-5.5/xhigh task review
+  `019f9e0a-eb3d-72e0-85b9-928f21d833a6` passed 0C/0H/0M/3L. The three Low/P3
+  findings are non-blocking follow-ups and remain untouched: lifecycle nested
+  `budget`/`failurePolicy` version rows, lifecycle disable tombstone wording,
+  and AGENTS migration-location wording. Commit/push is now authorized.
 
 ## Next Action
 
-Run the GPT-5.5/xhigh WAVE-011 worktree-readiness review. If it passes with
-0 Critical/High/Medium findings, commit and push the readiness checkpoint, then
-fast-forward TASK-020 branch/worktree to that exact pushed readiness commit and
-verify it clean/current before dispatch. Continue using GPT-5.5/xhigh review
-only; no GPT-5.6. Low/P3 findings remain follow-ups and must not trigger
+Commit and push the reviewed TASK-020 branch, open the TASK-020 PR against
+`epic/durable-lifecycle-pipeline`, monitor GitHub/PR review gates, merge fresh
+into the epic branch, and reconcile WAVE-011. Continue using GPT-5.5/xhigh
+review only; no GPT-5.6. Low/P3 findings remain follow-ups and must not trigger
 automatic edits.

--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/orchestration.json
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/orchestration.json
@@ -1012,7 +1012,7 @@
           "assignedModel": "codexHigh",
           "reviewModel": "reviewGate",
           "workerThreadId": null,
-          "reviewThreadId": null,
+          "reviewThreadId": "019f9e0a-eb3d-72e0-85b9-928f21d833a6",
           "branch": "task/TASK-008-run-tool-outbound-events",
           "workerWorktree": "/Users/ivo.toby/workspace/talon/.worktrees/WAVE-005-run-tool-outbound-events",
           "worktreeStatus": "cleaned_up",
@@ -1691,18 +1691,36 @@
           ],
           "assignedModel": "codexHigh",
           "reviewModel": "reviewGate",
-          "workerThreadId": null,
+          "workerThreadId": "019f9deb-502c-7171-a6b7-a1966bde589a-interrupted-no-edits-controller-finished",
           "reviewThreadId": null,
           "branch": "task/TASK-020-lifecycle-documentation-adoption",
           "workerWorktree": "/Users/ivo.toby/workspace/talon/.worktrees/WAVE-011-lifecycle-documentation-adoption",
-          "worktreeStatus": "created_clean_at_activation_sync",
+          "worktreeStatus": "task_review_passed_uncommitted",
           "cleanup": null,
           "pr": null,
           "latestCommit": null,
-          "branchFreshness": "branch_current_at_activation_sync_0053209_pending_readiness_ff",
-          "blockingFeedback": [],
-          "verification": null,
-          "currentGate": "worktree_readiness_review_pending"
+          "branchFreshness": "branch_current_at_readiness_8ee0b3f_with_reviewed_uncommitted_task_diff",
+          "blockingFeedback": [
+            {
+              "severity": "Medium",
+              "summary": "Lifecycle sub-agent handler docs omitted the required persona subagents authority.",
+              "status": "resolved_reviewed"
+            },
+            {
+              "severity": "Medium",
+              "summary": "Lifecycle budget.maxConcurrency was documented as runtime-enforced per handler/subscription, but current enforcement uses dispatcher policy plus timeoutMs.",
+              "status": "resolved_reviewed"
+            }
+          ],
+          "verification": {
+            "targetedVitest": "passed 3 files / 121 tests at 2026-07-26T10:45:54Z after Medium remediation",
+            "build": "npm run build passed at 2026-07-26T10:45:40Z after Medium remediation",
+            "diffCheck": "git diff --check passed at 2026-07-26T10:45:54Z",
+            "wddJson": "jq empty orchestration.json passed at 2026-07-26T10:45:54Z",
+            "initialTaskReview": "gpt-5.5/xhigh review 019f9e01-d202-7150-a5c5-c8b921a1dcf1 failed 0C/0H/2M/2L; Medium findings remediated; Low/P3 left as non-blocking follow-ups",
+            "finalTaskReview": "gpt-5.5/xhigh review 019f9e0a-eb3d-72e0-85b9-928f21d833a6 passed 0C/0H/0M/3L"
+          },
+          "currentGate": "commit_pending"
         }
       ],
       "activatedAt": "2026-07-26T09:32:42Z",
@@ -1716,10 +1734,10 @@
         ],
         "branch": "task/TASK-020-lifecycle-documentation-adoption",
         "workerWorktree": "/Users/ivo.toby/workspace/talon/.worktrees/WAVE-011-lifecycle-documentation-adoption",
-        "worktreeStatus": "created_clean_at_activation_sync",
-        "workerThreadId": null,
-        "reviewThreadId": null,
-        "currentGate": "worktree_readiness_review_pending"
+        "worktreeStatus": "task_review_passed_uncommitted",
+        "workerThreadId": "019f9deb-502c-7171-a6b7-a1966bde589a-interrupted-no-edits-controller-finished",
+        "reviewThreadId": "019f9e0a-eb3d-72e0-85b9-928f21d833a6",
+        "currentGate": "commit_pending"
       }
     }
   ],
@@ -1744,7 +1762,7 @@
     "activationBase": "ee1b057166fdd02e6b31b1799b512c5e27f24be4",
     "activationCheckpoint": "4c72c9de10cd0b2439929d0a7d20a4616579da9f",
     "activationSyncCommit": "0053209080b96c02c2d4fb7af02a24a1af0a477d",
-    "readinessCommit": null,
+    "readinessCommit": "8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438",
     "modelPolicyCheckpointCommit": "d104ba468dbe3241691f8940e90238953b82ebeb",
     "pauseAfterWave": null,
     "nextWaveActivationAllowed": false,
@@ -2272,7 +2290,7 @@
       "localRemoteVerifiedAt": "2026-07-26T09:32:42Z"
     },
     "wave011Activation": {
-      "status": "worktree_readiness_review_pending",
+      "status": "commit_pending",
       "activatedAt": "2026-07-26T09:32:42Z",
       "activationBase": "ee1b057166fdd02e6b31b1799b512c5e27f24be4",
       "tasks": [
@@ -2285,7 +2303,7 @@
         ],
         "branch": "task/TASK-020-lifecycle-documentation-adoption",
         "worktree": "/Users/ivo.toby/workspace/talon/.worktrees/WAVE-011-lifecycle-documentation-adoption",
-        "worktreeStatus": "created_clean_at_activation_sync"
+        "worktreeStatus": "task_review_passed_uncommitted"
       },
       "branches": {
         "TASK-020-lifecycle-documentation-adoption": "task/TASK-020-lifecycle-documentation-adoption"
@@ -2306,10 +2324,10 @@
       "activationCheckpoint": "4c72c9de10cd0b2439929d0a7d20a4616579da9f",
       "activationSyncReviewStatus": "passed",
       "activationSyncCommit": "0053209080b96c02c2d4fb7af02a24a1af0a477d",
-      "readinessReviewStatus": "failed_blocking_medium_remediated_pending_fresh_review",
-      "readinessCommit": null,
-      "dispatchStatus": "blocked_until_readiness_review_commit_push_and_task_ff",
-      "notes": "TASK-020 branch/worktree were created and pushed from exact activation-sync commit 0053209080b96c02c2d4fb7af02a24a1af0a477d and verified clean/current. Do not dispatch until the readiness checkpoint passes GPT-5.5/xhigh review, is committed/pushed, and the task branch/worktree are fast-forwarded to that exact readiness commit and reverified clean/current.",
+      "readinessReviewStatus": "passed_committed_pushed_fast_forwarded",
+      "readinessCommit": "8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438",
+      "dispatchStatus": "task_review_passed_commit_pending",
+      "notes": "TASK-020 branch/worktree were created and pushed from exact activation-sync commit 0053209080b96c02c2d4fb7af02a24a1af0a477d and verified clean/current. Fresh readiness review 019f9de5-d632-7d30-9dec-69e552084d2d passed 0C/0H/0M/0L; reviewed readiness commit 8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438 was pushed and fast-forwarded into the task branch/worktree. Documentation/adoption implementation is complete; initial GPT-5.5/xhigh task review 019f9e01-d202-7150-a5c5-c8b921a1dcf1 failed 0C/0H/2M/2L, the two Medium findings are remediated, targeted verification is green again, and fresh GPT-5.5/xhigh task review 019f9e0a-eb3d-72e0-85b9-928f21d833a6 passed 0C/0H/0M/3L. Commit/push is now authorized.",
       "activationCheckpointReviewEvidence": "read-only gpt-5.5/xhigh review verified WDD-only activation metadata, local/remote epic head ee1b057, no TASK-020 branch/worktree, no stale current WAVE-010 pending wording, and .minispec outside scope",
       "activationCheckpointCommitStatus": "pushed_local_remote_match",
       "activationCheckpointRecordedAt": "2026-07-26T09:41:46Z",
@@ -2336,20 +2354,33 @@
       "readinessReviewAttemptCounts": "0C/0H/1M/0L",
       "readinessReviewAttemptFinding": "stale current branch/worktree note and branch freshness summary contradicted created clean readiness state",
       "readinessReviewAttemptRemediation": "updated WAVE-011 notes and branch freshness summary to the created-clean activation-sync state",
-      "taskBranchesFastForwardedToReadiness": false,
-      "taskWorktreesVerifiedBeforeDispatch": false
+      "readinessReviewFinalThreadId": "019f9de5-d632-7d30-9dec-69e552084d2d",
+      "readinessReviewFinalCounts": "0C/0H/0M/0L",
+      "readinessReviewFinalModel": "gpt-5.5",
+      "readinessReviewFinalReasoningEffort": "xhigh",
+      "taskBranchesFastForwardedToReadiness": true,
+      "taskWorktreesVerifiedBeforeDispatch": true,
+      "implementationStatus": "review_passed_uncommitted_commit_pending",
+      "implementationVerification": {
+        "targetedVitest": "passed 3 files / 121 tests at 2026-07-26T10:45:54Z after Medium remediation",
+        "build": "npm run build passed at 2026-07-26T10:45:40Z after Medium remediation",
+        "diffCheck": "git diff --check passed at 2026-07-26T10:45:54Z",
+        "wddJson": "jq empty orchestration.json passed at 2026-07-26T10:45:54Z",
+        "initialTaskReview": "gpt-5.5/xhigh review 019f9e01-d202-7150-a5c5-c8b921a1dcf1 failed 0C/0H/2M/2L; Medium findings remediated; Low/P3 left as non-blocking follow-ups",
+        "finalTaskReview": "gpt-5.5/xhigh review 019f9e0a-eb3d-72e0-85b9-928f21d833a6 passed 0C/0H/0M/3L"
+      }
     }
   },
   "monitoring": {
     "mode": "manual",
     "formerMode": "codex_thread_heartbeat",
     "cadence": "adaptive",
-    "status": "wave011_readiness_medium_remediated_review_pending",
-    "lastCheckedAt": "2026-07-26T10:06:32Z",
-    "nextCheckDueAt": "2026-07-26T10:11:32Z",
+    "status": "wave011_commit_pending",
+    "lastCheckedAt": "2026-07-26T10:54:13Z",
+    "nextCheckDueAt": "2026-07-26T10:59:13Z",
     "schedulerRef": "talon-issue-256-wdd-remaining-waves-monitor",
-    "schedulerStatus": "active_recurring_thread_monitor_recorded_by_user_controller; WAVE-011 readiness review found one Medium stale metadata note, remediated pending fresh GPT-5.5/xhigh review",
-    "fallbackPrompt": "Run one bounded WDD controller heartbeat for EPIC-durable-lifecycle-pipeline in /Users/ivo.toby/workspace/talon. WAVE-011 worktree-readiness review 019f9de0-4467-7e52-931e-19df30d02e7b failed 0C/0H/1M/0L on stale current branch/worktree metadata; remediation is applied and needs fresh GPT-5.5/xhigh review before commit/push. Sync checkpoint 0053209080b96c02c2d4fb7af02a24a1af0a477d is pushed and TASK-020 branch/worktree are clean at that exact commit. Do not dispatch TASK-020 until readiness review passes, the readiness checkpoint is committed/pushed, and the task branch/worktree are fast-forwarded to that exact readiness commit and verified clean/current. Use only global old WDD skills, never repo-local WDD cruft or wddctl. Do not use GPT-5.6. Implementation/remediation are capped at GPT-5.5/high; reviews are GPT-5.5/xhigh. Do not run full npm test without explicit approval. Preserve unrelated changes and keep .minispec untouched.",
+    "schedulerStatus": "active_recurring_thread_monitor_recorded_by_user_controller; WAVE-011 TASK-020 review passed 0C/0H/0M/3L and task commit/push is pending",
+    "fallbackPrompt": "Run one bounded WDD controller heartbeat for EPIC-durable-lifecycle-pipeline in /Users/ivo.toby/workspace/talon. WAVE-011 TASK-020 implementation is complete and uncommitted in /Users/ivo.toby/workspace/talon/.worktrees/WAVE-011-lifecycle-documentation-adoption on branch task/TASK-020-lifecycle-documentation-adoption. Readiness review 019f9de5-d632-7d30-9dec-69e552084d2d passed 0C/0H/0M/0L, readiness commit 8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438 is pushed and fast-forwarded into the task branch/worktree. Initial task review 019f9e01-d202-7150-a5c5-c8b921a1dcf1 failed 0C/0H/2M/2L; the two Medium findings are remediated and targeted Vitest (3 files / 121 tests), npm run build, git diff --check, and WDD JSON validation passed. Fresh GPT-5.5/xhigh task review 019f9e0a-eb3d-72e0-85b9-928f21d833a6 passed 0C/0H/0M/3L; Low/P3 findings are non-blocking follow-ups. Commit and push the task branch, open/monitor the PR against the epic branch, then reconcile WAVE-011 after merge. Do not use GPT-5.6, do not run full npm test without explicit user approval, preserve unrelated changes, and keep .minispec untouched.",
     "stopCondition": "All remaining waves are merged/reconciled and epic validation plus final PR handoff are ready, or a real blocker is recorded.",
     "stopReason": null
   }

--- a/.wdd/epics/EPIC-durable-lifecycle-pipeline/wave-plan.md
+++ b/.wdd/epics/EPIC-durable-lifecycle-pipeline/wave-plan.md
@@ -58,7 +58,7 @@ gate throughput rather than speculative conflict-heavy parallelism.
 | TASK-017-behavior-review-reducers | TICKET-005-behavior-learning | TASK-013-handler-telemetry-correlation, TASK-015-behavior-signal-projector | behavior review, default reviewer subagents, scheduler | done |
 | TASK-018-governed-prompt-promotion | TICKET-005-behavior-learning | TASK-016-lifecycle-operator-cli, TASK-017-behavior-review-reducers | lifecycle behavior, personas, daemon reload, lifecycle CLI | done |
 | TASK-019-lifecycle-end-to-end-verification | TICKET-006-operations-adoption | TASK-018-governed-prompt-promotion | integration tests, fixtures, defect-fix hotspots | done |
-| TASK-020-lifecycle-documentation-adoption | TICKET-006-operations-adoption | TASK-019-lifecycle-end-to-end-verification | README, selfdoc, AGENTS, example config, starter assets, agent skills | in_progress_worktree_readiness_review_pending |
+| TASK-020-lifecycle-documentation-adoption | TICKET-006-operations-adoption | TASK-019-lifecycle-end-to-end-verification | README, selfdoc, AGENTS, example config, starter assets, agent skills | in_progress_commit_pending |
 
 ## Dependency Grid
 
@@ -868,7 +868,18 @@ Activation rule:
   0C/0H/0M/0L, and reviewed sync checkpoint
   `0053209080b96c02c2d4fb7af02a24a1af0a477d` is pushed. TASK-020 branch and
   worktree were created and pushed from that exact commit; the worktree is
-  clean with current WDD artifacts. Worktree-readiness review is next.
+  clean with current WDD artifacts.
+- Worktree-readiness review
+  `019f9de5-d632-7d30-9dec-69e552084d2d` passed 0C/0H/0M/0L after a prior
+  stale-metadata Medium was remediated. Reviewed readiness checkpoint
+  `8ee0b3f819dbbe29354ee1cd046e80ae0ca6b438` is pushed and current in the
+  TASK-020 branch/worktree.
+- TASK-020 documentation/adoption implementation is complete and uncommitted.
+  Targeted Vitest passed 3 files / 121 tests, `npm run build` passed, and
+  `git diff --check` passed. Initial GPT-5.5/xhigh review failed 0C/0H/2M/2L,
+  the two Medium findings were remediated, and fresh GPT-5.5/xhigh review
+  `019f9e0a-eb3d-72e0-85b9-928f21d833a6` passed 0C/0H/0M/3L. Current gate:
+  commit/push the reviewed task branch.
 
 Stop condition:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Channel Connector → MessagePipeline (normalize, dedup, route, persist)
 | Channels  | `src/channels/connectors/` | 7 adapters: telegram, slack, discord, whatsapp-business, whatsapp-baileys, email, terminal                                 |
 | Pipeline  | `src/pipeline/`            | Inbound normalization, dedup, routing, persistence                                                                         |
 | Queue     | `src/queue/`               | Durable SQLite queue, retry with exponential backoff, dead-letter                                                          |
+| Lifecycle | `src/lifecycle/`           | Durable event contracts, publication, dispatcher execution, interceptors, telemetry, retention, and behavior governance    |
 | Scheduler | `src/scheduler/`           | Cron/interval/one-shot task execution                                                                                      |
 | Memory    | `src/memory/`              | Per-thread fact/summary/note storage + context assembly                                                                    |
 | Tools     | `src/tools/`               | 11 host-tools + capability-based filtering via `tool-filter.ts`                                                            |
@@ -70,7 +71,7 @@ Channel Connector → MessagePipeline (normalize, dedup, route, persist)
 
 ### Database
 
-Schema in `src/core/database/migrations/001-initial-schema.sql`. Key tables: `channels`, `personas`, `bindings` (channel↔persona routing), `threads`, `messages`, `queue_items`, `runs`, `schedules`, `memory_items`, `artifacts`, `audit_log`, `tool_results`.
+Schema in `src/core/database/migrations/001-initial-schema.sql`. Key tables: `channels`, `personas`, `bindings` (channel↔persona routing), `threads`, `messages`, `queue_items`, `runs`, `schedules`, `memory_items`, `artifacts`, `audit_log`, `tool_results`, lifecycle event/delivery tables, and behavior ledger/candidate/promotion tables.
 
 Table names to know: `memory_items` (not `memory`), `schedules` (column `expression` not `cron_expression`).
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ backgroundAgent:
 - **Sub-agent system** — Route mechanical LLM tasks (summarization, memory grooming, search) to cheap models via pluggable sub-agents
 - **Background agents** — Launch long-running provider workers for deep tasks without blocking the foreground conversation
 - **Sandboxed execution environments** — Isolate background agent work in persistent Firecracker VMs via [Sprites.dev](https://sprites.dev), with file transfer, checkpointing, and automatic cleanup
+- **Durable lifecycle pipeline** — Publish bounded daemon events for context rotation, behavior learning, telemetry, replay, and governed prompt promotion without letting model-backed handlers mutate state directly
 - **Hot reload** — Change config, personas, and skills without restarting the daemon
 - **Systemd integration** — Watchdog heartbeat, graceful shutdown, timer-based wake-only mode
 - **Session persistence** — Resumable agent sessions resume across messages in the same thread, scoped by provider, model, and configured reasoning effort so model or effort swaps start fresh
@@ -225,7 +226,7 @@ backgroundAgent:
 
 ## Architecture
 
-Messages arrive from channels, pass through a durable queue, and get dispatched to the agent runner. The runner resolves a provider from the registry and executes via that provider's strategy (SDK streaming or CLI). Agents interact with the host through MCP host-tools on a Unix socket. Background agents run as separate provider-managed processes.
+Messages arrive from channels, pass through a durable queue, and get dispatched to the agent runner. The runner resolves a provider from the registry and executes via that provider's strategy (SDK streaming or CLI). Agents interact with the host through MCP host-tools on a Unix socket. Background agents run as separate provider-managed processes. For the compact maintainer map, see [`selfdoc.md`](selfdoc.md).
 
 ```mermaid
 graph TB
@@ -1367,15 +1368,16 @@ Uses `generateObject` with a Zod discriminated union schema to ensure the LLM re
 | **Input**                 | Fenced `talon.lifecycle.event.envelope.v1` via lifecycle handler adapter         |
 | **Output**                | `talon.lifecycle.signal.envelopes.v1` with `behavior.feedback.detected.v1` items |
 
-Personas must explicitly subscribe a lifecycle event handler such as
-`behavior-feedback-detector` to the bounded events they want inspected, and
-explicitly subscribe the native `native-behavior-signal-projector` signal
-handler to `behavior.feedback.detected.v1`. The native projector persists only
-persona-scoped ledger evidence and notes-only candidates: it fingerprints source
-evidence to collapse schedule/direct copies, suppresses duplicate or
-out-of-scope signals with bounded audit, creates collecting candidates for
-explicit feedback, and requires three distinct inferred sources before creating
-a ready inferred-pattern candidate.
+Personas must list `behavior-feedback-detector` in `subagents`, explicitly
+subscribe its lifecycle event handler to the bounded events they want inspected,
+and explicitly subscribe the native `native-behavior-signal-projector` signal
+handler to `behavior.feedback.detected.v1`. The lifecycle subscription does not
+load or authorize the model-backed handler by itself. The native projector
+persists only persona-scoped ledger evidence and notes-only candidates: it
+fingerprints source evidence to collapse schedule/direct copies, suppresses
+duplicate or out-of-scope signals with bounded audit, creates collecting
+candidates for explicit feedback, and requires three distinct inferred sources
+before creating a ready inferred-pattern candidate.
 
 Accepted behavior promotions are applied only by the native governed prompt
 promotion path. Talon resolves the persona-owned `systemPromptFile`, validates a

--- a/config/talond.example.yaml
+++ b/config/talond.example.yaml
@@ -153,7 +153,20 @@ queue:
 # after validation, evaluation, atomic prompt write, reload, and rollback gates.
 # lifecycle:
 #   enabled: false
-#   handlers: []
+#   handlers:
+#     # Model-backed handlers may inspect fenced event data and emit bounded
+#     # signals, but native handlers own durable state mutation and governed
+#     # prompt promotion. Personas must also list a sub-agent handler's ref
+#     # under their own subagents list before it can execute for that persona.
+#     # - version: v1
+#     #   id: behavior-feedback-detector
+#     #   mode: event
+#     #   inputContract: talon.lifecycle.event.envelope.v1
+#     #   outputContract: talon.lifecycle.signal.envelopes.v1
+#     #   runtime:
+#     #     kind: subagent
+#     #     ref: behavior-feedback-detector
+#     #     implementationVersion: 1.0.0
 #   retention:
 #     completedAuditWindowMs: 2592000000 # 30 days
 

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -205,6 +205,154 @@ queue:
 
 ---
 
+## `lifecycle`
+
+Durable lifecycle processing is opt-in. When enabled, Talon validates handler
+declarations and persona subscriptions, persists bounded event envelopes, and
+delivers them through the lifecycle dispatcher. Handlers are a two-lane
+extension surface:
+
+- `native` handlers are trusted implementation catalog entries shipped by
+  Talon. They are the only handlers allowed to enforce interceptor decisions or
+  mutate governed state such as behavior prompt promotions.
+- `subagent` handlers run through Talon's model-backed sub-agent adapter. They
+  receive fenced lifecycle input and may emit bounded lifecycle signals, but
+  they do not get direct write authority over prompts, memory, tools, or
+  config.
+
+```yaml
+lifecycle:
+  enabled: true
+  handlers:
+    - version: v1
+      id: behavior-feedback-detector
+      displayName: Behavior feedback detector
+      mode: event
+      inputContract: talon.lifecycle.event.envelope.v1
+      outputContract: talon.lifecycle.signal.envelopes.v1
+      runtime:
+        kind: subagent
+        ref: behavior-feedback-detector
+        implementationVersion: 1.0.0
+      failurePolicy:
+        version: v1
+        mode: preserve_session
+  retention:
+    completedAuditWindowMs: 2592000000
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | boolean | `false` | Enable lifecycle registry validation, publication, and delivery |
+| `handlers` | array, max 32 | `[]` | Global handler declarations that personas can subscribe to |
+| `retention.completedAuditWindowMs` | integer ≥ 0 | `2592000000` | Audit window before completed/no-subscriber event detail may be compacted |
+
+### `lifecycle.handlers[]`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `version` | `v1` | required | Contract version |
+| `id` | lifecycle identifier | required | Stable handler id used by persona subscriptions and `talonctl lifecycle` |
+| `displayName` | string | — | Optional operator-facing name |
+| `mode` | `event \| signal \| interceptor` | required | Handler lane |
+| `inputContract` | versioned contract name | required | Input contract the handler accepts |
+| `outputContract` | versioned contract name | required | Output contract the handler returns |
+| `runtime.kind` | `native \| subagent` | required | Trusted native catalog entry or model-backed sub-agent |
+| `runtime.ref` | string | required | Native implementation ref or loaded sub-agent name |
+| `runtime.implementationVersion` | string | required | Implementation version captured on durable deliveries |
+| `budget.timeoutMs` | integer 1..3600000 | — | Optional per-delivery timeout |
+| `budget.maxConcurrency` | integer 1..256 | — | Accepted by the budget contract for compatibility; current dispatcher concurrency is enforced by dispatcher policy, not per handler/subscription budget |
+| `failurePolicy.mode` | `fail_closed \| fail_open \| dead_letter \| preserve_session` | handler/runtime default | Failure behavior |
+| `interceptorSafety` | `advisory \| enforcing` | — | Valid only for interceptor handlers; `enforcing` requires `native` runtime and `fail_closed` policy |
+
+Supported lifecycle event types are currently:
+`message.persisted.v1`, `message.routed.v1`, `queue.item.enqueued.v1`,
+`queue.item.completed.v1`, `queue.item.failed.v1`,
+`queue.item.dead_lettered.v1`, `run.started.v1`,
+`provider.tool.started.v1`, `provider.tool.completed.v1`,
+`run.completed.v1`, `run.failed.v1`, `message.sent.v1`,
+`message.send_failed.v1`, `context.threshold_exceeded.v1`,
+`context.rotated.v1`, `context.observation_log_threshold_exceeded.v1`, and
+`schedule.fired.v1`.
+
+Supported lifecycle signal types are currently:
+`context.rotate.requested.v1`, `context.observation.proposed.v1`,
+`context.reduction.proposed.v1`, `behavior.feedback.detected.v1`, and
+`behavior.candidate.proposed.v1`.
+
+Supported interceptor hooks are currently:
+`message.before_persist`, `run.before_execute`, `tool.before_execute`, and
+`message.before_send`.
+
+### `personas[].lifecycle`
+
+Personas opt in to lifecycle handlers explicitly. A handler declared globally
+does nothing until a persona subscribes to its event, signal, or interceptor
+contract. For `subagent` handlers, the persona must also list the handler's
+`runtime.ref` in `personas[].subagents`; a lifecycle subscription alone does
+not load or authorize model-backed handler execution.
+
+```yaml
+personas:
+  - name: assistant
+    subagents:
+      - behavior-feedback-detector
+    lifecycle:
+      subscriptions:
+        - version: v1
+          handler: behavior-feedback-detector
+          priority: 100
+          subscription:
+            version: v1
+            kind: event
+            events:
+              - version: v1
+                type: run.completed.v1
+            filter:
+              version: v1
+              personas:
+                - assistant
+              itemOrigins:
+                - run
+          failurePolicy:
+            version: v1
+            mode: preserve_session
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `subscriptions` | array, max 32 | `[]` | Persona-scoped lifecycle attachments |
+| `subscriptions[].version` | `v1` | required | Contract version |
+| `subscriptions[].handler` | lifecycle identifier | required | Handler id from `lifecycle.handlers[]` |
+| `subscriptions[].priority` | integer -1000..1000 | `0` | Delivery order within the matching lane |
+| `subscriptions[].subscription.kind` | `event \| signal \| interceptor` | required | Must match the handler mode |
+| `subscriptions[].subscription.events[].type` | lifecycle event type | required for `event` | Event names to match |
+| `subscriptions[].subscription.signals[].type` | lifecycle signal type | required for `signal` | Signal names to match |
+| `subscriptions[].subscription.interceptors[].hook` | interceptor hook | required for `interceptor` | Hook names to match |
+| `subscriptions[].subscription.filter` | object | — | Strict filters by item origin/type, channel, persona, message source, or schedule source |
+| `subscriptions[].budget` | object | — | Optional subscription-local timeout budget; `maxConcurrency` is parsed but not currently used for dispatcher concurrency |
+| `subscriptions[].failurePolicy` | object | — | Optional subscription-local failure behavior |
+
+Lifecycle payloads are intentionally bounded: durable events and signals carry
+references plus scalar metadata, not raw transcripts or arbitrary JSON blobs.
+Retention compaction may remove completed/no-subscriber event detail after the
+audit window; pending, failed, claimed, dead-letter, privacy-deleted, and
+handler-disabled rows keep their operational safety semantics.
+
+Operator controls are exposed through daemon IPC:
+
+```bash
+talonctl lifecycle handlers
+talonctl lifecycle inspect <event-id> --handler <handler-id>
+talonctl lifecycle replay <event-id> <handler-id>
+talonctl lifecycle disable <handler-id>
+talonctl lifecycle candidates <persona> --limit 25
+talonctl lifecycle promote <persona> <promotion-id> --approved-by operator
+talonctl lifecycle rollback-promotion <persona> <activation-id> --reason operator-rejected
+```
+
+---
+
 ## `scheduler`
 
 ```yaml

--- a/selfdoc.md
+++ b/selfdoc.md
@@ -1,0 +1,147 @@
+# Talon self-documentation
+
+This document is the compact architectural map for maintainers and operators.
+It intentionally describes the current daemon shape rather than a future design.
+
+## What Talon is
+
+Talon (`talond`) is a self-hosted autonomous agent daemon. It receives human
+messages from channel connectors, stores them durably, routes work through a
+SQLite-backed queue, runs an agent provider, exposes capability-filtered host
+tools, and sends responses back through the originating channel. The default
+posture is local-first: runtime state, audit evidence, queues, memory, and
+artifacts stay on the operator's machine.
+
+## Runtime flow
+
+```text
+Channel connector
+  -> MessagePipeline
+  -> Durable queue
+  -> QueueProcessor
+  -> AgentRunner provider runtime
+  -> Host-tools MCP bridge
+  -> Channel connector response
+```
+
+The queue is the durability seam. Incoming messages are normalized,
+deduplicated, persisted, and enqueued before provider execution. Provider runs
+record usage and session identity, host-tool calls are capability filtered, and
+channel sends are audited.
+
+## Durable lifecycle pipeline
+
+The lifecycle pipeline is Talon's extension spine for events that cross core
+boundaries. It solves a specific problem: features such as context rotation,
+behavior learning, telemetry, replay, and governed prompt promotion need to
+observe the same daemon facts without each feature patching the message queue,
+agent runner, scheduler, tools, and channels independently.
+
+The lifecycle runtime publishes bounded, versioned envelopes for key daemon
+events:
+
+- inbound and outbound messages;
+- queue enqueue, completion, failure, and dead-letter transitions;
+- provider run start/completion/failure;
+- provider tool start/completion;
+- context threshold and rotation events;
+- schedule firing.
+
+Each event contains stable ids, causal context, recursion metadata, references,
+and bounded scalar metadata. It deliberately does not persist raw unbounded
+transcripts or arbitrary object graphs.
+
+## Handler model
+
+Lifecycle handlers use two lanes:
+
+- Native handlers are trusted code shipped in Talon. They may enforce
+  interceptors or mutate governed internal state when their contracts allow it.
+- Sub-agent handlers are model-backed observers. They receive fenced lifecycle
+  input and can return bounded lifecycle signals, but they cannot directly
+  write prompts, memory, tools, config, or databases. A persona must both
+  subscribe the lifecycle handler and list the handler's sub-agent name in
+  `personas[].subagents`; subscription alone does not load or authorize the
+  model-backed runtime.
+
+Personas subscribe explicitly to handlers. A globally declared handler is inert
+until a persona attaches an event, signal, or interceptor subscription. This
+keeps behavior scoped by persona, channel, source, and schedule filters instead
+of creating implicit global hooks.
+
+## Context management
+
+Provider context management now lives under
+`agentRunner.providers.<name>.contextManagement`.
+
+The legacy single-summary mode uses `session-summarizer` to compress a thread
+when a configured usage metric crosses a threshold. Observation mode uses
+`session-observer` to write dated observations and `session-reflector` to
+consolidate long observation logs. Legacy configs that use
+`summarizer: session-observer` are translated at load time to explicit
+observation mode, but new configs should use `mode: observation`,
+`observer: session-observer`, and `reducer: session-reflector`.
+
+Lifecycle context signals are proposals. Native context handlers own durable
+context mutation so model output cannot silently rewrite session state.
+
+## Behavior learning and prompt promotion
+
+Behavior learning is intentionally governed. The
+`behavior-feedback-detector` sub-agent can inspect fenced lifecycle events and
+emit `behavior.feedback.detected.v1` signals. The native behavior projector
+validates source ids, fingerprints evidence, enforces persona scope, stores
+ledger evidence, and creates bounded candidates.
+
+Prompt promotion is native-only. Talon resolves the persona-owned
+`systemPromptFile`, validates a bounded prompt patch, defaults to operator
+approval, allows only explicit narrow auto-policy for append-only style,
+preference, or context changes, evaluates the candidate, writes through an
+atomic same-file rename, verifies daemon reload, records provenance, and keeps
+rollback evidence. Safety, capability, tool, integration, or notification
+expansions require explicit operator approval.
+
+Operators inspect and control this surface with:
+
+```bash
+talonctl lifecycle handlers
+talonctl lifecycle inspect <event-id> --handler <handler-id>
+talonctl lifecycle replay <event-id> <handler-id>
+talonctl lifecycle disable <handler-id>
+talonctl lifecycle candidates <persona> --limit 25
+talonctl lifecycle promote <persona> <promotion-id> --approved-by operator
+talonctl lifecycle rollback-promotion <persona> <activation-id> --reason operator-rejected
+```
+
+## Persistence, retention, and privacy
+
+SQLite is the durable store. Lifecycle events and handler deliveries are
+persisted separately so the dispatcher can retry, dead-letter, replay terminal
+failures, and preserve handler snapshots even if configuration changes later.
+
+Retention compaction may remove completed/no-subscriber event payload and
+provenance detail after the configured audit window. Pending, claimed, failed,
+dead-letter, handler-disabled, and privacy-deleted rows retain their safety
+semantics. Thread/persona privacy deletion tombstones matching lifecycle event
+detail and dead-letters outstanding matching deliveries.
+
+## Security boundaries
+
+The important security rule is that model output is advisory unless trusted
+native code decides otherwise. Talon enforces that with:
+
+- strict Zod contracts at lifecycle boundaries;
+- bounded references and scalar metadata for durable events/signals;
+- fenced prompts for sub-agent lifecycle input;
+- explicit persona subscriptions and filters;
+- native-only enforcing interceptors;
+- native-only governed prompt promotion;
+- capability-filtered host tools;
+- audit records for lifecycle publication, delivery, retries, decisions,
+  prompt promotion, rollback, and retention.
+
+## Operator-facing docs
+
+Use `README.md` for the broad user guide, `docs/reference/config-schema.mdx`
+for exact config fields, `config/talond.example.yaml` for a commented template,
+and `.agents/skills/` plus `.claude/skills/` for guided local setup flows.

--- a/starter-stack/.claude/skills/create-personality/SKILL.md
+++ b/starter-stack/.claude/skills/create-personality/SKILL.md
@@ -19,6 +19,11 @@ Guide the user through creating personality files for a Talon persona.
 Personality files are markdown files in `personas/<name>/personality/` that
 get appended to the system prompt (after `system.md`, before skills).
 
+This skill is for explicit operator-authored personality files. Do not use it
+to apply lifecycle behavior-learning candidates automatically; those changes
+must go through `talonctl lifecycle candidates`, `promote`, and
+`rollback-promotion`.
+
 ## Phase 1: Select Persona
 
 1. Run `npx talonctl list-personas` to show available personas.

--- a/starter-stack/.claude/skills/create-profile/SKILL.md
+++ b/starter-stack/.claude/skills/create-profile/SKILL.md
@@ -27,6 +27,9 @@ show the draft, refine it, then scaffold it.
 - **Confirm before mutating files.** Show the inferred summary first.
 - **Write/send defaults are gated.** Put write/send capabilities in
   `requireApproval` unless the user explicitly wants broader access.
+- **Lifecycle behavior changes are governed.** If the persona should learn from
+  behavior feedback, mention lifecycle subscriptions as an advanced config step;
+  do not instruct model-backed agents to rewrite prompt files directly.
 - **Preview before reload.** The operator can inspect and edit generated files
   before running `talonctl reload`.
 
@@ -45,6 +48,8 @@ If needed, follow up one question at a time to learn:
 - Main purpose
 - Whether it needs file read/write, messaging, HTTP/API access, memory,
   subagent delegation, scheduling, or database access
+- Whether it should participate in lifecycle behavior review/prompt promotion
+  after setup
 - Whether quality or speed/cost matters more
 
 ## Phase 2: Infer defaults
@@ -112,6 +117,22 @@ Rules:
 ### Skills
 
 Default to no skills unless the user explicitly asks for one.
+
+### Lifecycle behavior review
+
+If the user wants the persona to learn preferences over time, explain that this
+is not part of `talonctl add-persona` yet. It requires explicit
+`personas[].lifecycle.subscriptions` to the configured behavior handlers, then
+operator review through:
+
+```bash
+npx talonctl lifecycle candidates <persona> --limit 25
+npx talonctl lifecycle promote <persona> <promotion-id> --approved-by <operator-id>
+npx talonctl lifecycle rollback-promotion <persona> <activation-id> --reason operator-rejected
+```
+
+Summarize this as a follow-up config step instead of editing the lifecycle YAML
+implicitly during profile creation.
 
 ### Description
 

--- a/starter-stack/.claude/skills/manage-schedules/SKILL.md
+++ b/starter-stack/.claude/skills/manage-schedules/SKILL.md
@@ -24,6 +24,7 @@ Ask what they want to do:
 1. **Create** a new scheduled task
 2. **List** existing schedules
 3. **Remove** a schedule
+4. **Create a behavior-review reminder** for lifecycle candidates
 
 ## Phase 2a: Create Schedule
 
@@ -42,6 +43,23 @@ Ask what they want to do:
 8. Run: `npx talonctl add-schedule --persona <name> --channel <channel> --cron "<expr>" --label "<label>" --prompt "<prompt>" --config talond.yaml`
 9. Confirm with schedule ID and next run time.
 
+For behavior-review reminders, suggest a narrow operator-facing prompt such as:
+
+```text
+Review recent lifecycle behavior candidates for this persona. Summarize the
+candidate IDs, evidence-source counts, confidence, and whether any need
+operator approval. Do not edit prompt files directly; tell the operator to use
+talonctl lifecycle promote or rollback-promotion.
+```
+
+The actual promotion/rollback path is governed by lifecycle IPC commands:
+
+```bash
+npx talonctl lifecycle candidates <persona> --limit 25
+npx talonctl lifecycle promote <persona> <promotion-id> --approved-by <operator-id>
+npx talonctl lifecycle rollback-promotion <persona> <activation-id> --reason operator-rejected
+```
+
 ## Phase 2b: List Schedules
 
 Run: `npx talonctl list-schedules --config talond.yaml`
@@ -58,4 +76,6 @@ Optionally filter: `--persona <name>`
 - Schedules fire in system local time (CET on the VM).
 - Schedule output is silent -- the agent only sends messages if it explicitly uses channel.send.
 - The daemon must be running for schedules to fire (they live in the DB, not the config).
+- Behavior-review schedules may summarize candidates, but they must not directly
+  rewrite system prompts. Use lifecycle promotion commands for governed changes.
 - After creating schedules, remind the user: schedules require a running daemon to execute.

--- a/starter-stack/.claude/skills/talon-setup-docker/SKILL.md
+++ b/starter-stack/.claude/skills/talon-setup-docker/SKILL.md
@@ -118,7 +118,7 @@ installed `talonctl` if `./install.sh` has been run):
 | `talonctl unbind --persona <p> --channel <c>` | Remove a binding |
 | `talonctl add-mcp --skill <s> --name <n> --transport stdio --command <c>` | Add an MCP server to a skill |
 | `talonctl list-providers` | Configured AI providers |
-| `talonctl add-provider --name <n> --command <c> [--context both]` | Add a provider |
+| `talonctl add-provider --name <n> --command <c> [--context both] [--type <t>]` | Add a provider |
 | `talonctl set-default-provider --name <n> --context <ctx>` | Set default provider |
 | `talonctl test-provider --name <n>` | Verify a provider connects |
 | `talonctl list-capabilities` | All available capability labels |
@@ -127,6 +127,13 @@ installed `talonctl` if `./install.sh` has been run):
 | `talonctl list-schedules` | Configured scheduled tasks |
 | `talonctl add-schedule --persona <p> --channel <c> --cron <expr> --label <l> --prompt <text>` | Add a scheduled task |
 | `talonctl remove-schedule <id>` | Remove a scheduled task |
+| `talonctl lifecycle handlers` | Show lifecycle handler health, backlog, and dispatcher status |
+| `talonctl lifecycle inspect <event-id> --handler <handler-id>` | Inspect a durable lifecycle event and delivery state |
+| `talonctl lifecycle replay <event-id> <handler-id>` | Reopen one terminal lifecycle delivery for exact replay |
+| `talonctl lifecycle disable <handler-id>` | Dead-letter pending/failed/claimed deliveries for one handler |
+| `talonctl lifecycle candidates <persona> --limit <n>` | List behavior-candidate provenance for a persona |
+| `talonctl lifecycle promote <persona> <promotion-id> --approved-by <id>` | Apply a governed behavior prompt promotion |
+| `talonctl lifecycle rollback-promotion <persona> <activation-id> --reason <id>` | Roll back an active behavior prompt promotion |
 
 Use these for all post-boot mutations. **Do not edit `config/talond.yaml`
 by hand** once the daemon is running — talonctl handles it correctly.
@@ -307,6 +314,11 @@ Once boot is verified, anything else uses `talonctl`:
 - **Adjust capabilities** — `talonctl set-capabilities --persona <p> --show`
   to see current, then `--add` or `--remove`.
 - **Schedule tasks** — `talonctl add-schedule …` (see `/manage-schedules`).
+- **Inspect lifecycle health/provenance** — `talonctl lifecycle handlers` and
+  `talonctl lifecycle candidates <persona> --limit 25`.
+- **Apply governed behavior changes** — use `talonctl lifecycle promote` only
+  for an existing candidate, and `rollback-promotion` if an activation needs to
+  be restored.
 - **Add MCP servers** — `talonctl add-mcp …`. Pre-built MCP servers for
   GitHub, Atlassian, Gmail, Slack, etc. are documented in
   `starter/docs/troubleshooting.md` and the upstream MCP server registry.

--- a/starter-stack/README.md
+++ b/starter-stack/README.md
@@ -111,6 +111,12 @@ operator's local Claude Code session. They know the bundle layout, use the
 bundled `talonctl` wrapper, and never ask you to run `npm install` or
 `npx talonctl`.
 
+Durable lifecycle operations are also exposed through the same wrapper once the
+daemon is running. Use `talonctl lifecycle handlers` for handler health/backlog,
+`inspect` / `replay` / `disable` for delivery troubleshooting, `candidates` for
+behavior-learning provenance, and `promote` / `rollback-promotion` for governed
+behavior prompt changes.
+
 ## Common operations
 
 ```bash
@@ -118,6 +124,8 @@ docker compose ps                       # all four services
 docker compose logs -f talond           # Talon logs
 docker compose logs -f postgram         # Postgram logs
 talonctl status                         # daemon health
+talonctl lifecycle handlers             # lifecycle handler health/backlog
+talonctl lifecycle candidates assistant --limit 25
 docker compose down                     # stop (data persists in volumes)
 docker compose pull && ./bootstrap.sh   # update images, re-run bootstrap
 ```

--- a/starter-stack/config/talond.example.yaml
+++ b/starter-stack/config/talond.example.yaml
@@ -53,6 +53,20 @@ bindings:
     isDefault: true
 
 # ---------------------------------------------------------------------------
+# Durable lifecycle (optional)
+# ---------------------------------------------------------------------------
+# Leave disabled until you intentionally configure lifecycle handlers and
+# persona subscriptions. Lifecycle events are bounded and durable; model-backed
+# handlers may propose signals, while native handlers own governed state changes
+# such as behavior prompt promotion. If a lifecycle handler uses a sub-agent,
+# also add that handler ref to the persona's subagents list.
+# lifecycle:
+#   enabled: false
+#   handlers: []
+#   retention:
+#     completedAuditWindowMs: 2592000000 # 30 days
+
+# ---------------------------------------------------------------------------
 # Agent runtime
 # ---------------------------------------------------------------------------
 agentRunner:

--- a/starter/README.md
+++ b/starter/README.md
@@ -68,6 +68,12 @@ The skills walk you through editing `.env` and `config/talond.yaml`
 manually for first-time setup, then drive `talonctl` for follow-on
 changes (add another channel, swap providers, etc.).
 
+After the daemon is running, durable lifecycle operations also go through
+`talonctl`. Use `talonctl lifecycle handlers` to see configured handler health
+and backlog, `inspect` / `replay` / `disable` for delivery troubleshooting,
+`candidates` for behavior-learning provenance, and
+`promote` / `rollback-promotion` for governed behavior prompt updates.
+
 ## Configuration
 
 | File or dir | Purpose |
@@ -132,6 +138,8 @@ docker compose down             # stop
 
 talonctl status                 # daemon health
 talonctl list-channels          # configured channels
+talonctl lifecycle handlers     # lifecycle handler health/backlog
+talonctl lifecycle candidates assistant --limit 25
 talonctl --help                 # all commands
 ```
 

--- a/starter/config/talond.example.yaml
+++ b/starter/config/talond.example.yaml
@@ -48,6 +48,20 @@ bindings:
     isDefault: true
 
 # ---------------------------------------------------------------------------
+# Durable lifecycle (optional)
+# ---------------------------------------------------------------------------
+# Leave disabled until you intentionally configure lifecycle handlers and
+# persona subscriptions. Lifecycle events are bounded and durable; model-backed
+# handlers may propose signals, while native handlers own governed state changes
+# such as behavior prompt promotion. If a lifecycle handler uses a sub-agent,
+# also add that handler ref to the persona's subagents list.
+# lifecycle:
+#   enabled: false
+#   handlers: []
+#   retention:
+#     completedAuditWindowMs: 2592000000 # 30 days
+
+# ---------------------------------------------------------------------------
 # Agent runtime
 # ---------------------------------------------------------------------------
 agentRunner:

--- a/tests/unit/deploy/starter-bundle.test.ts
+++ b/tests/unit/deploy/starter-bundle.test.ts
@@ -85,3 +85,62 @@ describe('.github/workflows/release.yaml', () => {
     expect(workflow).toMatch(/sync-starter-skills\.sh\s+starter-stack(?![-\w])/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Lifecycle documentation/adoption drift
+// ---------------------------------------------------------------------------
+
+describe('lifecycle documentation/adoption surfaces', () => {
+  it('documents lifecycle config and operator commands in the schema reference', () => {
+    const docs = readFileSync(resolve(ROOT, 'docs/reference/config-schema.mdx'), 'utf8');
+
+    expect(docs).toContain('## `lifecycle`');
+    expect(docs).toContain('### `personas[].lifecycle`');
+    expect(docs).toContain('talon.lifecycle.event.envelope.v1');
+    expect(docs).toContain('behavior.feedback.detected.v1');
+    expect(docs).toContain('current dispatcher concurrency is enforced by dispatcher policy');
+    expect(docs).toContain('subagents');
+    expect(docs).toMatch(/lifecycle subscription alone does\s+not load or authorize/);
+    expect(docs).toContain('talonctl lifecycle handlers');
+    expect(docs).toContain('talonctl lifecycle rollback-promotion');
+  });
+
+  it('keeps starter docs and example configs discoverable without enabling lifecycle', () => {
+    for (const bundle of ['starter', 'starter-stack'] as const) {
+      const readme = readFileSync(resolve(ROOT, bundle, 'README.md'), 'utf8');
+      const config = readFileSync(resolve(ROOT, bundle, 'config/talond.example.yaml'), 'utf8');
+
+      expect(readme).toContain('talonctl lifecycle handlers');
+      expect(readme).toContain('talonctl lifecycle candidates assistant --limit 25');
+      expect(config).toContain('Durable lifecycle (optional)');
+      expect(config).toContain('#   enabled: false');
+      expect(config).toContain('behavior prompt promotion');
+      expect(config).toContain("add that handler ref to the persona's subagents list");
+    }
+  });
+
+  it('keeps setup skills aligned with lifecycle inspection and governed promotion', () => {
+    const skillPaths = [
+      '.agents/skills/talon-setup/SKILL.md',
+      '.claude/skills/talon-setup/SKILL.md',
+      '.agents/skills/talon-setup-docker/SKILL.md',
+      '.claude/skills/talon-setup-docker/SKILL.md',
+      '.agents/skills/manage-schedules/SKILL.md',
+      '.claude/skills/manage-schedules/SKILL.md',
+      '.agents/skills/create-profile/SKILL.md',
+      '.claude/skills/create-profile/SKILL.md',
+      '.agents/skills/create-personality/SKILL.md',
+      '.claude/skills/create-personality/SKILL.md',
+    ];
+
+    for (const skillPath of skillPaths) {
+      const skill = readFileSync(resolve(ROOT, skillPath), 'utf8');
+      expect(skill, skillPath).toContain('talonctl lifecycle candidates');
+      expect(skill, skillPath).toContain('promote');
+      expect(skill, skillPath).toContain('rollback-promotion');
+    }
+
+    const smoke = readFileSync(resolve(ROOT, '.agents/skills/run-talon-smoke/SKILL.md'), 'utf8');
+    expect(smoke).toContain('talonctl lifecycle handlers');
+  });
+});


### PR DESCRIPTION
## Summary
- Document the durable lifecycle pipeline in README, config reference, AGENTS, and restored selfdoc.md
- Add disabled lifecycle examples and operator guidance to starter bundles/configs
- Update Talon setup/profile/personality/schedule/smoke skills and starter skill syncs for lifecycle inspection and governed prompt promotion
- Add drift tests for lifecycle docs/adoption surfaces

## Verification
- `npx vitest run tests/unit/deploy/starter-bundle.test.ts tests/unit/core/config/config-schema.test.ts tests/unit/cli/lifecycle-commands.test.ts` — 3 files / 121 tests passed
- `npm run build` — passed
- `git diff --check` — passed
- `jq empty .wdd/epics/EPIC-durable-lifecycle-pipeline/orchestration.json` — passed

## Review gate
- GPT-5.5/xhigh review `019f9e01-d202-7150-a5c5-c8b921a1dcf1` failed 0C/0H/2M/2L; both Medium findings remediated
- GPT-5.5/xhigh review `019f9e0a-eb3d-72e0-85b9-928f21d833a6` passed 0C/0H/0M/3L
- Low/P3 findings intentionally left as non-blocking follow-ups per WDD policy
